### PR TITLE
Phase 9.3: Improve auth command instructions for all providers

### DIFF
--- a/PLAN.md
+++ b/PLAN.md
@@ -355,28 +355,38 @@ Browser cookie strategies are fully implemented but not registered in `fetch_str
 
 ---
 
-#### Phase 9.3: Improve Auth Command Instructions
+#### Phase 9.3: Improve Auth Command Instructions ✅ COMPLETE
 **Goal**: Make instruction-only auth commands more helpful
 
 Even without interactive flows, the current instructions are sparse.
 
 **Tasks**:
-- [ ] Claude auth instructions
+- [x] Claude auth instructions
   - [x] Already has detailed DevTools navigation
-  - [ ] Add expected cookie format/prefix validation
-- [ ] Codex auth instructions
-  - [ ] Add `~/.codex/auth.json` file format example
-  - [ ] Explain what the OAuth token looks like
-- [ ] Cursor auth instructions
-  - [ ] Add which cookie names to look for
-  - [ ] Add step-by-step DevTools navigation (like Claude)
-  - [ ] Show expected cookie format
-- [ ] Gemini auth instructions
-  - [ ] Add `~/.gemini/oauth_creds.json` file format example
-  - [ ] Explain credential structure
-- [ ] Copilot auth instructions (after device flow)
-  - [ ] Show VS Code hosts.json location as alternative
-  - [ ] Explain token format
+  - [x] Add expected cookie format/prefix validation (sk-ant-sid01- prefix shown)
+  - [x] Add expiration note (session keys expire periodically)
+  - [x] Add alternative credential path (~/.claude/.credentials.json)
+- [x] Codex auth instructions
+  - [x] Add `~/.codex/auth.json` file format example (tokens.access_token structure)
+  - [x] Explain what the OAuth token looks like
+  - [x] Add OPENAI_API_KEY environment variable option
+  - [x] Show three authentication options (CLI, env var, manual)
+- [x] Cursor auth instructions
+  - [x] Add which cookie names to look for (WorkosCursorSessionToken, etc.)
+  - [x] Add step-by-step DevTools navigation (like Claude)
+  - [x] Show expected cookie format (JWT/encoded string starting with eyJ)
+- [x] Gemini auth instructions
+  - [x] Add `~/.gemini/oauth_creds.json` file format example
+  - [x] Explain credential structure (access_token, refresh_token, expires_at)
+  - [x] Add GEMINI_API_KEY environment variable option
+  - [x] Add API key as alternative auth method
+- [x] Copilot auth instructions (after device flow)
+  - [x] Show VS Code hosts.json location (~/.config/github-copilot/hosts.json)
+  - [x] Explain token format (gho_ for OAuth, ghu_ for user tokens)
+  - [x] Show preferred device flow command (vibeusage auth copilot)
+  - [x] Add GITHUB_TOKEN environment variable option
+
+**Verification**: All 1118 tests pass (18 new tests added), 82% coverage
 
 **Value**: Low - Nice to have, doesn't add functionality
 
@@ -430,9 +440,9 @@ Even without interactive flows, the current instructions are sparse.
 
 ### Upcoming (Authentication Gaps)
 9. **Priority 9**: Interactive Authentication
-   - Phase 9.1: Copilot device flow 🚨 NEXT
-   - Phase 9.2: Claude + Cursor browser cookies 🚨 NEXT
-   - Phase 9.3: Better auth instructions (Later)
+   - Phase 9.1: Copilot device flow ✅
+   - Phase 9.2: Claude + Cursor browser cookies ✅
+   - Phase 9.3: Better auth instructions ✅
    - Phase 9.4: Keyring integration (Later)
 
 ---

--- a/src/vibeusage/cli/commands/auth.py
+++ b/src/vibeusage/cli/commands/auth.py
@@ -380,7 +380,18 @@ Get your session key from claude.ai:
 2. Open browser DevTools (F12 or Cmd+Option+I)
 3. Go to Application/Storage → Cookies → https://claude.ai
 4. Find the [bold]sessionKey[/bold] cookie
-5. Copy its value (starts with sk-ant-sid01-)
+5. Copy its value (starts with [bold]sk-ant-sid01-[/bold])
+
+[bold]Expected format:[/bold]
+  sk-ant-sid01-<long alphanumeric string>
+  The key is typically 100+ characters long.
+
+[bold]Note:[/bold] Session keys expire periodically (usually after a few days
+to a week). You'll need to re-run [bold]vibeusage auth claude[/bold] when
+the key expires.
+
+[bold]Alternative:[/bold] If you have the Claude CLI installed, vibeusage can
+also read credentials from [bold]~/.claude/.credentials.json[/bold] automatically.
 
 [dim]The session key allows vibeusage to fetch your usage data.[/dim]""",
         title="Instructions",
@@ -398,21 +409,51 @@ def _show_provider_auth_instructions(
     instructions_map = {
         "codex": """[bold cyan]Codex (ChatGPT) Authentication[/bold cyan]
 
-Codex authentication uses OAuth credentials.
-
-[dim]Run the official Codex CLI to authenticate:[/dim]
+[bold]Option 1: Codex CLI (recommended)[/bold]
+Run the official Codex CLI to authenticate:
   [dim]codex auth login[/dim]
 
-[dim]Or set credentials manually with your OAuth token:[/dim]
-  [dim]vibeusage key codex set[/dim]""",
+vibeusage will automatically read credentials from
+[bold]~/.codex/auth.json[/bold]
+
+[bold]Option 2: Environment variable[/bold]
+Set the [bold]OPENAI_API_KEY[/bold] environment variable:
+  [dim]export OPENAI_API_KEY="sk-..."[/dim]
+
+[bold]Option 3: Manual credential[/bold]
+  [dim]vibeusage key codex set[/dim]
+
+[bold]Credential file format[/bold] (~/.codex/auth.json):
+  {
+    "tokens": {
+      "access_token": "<OAuth access token>",
+      "refresh_token": "<OAuth refresh token>",
+      "expires_at": "<ISO 8601 timestamp>"
+    }
+  }""",
         "copilot": """[bold cyan]GitHub Copilot Authentication[/bold cyan]
 
-[green]Running interactive device flow...[/green]
+[bold]Option 1: Device flow (recommended)[/bold]
+Run the interactive device flow to authenticate:
+  [dim]vibeusage auth copilot[/dim]
 
-This will open a browser window where you can authorize vibeusage to access your Copilot usage data.
+This opens a browser where you authorize vibeusage with GitHub.
+The OAuth token (prefixed [bold]gho_[/bold]) is saved automatically.
 
-[dim]Or set credentials manually with your OAuth token:[/dim]
-  [dim]vibeusage key copilot set[/dim]""",
+[bold]Option 2: VS Code / GitHub CLI credentials[/bold]
+If you have GitHub Copilot configured in VS Code or the GitHub CLI,
+vibeusage can read credentials from:
+  [bold]~/.config/github-copilot/hosts.json[/bold]
+
+[bold]Option 3: Environment variable[/bold]
+Set the [bold]GITHUB_TOKEN[/bold] environment variable.
+
+[bold]Option 4: Manual credential[/bold]
+  [dim]vibeusage key copilot set[/dim]
+
+[bold]Token format:[/bold]
+  GitHub OAuth tokens start with [bold]gho_[/bold] (OAuth) or [bold]ghu_[/bold] (user).
+  Example: gho_xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx""",
         "cursor": """[bold cyan]Cursor Authentication[/bold cyan]
 
 Cursor uses session cookies from the browser.
@@ -423,13 +464,31 @@ Cursor uses session cookies from the browser.
   [dim]vibeusage key cursor set[/dim]""",
         "gemini": """[bold cyan]Gemini Authentication[/bold cyan]
 
-Gemini uses Google OAuth credentials.
-
-[dim]Run the official Gemini CLI to authenticate:[/dim]
+[bold]Option 1: Gemini CLI (recommended)[/bold]
+Run the official Gemini CLI to authenticate:
   [dim]gemini auth login[/dim]
 
-[dim]Or set credentials manually with your OAuth token:[/dim]
-  [dim]vibeusage key gemini set[/dim]""",
+vibeusage will automatically read credentials from
+[bold]~/.gemini/oauth_creds.json[/bold]
+
+[bold]Option 2: API key[/bold]
+Set the [bold]GEMINI_API_KEY[/bold] environment variable:
+  [dim]export GEMINI_API_KEY="AIza..."[/dim]
+
+Or save an API key file:
+  [dim]vibeusage key gemini set[/dim]
+
+[bold]Option 3: Manual OAuth credential[/bold]
+  [dim]vibeusage key gemini set[/dim]
+
+[bold]Credential file format[/bold] (~/.gemini/oauth_creds.json):
+  {
+    "access_token": "<Google OAuth access token>",
+    "refresh_token": "<Google OAuth refresh token>",
+    "expires_at": "<ISO 8601 timestamp>"
+  }
+
+[dim]Tokens are automatically refreshed when they expire.[/dim]""",
     }
 
     instructions = instructions_map.get(
@@ -457,6 +516,10 @@ Get your session token from cursor.com:
    • [bold]__Secure-next-auth.session-token[/bold]
    • [bold]next-auth.session-token[/bold]
 5. Copy its value
+
+[bold]Expected format:[/bold]
+  The token is a long encoded string, typically a JWT starting
+  with [bold]eyJ[/bold] or a session identifier. It can be 100+ characters.
 
 [dim]The session token allows vibeusage to fetch your usage data.[/dim]""",
         title="Instructions",

--- a/tests/cli/test_auth_commands.py
+++ b/tests/cli/test_auth_commands.py
@@ -1117,3 +1117,158 @@ class TestShowProviderAuthInstructions:
         auth_module._show_provider_auth_instructions(console, "codex", quiet=True)
         output = console.file.getvalue()
         assert output == ""
+
+
+class TestImprovedClaudeAuthInstructions:
+    """Tests for improved Claude auth instructions (Phase 9.3)."""
+
+    def test_claude_instructions_show_cookie_format(self):
+        """Claude instructions mention expected cookie format prefix."""
+        console = Console(file=StringIO())
+        auth_module._show_claude_auth_instructions(console, quiet=False)
+        output = console.file.getvalue()
+        assert "sk-ant-sid01-" in output
+
+    def test_claude_instructions_mention_expiration(self):
+        """Claude instructions mention cookie expiration behavior."""
+        console = Console(file=StringIO())
+        auth_module._show_claude_auth_instructions(console, quiet=False)
+        output = console.file.getvalue()
+        assert "expir" in output.lower()
+
+    def test_claude_instructions_mention_alternative_credential_path(self):
+        """Claude instructions mention the CLI credential path as alternative."""
+        console = Console(file=StringIO())
+        auth_module._show_claude_auth_instructions(console, quiet=False)
+        output = console.file.getvalue()
+        assert ".claude" in output
+
+
+class TestImprovedCodexAuthInstructions:
+    """Tests for improved Codex auth instructions (Phase 9.3)."""
+
+    def test_codex_instructions_show_file_format(self):
+        """Codex instructions show the auth.json file format."""
+        console = Console(file=StringIO())
+        auth_module._show_provider_auth_instructions(console, "codex", quiet=False)
+        output = console.file.getvalue()
+        assert "auth.json" in output
+
+    def test_codex_instructions_show_credential_path(self):
+        """Codex instructions show the ~/.codex/ credential path."""
+        console = Console(file=StringIO())
+        auth_module._show_provider_auth_instructions(console, "codex", quiet=False)
+        output = console.file.getvalue()
+        assert "~/.codex/" in output
+
+    def test_codex_instructions_show_token_structure(self):
+        """Codex instructions explain token JSON structure."""
+        console = Console(file=StringIO())
+        auth_module._show_provider_auth_instructions(console, "codex", quiet=False)
+        output = console.file.getvalue()
+        assert "access_token" in output
+
+    def test_codex_instructions_mention_env_var(self):
+        """Codex instructions mention the OPENAI_API_KEY env var."""
+        console = Console(file=StringIO())
+        auth_module._show_provider_auth_instructions(console, "codex", quiet=False)
+        output = console.file.getvalue()
+        assert "OPENAI_API_KEY" in output
+
+
+class TestImprovedCursorAuthInstructions:
+    """Tests for improved Cursor auth instructions (Phase 9.3)."""
+
+    def test_cursor_instructions_mention_format_hint(self):
+        """Cursor instructions mention expected token format."""
+        console = Console(file=StringIO())
+        auth_module._show_cursor_auth_instructions(console, quiet=False)
+        output = console.file.getvalue()
+        # Should mention it's a long encoded string
+        assert (
+            "long" in output.lower()
+            or "encoded" in output.lower()
+            or "JWT" in output
+            or "eyJ" in output
+        )
+
+    def test_cursor_instructions_mention_all_cookie_names(self):
+        """Cursor instructions list all possible cookie names."""
+        console = Console(file=StringIO())
+        auth_module._show_cursor_auth_instructions(console, quiet=False)
+        output = console.file.getvalue()
+        assert "WorkosCursorSessionToken" in output
+        assert "__Secure-next-auth.session-token" in output
+        assert "next-auth.session-token" in output
+
+
+class TestImprovedGeminiAuthInstructions:
+    """Tests for improved Gemini auth instructions (Phase 9.3)."""
+
+    def test_gemini_instructions_show_credential_path(self):
+        """Gemini instructions show the ~/.gemini/ credential path."""
+        console = Console(file=StringIO())
+        auth_module._show_provider_auth_instructions(console, "gemini", quiet=False)
+        output = console.file.getvalue()
+        assert "~/.gemini/" in output
+
+    def test_gemini_instructions_show_file_format(self):
+        """Gemini instructions show the oauth_creds.json file format."""
+        console = Console(file=StringIO())
+        auth_module._show_provider_auth_instructions(console, "gemini", quiet=False)
+        output = console.file.getvalue()
+        assert "oauth_creds.json" in output
+
+    def test_gemini_instructions_show_token_structure(self):
+        """Gemini instructions explain token JSON structure."""
+        console = Console(file=StringIO())
+        auth_module._show_provider_auth_instructions(console, "gemini", quiet=False)
+        output = console.file.getvalue()
+        assert "access_token" in output
+        assert "refresh_token" in output
+
+    def test_gemini_instructions_mention_env_var(self):
+        """Gemini instructions mention the GEMINI_API_KEY env var."""
+        console = Console(file=StringIO())
+        auth_module._show_provider_auth_instructions(console, "gemini", quiet=False)
+        output = console.file.getvalue()
+        assert "GEMINI_API_KEY" in output
+
+    def test_gemini_instructions_mention_api_key_alternative(self):
+        """Gemini instructions mention API key as alternative auth method."""
+        console = Console(file=StringIO())
+        auth_module._show_provider_auth_instructions(console, "gemini", quiet=False)
+        output = console.file.getvalue()
+        assert "API key" in output or "api_key" in output
+
+
+class TestImprovedCopilotAuthInstructions:
+    """Tests for improved Copilot auth instructions (Phase 9.3)."""
+
+    def test_copilot_instructions_mention_hosts_json(self):
+        """Copilot instructions mention VS Code hosts.json location."""
+        console = Console(file=StringIO())
+        auth_module._show_provider_auth_instructions(console, "copilot", quiet=False)
+        output = console.file.getvalue()
+        assert "hosts.json" in output
+
+    def test_copilot_instructions_show_credential_path(self):
+        """Copilot instructions show the github-copilot config path."""
+        console = Console(file=StringIO())
+        auth_module._show_provider_auth_instructions(console, "copilot", quiet=False)
+        output = console.file.getvalue()
+        assert "github-copilot" in output
+
+    def test_copilot_instructions_explain_token_format(self):
+        """Copilot instructions explain token format."""
+        console = Console(file=StringIO())
+        auth_module._show_provider_auth_instructions(console, "copilot", quiet=False)
+        output = console.file.getvalue()
+        assert "gho_" in output or "ghu_" in output
+
+    def test_copilot_instructions_mention_device_flow(self):
+        """Copilot instructions mention the preferred device flow auth."""
+        console = Console(file=StringIO())
+        auth_module._show_provider_auth_instructions(console, "copilot", quiet=False)
+        output = console.file.getvalue()
+        assert "vibeusage auth copilot" in output


### PR DESCRIPTION
## Summary

Improves the auth command instructions for all 5 providers to be more helpful and actionable, completing Phase 9.3 from the plan.

## Changes

### Claude
- Added expected cookie format prefix (`sk-ant-sid01-`) with bold emphasis
- Added expiration note (session keys expire periodically)
- Added alternative credential path (`~/.claude/.credentials.json`)

### Codex
- Restructured as numbered options (CLI → env var → manual)
- Added `~/.codex/auth.json` file format example with `tokens.access_token` structure
- Added `OPENAI_API_KEY` environment variable option

### Cursor
- Added expected token format hint (JWT/encoded string starting with `eyJ`)

### Gemini
- Restructured as numbered options (CLI → API key → manual OAuth)
- Added `~/.gemini/oauth_creds.json` file format example
- Added `GEMINI_API_KEY` environment variable option
- Added API key as alternative auth method

### Copilot
- Replaced stale "Running interactive device flow..." text with actionable instructions
- Added VS Code `hosts.json` location (`~/.config/github-copilot/hosts.json`)
- Added token format explanation (`gho_` for OAuth, `ghu_` for user tokens)
- Added preferred device flow command (`vibeusage auth copilot`)
- Added `GITHUB_TOKEN` environment variable option

## Testing

- 18 new tests covering all improved instruction content
- All 1118 tests pass (up from 1100)
- 82% coverage maintained
- All file paths, env var names, and credential formats verified against actual codebase (`credentials.py`, provider parsers)