### PR TITLE
feat(go): define typed JSON response structs for Claude Web API

### DIFF
--- a/vibeusage-go/IMPROVEMENTS.md
+++ b/vibeusage-go/IMPROVEMENTS.md
@@ -145,12 +145,12 @@ type claudeUsageResponse struct {
 ### Tasks
 
 - [x] Define response structs for Claude OAuth API
-- [ ] Define response structs for Claude Web API
+- [x] Define response structs for Claude Web API
 - [ ] Define response structs for Codex API
 - [ ] Define response structs for Copilot API (usage + device flow)
 - [ ] Define response structs for Cursor API
 - [ ] Define response structs for Gemini API (quota + token refresh)
-- [~] Migrate each provider's `Fetch()` and parse methods to use typed structs (Claude OAuth done)
+- [~] Migrate each provider's `Fetch()` and parse methods to use typed structs (Claude OAuth + Web done)
 - [ ] Replace `map[string]any` in credential loading where possible
 
 ## 5. Shared HTTP Client

--- a/vibeusage-go/internal/provider/claude/response.go
+++ b/vibeusage-go/internal/provider/claude/response.go
@@ -1,6 +1,10 @@
 package claude
 
-import "time"
+import (
+	"time"
+
+	"github.com/joshuadavidthomas/vibeusage/internal/models"
+)
 
 // UsagePeriodResponse represents a single usage period from the Claude OAuth API.
 type UsagePeriodResponse struct {
@@ -76,4 +80,66 @@ func (c OAuthCredentials) NeedsRefresh() bool {
 // ClaudeCLICredentials represents the Claude CLI credentials file format.
 type ClaudeCLICredentials struct {
 	ClaudeAiOauth *ClaudeCLIOAuth `json:"claudeAiOauth,omitempty"`
+}
+
+// WebUsageResponse represents the response from /api/organizations/{orgID}/usage.
+type WebUsageResponse struct {
+	UsageAmount  float64 `json:"usage_amount"`
+	UsageLimit   float64 `json:"usage_limit"`
+	PeriodEnd    string  `json:"period_end,omitempty"`
+	Email        string  `json:"email,omitempty"`
+	Organization string  `json:"organization,omitempty"`
+	Plan         string  `json:"plan,omitempty"`
+}
+
+// WebOverageResponse represents the response from /api/organizations/{orgID}/overage_spend_limit.
+type WebOverageResponse struct {
+	HasHardLimit bool    `json:"has_hard_limit"`
+	CurrentSpend float64 `json:"current_spend"`
+	HardLimit    float64 `json:"hard_limit"`
+}
+
+// ToOverageUsage converts the web overage response to a models.OverageUsage.
+// Returns nil if there is no hard limit.
+func (r *WebOverageResponse) ToOverageUsage() *models.OverageUsage {
+	if !r.HasHardLimit {
+		return nil
+	}
+	return &models.OverageUsage{
+		Used:      r.CurrentSpend,
+		Limit:     r.HardLimit,
+		Currency:  "USD",
+		IsEnabled: true,
+	}
+}
+
+// WebOrganization represents a single organization from /api/organizations.
+type WebOrganization struct {
+	UUID         string   `json:"uuid,omitempty"`
+	ID           string   `json:"id,omitempty"`
+	Name         string   `json:"name,omitempty"`
+	Capabilities []string `json:"capabilities,omitempty"`
+}
+
+// OrgID returns the best identifier for this organization, preferring UUID over ID.
+func (o *WebOrganization) OrgID() string {
+	if o.UUID != "" {
+		return o.UUID
+	}
+	return o.ID
+}
+
+// HasCapability reports whether the organization has the given capability.
+func (o *WebOrganization) HasCapability(cap string) bool {
+	for _, c := range o.Capabilities {
+		if c == cap {
+			return true
+		}
+	}
+	return false
+}
+
+// WebSessionCredentials represents stored web session credentials.
+type WebSessionCredentials struct {
+	SessionKey string `json:"session_key"`
 }

--- a/vibeusage-go/internal/provider/claude/web_response_test.go
+++ b/vibeusage-go/internal/provider/claude/web_response_test.go
@@ -1,0 +1,441 @@
+package claude
+
+import (
+	"encoding/json"
+	"testing"
+)
+
+func TestWebUsageResponse_UnmarshalFullResponse(t *testing.T) {
+	raw := `{
+		"usage_amount": 42.5,
+		"usage_limit": 100.0,
+		"period_end": "2025-02-19T22:00:00Z",
+		"email": "user@example.com",
+		"organization": "My Org",
+		"plan": "pro"
+	}`
+
+	var resp WebUsageResponse
+	if err := json.Unmarshal([]byte(raw), &resp); err != nil {
+		t.Fatalf("unmarshal failed: %v", err)
+	}
+
+	if resp.UsageAmount != 42.5 {
+		t.Errorf("usage_amount = %v, want 42.5", resp.UsageAmount)
+	}
+	if resp.UsageLimit != 100.0 {
+		t.Errorf("usage_limit = %v, want 100.0", resp.UsageLimit)
+	}
+	if resp.PeriodEnd != "2025-02-19T22:00:00Z" {
+		t.Errorf("period_end = %q, want %q", resp.PeriodEnd, "2025-02-19T22:00:00Z")
+	}
+	if resp.Email != "user@example.com" {
+		t.Errorf("email = %q, want %q", resp.Email, "user@example.com")
+	}
+	if resp.Organization != "My Org" {
+		t.Errorf("organization = %q, want %q", resp.Organization, "My Org")
+	}
+	if resp.Plan != "pro" {
+		t.Errorf("plan = %q, want %q", resp.Plan, "pro")
+	}
+}
+
+func TestWebUsageResponse_UnmarshalMinimalResponse(t *testing.T) {
+	raw := `{
+		"usage_amount": 10.0,
+		"usage_limit": 50.0
+	}`
+
+	var resp WebUsageResponse
+	if err := json.Unmarshal([]byte(raw), &resp); err != nil {
+		t.Fatalf("unmarshal failed: %v", err)
+	}
+
+	if resp.UsageAmount != 10.0 {
+		t.Errorf("usage_amount = %v, want 10.0", resp.UsageAmount)
+	}
+	if resp.UsageLimit != 50.0 {
+		t.Errorf("usage_limit = %v, want 50.0", resp.UsageLimit)
+	}
+	if resp.PeriodEnd != "" {
+		t.Errorf("period_end = %q, want empty", resp.PeriodEnd)
+	}
+	if resp.Email != "" {
+		t.Errorf("email = %q, want empty", resp.Email)
+	}
+	if resp.Organization != "" {
+		t.Errorf("organization = %q, want empty", resp.Organization)
+	}
+	if resp.Plan != "" {
+		t.Errorf("plan = %q, want empty", resp.Plan)
+	}
+}
+
+func TestWebUsageResponse_UnmarshalEmptyResponse(t *testing.T) {
+	raw := `{}`
+
+	var resp WebUsageResponse
+	if err := json.Unmarshal([]byte(raw), &resp); err != nil {
+		t.Fatalf("unmarshal failed: %v", err)
+	}
+
+	if resp.UsageAmount != 0 {
+		t.Errorf("usage_amount = %v, want 0", resp.UsageAmount)
+	}
+	if resp.UsageLimit != 0 {
+		t.Errorf("usage_limit = %v, want 0", resp.UsageLimit)
+	}
+}
+
+func TestWebUsageResponse_UnmarshalZeroLimit(t *testing.T) {
+	raw := `{
+		"usage_amount": 0,
+		"usage_limit": 0
+	}`
+
+	var resp WebUsageResponse
+	if err := json.Unmarshal([]byte(raw), &resp); err != nil {
+		t.Fatalf("unmarshal failed: %v", err)
+	}
+
+	if resp.UsageAmount != 0 {
+		t.Errorf("usage_amount = %v, want 0", resp.UsageAmount)
+	}
+	if resp.UsageLimit != 0 {
+		t.Errorf("usage_limit = %v, want 0", resp.UsageLimit)
+	}
+}
+
+func TestWebOverageResponse_UnmarshalWithHardLimit(t *testing.T) {
+	raw := `{
+		"has_hard_limit": true,
+		"current_spend": 25.50,
+		"hard_limit": 100.0
+	}`
+
+	var resp WebOverageResponse
+	if err := json.Unmarshal([]byte(raw), &resp); err != nil {
+		t.Fatalf("unmarshal failed: %v", err)
+	}
+
+	if !resp.HasHardLimit {
+		t.Error("expected has_hard_limit to be true")
+	}
+	if resp.CurrentSpend != 25.50 {
+		t.Errorf("current_spend = %v, want 25.50", resp.CurrentSpend)
+	}
+	if resp.HardLimit != 100.0 {
+		t.Errorf("hard_limit = %v, want 100.0", resp.HardLimit)
+	}
+}
+
+func TestWebOverageResponse_UnmarshalNoHardLimit(t *testing.T) {
+	raw := `{
+		"has_hard_limit": false,
+		"current_spend": 0,
+		"hard_limit": 0
+	}`
+
+	var resp WebOverageResponse
+	if err := json.Unmarshal([]byte(raw), &resp); err != nil {
+		t.Fatalf("unmarshal failed: %v", err)
+	}
+
+	if resp.HasHardLimit {
+		t.Error("expected has_hard_limit to be false")
+	}
+	if resp.CurrentSpend != 0 {
+		t.Errorf("current_spend = %v, want 0", resp.CurrentSpend)
+	}
+	if resp.HardLimit != 0 {
+		t.Errorf("hard_limit = %v, want 0", resp.HardLimit)
+	}
+}
+
+func TestWebOverageResponse_UnmarshalEmptyResponse(t *testing.T) {
+	raw := `{}`
+
+	var resp WebOverageResponse
+	if err := json.Unmarshal([]byte(raw), &resp); err != nil {
+		t.Fatalf("unmarshal failed: %v", err)
+	}
+
+	if resp.HasHardLimit {
+		t.Error("expected has_hard_limit to be false")
+	}
+}
+
+func TestWebOrganization_UnmarshalWithUUID(t *testing.T) {
+	raw := `{
+		"uuid": "org-uuid-123",
+		"name": "Test Org",
+		"capabilities": ["chat", "billing"]
+	}`
+
+	var org WebOrganization
+	if err := json.Unmarshal([]byte(raw), &org); err != nil {
+		t.Fatalf("unmarshal failed: %v", err)
+	}
+
+	if org.UUID != "org-uuid-123" {
+		t.Errorf("uuid = %q, want %q", org.UUID, "org-uuid-123")
+	}
+	if org.Name != "Test Org" {
+		t.Errorf("name = %q, want %q", org.Name, "Test Org")
+	}
+	if len(org.Capabilities) != 2 {
+		t.Fatalf("len(capabilities) = %d, want 2", len(org.Capabilities))
+	}
+	if org.Capabilities[0] != "chat" {
+		t.Errorf("capabilities[0] = %q, want %q", org.Capabilities[0], "chat")
+	}
+	if org.Capabilities[1] != "billing" {
+		t.Errorf("capabilities[1] = %q, want %q", org.Capabilities[1], "billing")
+	}
+}
+
+func TestWebOrganization_UnmarshalWithID(t *testing.T) {
+	raw := `{
+		"id": "org-id-456",
+		"capabilities": ["chat"]
+	}`
+
+	var org WebOrganization
+	if err := json.Unmarshal([]byte(raw), &org); err != nil {
+		t.Fatalf("unmarshal failed: %v", err)
+	}
+
+	if org.ID != "org-id-456" {
+		t.Errorf("id = %q, want %q", org.ID, "org-id-456")
+	}
+}
+
+func TestWebOrganization_UnmarshalBothUUIDAndID(t *testing.T) {
+	raw := `{
+		"uuid": "org-uuid-123",
+		"id": "org-id-456",
+		"capabilities": ["chat"]
+	}`
+
+	var org WebOrganization
+	if err := json.Unmarshal([]byte(raw), &org); err != nil {
+		t.Fatalf("unmarshal failed: %v", err)
+	}
+
+	if org.UUID != "org-uuid-123" {
+		t.Errorf("uuid = %q, want %q", org.UUID, "org-uuid-123")
+	}
+	if org.ID != "org-id-456" {
+		t.Errorf("id = %q, want %q", org.ID, "org-id-456")
+	}
+}
+
+func TestWebOrganization_UnmarshalNoCaps(t *testing.T) {
+	raw := `{
+		"uuid": "org-uuid-123"
+	}`
+
+	var org WebOrganization
+	if err := json.Unmarshal([]byte(raw), &org); err != nil {
+		t.Fatalf("unmarshal failed: %v", err)
+	}
+
+	if org.UUID != "org-uuid-123" {
+		t.Errorf("uuid = %q, want %q", org.UUID, "org-uuid-123")
+	}
+	if org.Capabilities != nil {
+		t.Errorf("capabilities = %v, want nil", org.Capabilities)
+	}
+}
+
+func TestWebOrganization_HasCapability(t *testing.T) {
+	tests := []struct {
+		name       string
+		org        WebOrganization
+		capability string
+		want       bool
+	}{
+		{
+			name:       "has chat capability",
+			org:        WebOrganization{Capabilities: []string{"chat", "billing"}},
+			capability: "chat",
+			want:       true,
+		},
+		{
+			name:       "missing capability",
+			org:        WebOrganization{Capabilities: []string{"billing"}},
+			capability: "chat",
+			want:       false,
+		},
+		{
+			name:       "nil capabilities",
+			org:        WebOrganization{},
+			capability: "chat",
+			want:       false,
+		},
+		{
+			name:       "empty capabilities",
+			org:        WebOrganization{Capabilities: []string{}},
+			capability: "chat",
+			want:       false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := tt.org.HasCapability(tt.capability)
+			if got != tt.want {
+				t.Errorf("HasCapability(%q) = %v, want %v", tt.capability, got, tt.want)
+			}
+		})
+	}
+}
+
+func TestWebOrganization_OrgID(t *testing.T) {
+	tests := []struct {
+		name string
+		org  WebOrganization
+		want string
+	}{
+		{
+			name: "uuid takes precedence",
+			org:  WebOrganization{UUID: "org-uuid", ID: "org-id"},
+			want: "org-uuid",
+		},
+		{
+			name: "fallback to id",
+			org:  WebOrganization{ID: "org-id"},
+			want: "org-id",
+		},
+		{
+			name: "both empty",
+			org:  WebOrganization{},
+			want: "",
+		},
+		{
+			name: "uuid only",
+			org:  WebOrganization{UUID: "org-uuid"},
+			want: "org-uuid",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := tt.org.OrgID()
+			if got != tt.want {
+				t.Errorf("OrgID() = %q, want %q", got, tt.want)
+			}
+		})
+	}
+}
+
+func TestWebOrganization_UnmarshalOrganizationsList(t *testing.T) {
+	raw := `[
+		{"uuid": "org-1", "name": "Personal", "capabilities": ["chat"]},
+		{"uuid": "org-2", "name": "Work", "capabilities": ["chat", "billing"]},
+		{"id": "org-3", "name": "Legacy", "capabilities": ["billing"]}
+	]`
+
+	var orgs []WebOrganization
+	if err := json.Unmarshal([]byte(raw), &orgs); err != nil {
+		t.Fatalf("unmarshal failed: %v", err)
+	}
+
+	if len(orgs) != 3 {
+		t.Fatalf("len(orgs) = %d, want 3", len(orgs))
+	}
+
+	if orgs[0].UUID != "org-1" {
+		t.Errorf("orgs[0].uuid = %q, want %q", orgs[0].UUID, "org-1")
+	}
+	if orgs[0].Name != "Personal" {
+		t.Errorf("orgs[0].name = %q, want %q", orgs[0].Name, "Personal")
+	}
+	if !orgs[0].HasCapability("chat") {
+		t.Error("orgs[0] should have chat capability")
+	}
+
+	if orgs[2].ID != "org-3" {
+		t.Errorf("orgs[2].id = %q, want %q", orgs[2].ID, "org-3")
+	}
+	if orgs[2].HasCapability("chat") {
+		t.Error("orgs[2] should not have chat capability")
+	}
+}
+
+func TestWebSessionCredentials_Unmarshal(t *testing.T) {
+	raw := `{"session_key": "sk-ant-sid01-test-key"}`
+
+	var creds WebSessionCredentials
+	if err := json.Unmarshal([]byte(raw), &creds); err != nil {
+		t.Fatalf("unmarshal failed: %v", err)
+	}
+
+	if creds.SessionKey != "sk-ant-sid01-test-key" {
+		t.Errorf("session_key = %q, want %q", creds.SessionKey, "sk-ant-sid01-test-key")
+	}
+}
+
+func TestWebSessionCredentials_UnmarshalEmpty(t *testing.T) {
+	raw := `{}`
+
+	var creds WebSessionCredentials
+	if err := json.Unmarshal([]byte(raw), &creds); err != nil {
+		t.Fatalf("unmarshal failed: %v", err)
+	}
+
+	if creds.SessionKey != "" {
+		t.Errorf("session_key = %q, want empty", creds.SessionKey)
+	}
+}
+
+func TestWebOverageResponse_ToOverageUsage(t *testing.T) {
+	tests := []struct {
+		name     string
+		resp     WebOverageResponse
+		wantNil  bool
+		wantUsed float64
+	}{
+		{
+			name: "with hard limit",
+			resp: WebOverageResponse{
+				HasHardLimit: true,
+				CurrentSpend: 25.50,
+				HardLimit:    100.0,
+			},
+			wantNil:  false,
+			wantUsed: 25.50,
+		},
+		{
+			name: "without hard limit",
+			resp: WebOverageResponse{
+				HasHardLimit: false,
+			},
+			wantNil: true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := tt.resp.ToOverageUsage()
+			if tt.wantNil {
+				if got != nil {
+					t.Errorf("ToOverageUsage() = %+v, want nil", got)
+				}
+				return
+			}
+			if got == nil {
+				t.Fatal("ToOverageUsage() = nil, want non-nil")
+			}
+			if got.Used != tt.wantUsed {
+				t.Errorf("Used = %v, want %v", got.Used, tt.wantUsed)
+			}
+			if got.Currency != "USD" {
+				t.Errorf("Currency = %q, want %q", got.Currency, "USD")
+			}
+			if !got.IsEnabled {
+				t.Error("expected IsEnabled to be true")
+			}
+		})
+	}
+}

--- a/vibeusage-go/internal/provider/claude/web_test.go
+++ b/vibeusage-go/internal/provider/claude/web_test.go
@@ -1,0 +1,274 @@
+package claude
+
+import (
+	"testing"
+	"time"
+
+	"github.com/joshuadavidthomas/vibeusage/internal/models"
+)
+
+func TestParseWebUsageResponse_FullResponse(t *testing.T) {
+	resp := WebUsageResponse{
+		UsageAmount:  42.5,
+		UsageLimit:   100.0,
+		PeriodEnd:    "2025-02-19T22:00:00Z",
+		Email:        "user@example.com",
+		Organization: "My Org",
+		Plan:         "pro",
+	}
+
+	s := WebStrategy{}
+	snapshot := s.parseWebUsageResponse(resp, nil)
+
+	if snapshot == nil {
+		t.Fatal("expected non-nil snapshot")
+	}
+	if snapshot.Provider != "claude" {
+		t.Errorf("provider = %q, want %q", snapshot.Provider, "claude")
+	}
+	if snapshot.Source != "web" {
+		t.Errorf("source = %q, want %q", snapshot.Source, "web")
+	}
+
+	// Should have 1 period
+	if len(snapshot.Periods) != 1 {
+		t.Fatalf("len(periods) = %d, want 1", len(snapshot.Periods))
+	}
+
+	p := snapshot.Periods[0]
+	if p.Name != "Usage" {
+		t.Errorf("period name = %q, want %q", p.Name, "Usage")
+	}
+	// 42.5/100.0 = 42.5% -> int(42)
+	if p.Utilization != 42 {
+		t.Errorf("utilization = %d, want 42", p.Utilization)
+	}
+	if p.PeriodType != models.PeriodDaily {
+		t.Errorf("period_type = %q, want %q", p.PeriodType, models.PeriodDaily)
+	}
+	if p.ResetsAt == nil {
+		t.Fatal("expected resets_at to be set")
+	}
+	expected := time.Date(2025, 2, 19, 22, 0, 0, 0, time.UTC)
+	if !p.ResetsAt.Equal(expected) {
+		t.Errorf("resets_at = %v, want %v", p.ResetsAt, expected)
+	}
+
+	// Identity
+	if snapshot.Identity == nil {
+		t.Fatal("expected identity to be set")
+	}
+	if snapshot.Identity.Email != "user@example.com" {
+		t.Errorf("email = %q, want %q", snapshot.Identity.Email, "user@example.com")
+	}
+	if snapshot.Identity.Organization != "My Org" {
+		t.Errorf("organization = %q, want %q", snapshot.Identity.Organization, "My Org")
+	}
+	if snapshot.Identity.Plan != "pro" {
+		t.Errorf("plan = %q, want %q", snapshot.Identity.Plan, "pro")
+	}
+
+	// No overage
+	if snapshot.Overage != nil {
+		t.Error("expected overage to be nil")
+	}
+}
+
+func TestParseWebUsageResponse_WithOverage(t *testing.T) {
+	resp := WebUsageResponse{
+		UsageAmount: 50.0,
+		UsageLimit:  100.0,
+	}
+	overage := &models.OverageUsage{
+		Used:      25.50,
+		Limit:     100.0,
+		Currency:  "USD",
+		IsEnabled: true,
+	}
+
+	s := WebStrategy{}
+	snapshot := s.parseWebUsageResponse(resp, overage)
+
+	if snapshot == nil {
+		t.Fatal("expected non-nil snapshot")
+	}
+	if snapshot.Overage == nil {
+		t.Fatal("expected overage to be present")
+	}
+	if snapshot.Overage.Used != 25.50 {
+		t.Errorf("overage used = %v, want 25.50", snapshot.Overage.Used)
+	}
+}
+
+func TestParseWebUsageResponse_ZeroLimit(t *testing.T) {
+	resp := WebUsageResponse{
+		UsageAmount: 0,
+		UsageLimit:  0,
+	}
+
+	s := WebStrategy{}
+	snapshot := s.parseWebUsageResponse(resp, nil)
+
+	if snapshot == nil {
+		t.Fatal("expected non-nil snapshot")
+	}
+	// With zero limit, no period should be created
+	if len(snapshot.Periods) != 0 {
+		t.Errorf("len(periods) = %d, want 0", len(snapshot.Periods))
+	}
+}
+
+func TestParseWebUsageResponse_NoIdentity(t *testing.T) {
+	resp := WebUsageResponse{
+		UsageAmount: 10.0,
+		UsageLimit:  50.0,
+	}
+
+	s := WebStrategy{}
+	snapshot := s.parseWebUsageResponse(resp, nil)
+
+	if snapshot == nil {
+		t.Fatal("expected non-nil snapshot")
+	}
+	if snapshot.Identity != nil {
+		t.Error("expected identity to be nil when no email/org/plan")
+	}
+}
+
+func TestParseWebUsageResponse_InvalidPeriodEnd(t *testing.T) {
+	resp := WebUsageResponse{
+		UsageAmount: 50.0,
+		UsageLimit:  100.0,
+		PeriodEnd:   "not-a-date",
+	}
+
+	s := WebStrategy{}
+	snapshot := s.parseWebUsageResponse(resp, nil)
+
+	if snapshot == nil {
+		t.Fatal("expected non-nil snapshot")
+	}
+	if len(snapshot.Periods) != 1 {
+		t.Fatalf("len(periods) = %d, want 1", len(snapshot.Periods))
+	}
+	// Period should exist but resets_at should be nil
+	if snapshot.Periods[0].ResetsAt != nil {
+		t.Error("expected resets_at to be nil for invalid date")
+	}
+}
+
+func TestParseWebUsageResponse_EmptyPeriodEnd(t *testing.T) {
+	resp := WebUsageResponse{
+		UsageAmount: 50.0,
+		UsageLimit:  100.0,
+	}
+
+	s := WebStrategy{}
+	snapshot := s.parseWebUsageResponse(resp, nil)
+
+	if snapshot == nil {
+		t.Fatal("expected non-nil snapshot")
+	}
+	if len(snapshot.Periods) != 1 {
+		t.Fatalf("len(periods) = %d, want 1", len(snapshot.Periods))
+	}
+	if snapshot.Periods[0].ResetsAt != nil {
+		t.Error("expected resets_at to be nil when period_end is empty")
+	}
+}
+
+func TestParseWebUsageResponse_HighUtilization(t *testing.T) {
+	resp := WebUsageResponse{
+		UsageAmount: 95.0,
+		UsageLimit:  100.0,
+	}
+
+	s := WebStrategy{}
+	snapshot := s.parseWebUsageResponse(resp, nil)
+
+	if snapshot == nil {
+		t.Fatal("expected non-nil snapshot")
+	}
+	if len(snapshot.Periods) != 1 {
+		t.Fatalf("len(periods) = %d, want 1", len(snapshot.Periods))
+	}
+	if snapshot.Periods[0].Utilization != 95 {
+		t.Errorf("utilization = %d, want 95", snapshot.Periods[0].Utilization)
+	}
+}
+
+func TestParseWebUsageResponse_PartialIdentity(t *testing.T) {
+	resp := WebUsageResponse{
+		UsageAmount: 50.0,
+		UsageLimit:  100.0,
+		Email:       "user@example.com",
+	}
+
+	s := WebStrategy{}
+	snapshot := s.parseWebUsageResponse(resp, nil)
+
+	if snapshot == nil {
+		t.Fatal("expected non-nil snapshot")
+	}
+	if snapshot.Identity == nil {
+		t.Fatal("expected identity when email is present")
+	}
+	if snapshot.Identity.Email != "user@example.com" {
+		t.Errorf("email = %q, want %q", snapshot.Identity.Email, "user@example.com")
+	}
+	if snapshot.Identity.Organization != "" {
+		t.Errorf("organization = %q, want empty", snapshot.Identity.Organization)
+	}
+}
+
+func TestGetOrgFromList_ChatCapability(t *testing.T) {
+	orgs := []WebOrganization{
+		{UUID: "org-1", Capabilities: []string{"billing"}},
+		{UUID: "org-2", Capabilities: []string{"chat", "billing"}},
+		{UUID: "org-3", Capabilities: []string{"chat"}},
+	}
+
+	s := WebStrategy{}
+	orgID := s.findChatOrgID(orgs)
+
+	if orgID != "org-2" {
+		t.Errorf("findChatOrgID() = %q, want %q (first org with chat)", orgID, "org-2")
+	}
+}
+
+func TestGetOrgFromList_NoChatCapability(t *testing.T) {
+	orgs := []WebOrganization{
+		{UUID: "org-1", Capabilities: []string{"billing"}},
+		{UUID: "org-2", Capabilities: []string{"billing"}},
+	}
+
+	s := WebStrategy{}
+	orgID := s.findChatOrgID(orgs)
+
+	// Fallback to first org
+	if orgID != "org-1" {
+		t.Errorf("findChatOrgID() = %q, want %q (fallback to first)", orgID, "org-1")
+	}
+}
+
+func TestGetOrgFromList_Empty(t *testing.T) {
+	s := WebStrategy{}
+	orgID := s.findChatOrgID(nil)
+
+	if orgID != "" {
+		t.Errorf("findChatOrgID() = %q, want empty", orgID)
+	}
+}
+
+func TestGetOrgFromList_UsesIDFallback(t *testing.T) {
+	orgs := []WebOrganization{
+		{ID: "org-legacy", Capabilities: []string{"chat"}},
+	}
+
+	s := WebStrategy{}
+	orgID := s.findChatOrgID(orgs)
+
+	if orgID != "org-legacy" {
+		t.Errorf("findChatOrgID() = %q, want %q", orgID, "org-legacy")
+	}
+}


### PR DESCRIPTION
## Summary

Replace all `map[string]any` usage in the Claude web strategy with typed response structs, continuing Phase 4 (Typed JSON Response Structs) of the improvement plan.

## Changes

### New types in `response.go`

- **`WebUsageResponse`** — `/api/organizations/{orgID}/usage` response
- **`WebOverageResponse`** — `/api/organizations/{orgID}/overage_spend_limit` response with `ToOverageUsage()` conversion method
- **`WebOrganization`** — `/api/organizations` list items with `HasCapability()` and `OrgID()` helpers
- **`WebSessionCredentials`** — stored web session credential format

### Migrated in `web.go`

- `Fetch()` now unmarshals into `WebUsageResponse` and `WebOverageResponse`
- `loadSessionKey()` uses `WebSessionCredentials` instead of `map[string]any`
- `getOrgID()` uses `[]WebOrganization` instead of `[]map[string]any`
- Extracted `findChatOrgID()` for testable org selection logic
- `parseWebUsageResponse()` replaces `parseUsageResponse()` with typed input
- Removed `getStringField()` and `parseOverage()` helpers (no longer needed)

### Tests

- 18 struct unmarshal tests (`web_response_test.go`)
- 12 behavioral tests for parse/org-selection logic (`web_test.go`)

## IMPROVEMENTS.md updates

- [x] Define response structs for Claude Web API
- [~] Migrate each provider's Fetch() and parse methods → now "Claude OAuth + Web done"