### PR TITLE
Add Go CI workflows for lint and test

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -1,0 +1,65 @@
+name: lint
+
+on:
+  push:
+    branches: [main]
+    paths:
+      - "vibeusage-go/**"
+  pull_request:
+    paths:
+      - "vibeusage-go/**"
+
+concurrency:
+  group: lint-${{ github.head_ref || github.run_id }}
+  cancel-in-progress: true
+
+defaults:
+  run:
+    working-directory: vibeusage-go
+
+jobs:
+  fmt:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v6
+
+      - uses: actions/setup-go@v6
+        with:
+          go-version-file: vibeusage-go/go.mod
+
+      - name: Check formatting
+        run: |
+          BAD=$(gofmt -l .)
+          if [ -n "$BAD" ]; then
+            echo "Files need formatting:"
+            echo "$BAD"
+            exit 1
+          fi
+
+  lint:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v6
+
+      - uses: actions/setup-go@v6
+        with:
+          go-version-file: vibeusage-go/go.mod
+
+      - uses: golangci/golangci-lint-action@v9
+        with:
+          working-directory: vibeusage-go
+          args: --timeout=5m
+
+  tidy:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v6
+
+      - uses: actions/setup-go@v6
+        with:
+          go-version-file: vibeusage-go/go.mod
+
+      - name: Check go.mod/go.sum
+        run: |
+          go mod tidy
+          git diff --exit-code go.mod go.sum

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,0 +1,31 @@
+name: test
+
+on:
+  push:
+    branches: [main]
+    paths:
+      - "vibeusage-go/**"
+  pull_request:
+    paths:
+      - "vibeusage-go/**"
+
+concurrency:
+  group: test-${{ github.head_ref || github.run_id }}
+  cancel-in-progress: true
+
+defaults:
+  run:
+    working-directory: vibeusage-go
+
+jobs:
+  test:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v6
+
+      - uses: actions/setup-go@v6
+        with:
+          go-version-file: vibeusage-go/go.mod
+
+      - name: Run tests
+        run: go test ./... -race -v


### PR DESCRIPTION
Adds GitHub Actions workflows for the Go codebase in `vibeusage-go/`, modeled after the agent-todos CI setup.

## Workflows

### `go-lint.yml`
- **fmt** — checks all `.go` files are `gofmt`-formatted
- **lint** — runs `golangci-lint` with a 5-minute timeout
- **tidy** — ensures `go.mod`/`go.sum` are tidy

### `go-test.yml`
- Runs `go test ./... -race -v`

Both workflows:
- Trigger on pushes to `main` and PRs, scoped to `vibeusage-go/**` paths only
- Use concurrency groups with cancel-in-progress
- Read Go version from `vibeusage-go/go.mod`
- Set `working-directory: vibeusage-go` as default