### PR TITLE
feat(go): structured logging and consistent error wrapping

### DIFF
--- a/vibeusage-go/IMPROVEMENTS.md
+++ b/vibeusage-go/IMPROVEMENTS.md
@@ -334,7 +334,7 @@ log.Info("account", "email", snap.Identity.Email)
 
 These can be done opportunistically alongside the items above.
 
-- [ ] Replace hand-rolled `itoa` in `models.go` and `gemini.go` with `strconv.Itoa`
-- [ ] Remove duplicate `fileExists` helper (defined in both `config/credentials.go` and `provider/claude/web.go`)
-- [ ] Consistent error wrapping with `fmt.Errorf("...: %w", err)` throughout
-- [ ] `http.NewRequest` error handling (currently `req, _ := http.NewRequest(...)` ignores errors everywhere)
+- [x] Replace hand-rolled `itoa` in `models.go` and `gemini.go` with `strconv.Itoa`
+- [x] Remove duplicate `fileExists` helper (defined in both `config/credentials.go` and `provider/claude/web.go`)
+- [x] Consistent error wrapping with `fmt.Errorf("...: %w", err)` throughout
+- [x] `http.NewRequest` error handling (currently `req, _ := http.NewRequest(...)` ignores errors everywhere)

--- a/vibeusage-go/cmd/config.go
+++ b/vibeusage-go/cmd/config.go
@@ -1,6 +1,7 @@
 package cmd
 
 import (
+	"fmt"
 	"os"
 	"os/exec"
 
@@ -126,7 +127,7 @@ var configResetCmd = &cobra.Command{
 
 		cfgPath := config.ConfigFile()
 		if err := os.Remove(cfgPath); err != nil && !os.IsNotExist(err) {
-			return err
+			return fmt.Errorf("resetting config: %w", err)
 		}
 
 		if jsonOutput {

--- a/vibeusage-go/internal/config/cache.go
+++ b/vibeusage-go/internal/config/cache.go
@@ -2,6 +2,7 @@ package config
 
 import (
 	"encoding/json"
+	"fmt"
 	"os"
 	"path/filepath"
 
@@ -15,13 +16,16 @@ func SnapshotPath(providerID string) string {
 func CacheSnapshot(snapshot models.UsageSnapshot) error {
 	path := SnapshotPath(snapshot.Provider)
 	if err := os.MkdirAll(filepath.Dir(path), 0o755); err != nil {
-		return err
+		return fmt.Errorf("caching snapshot for %s: %w", snapshot.Provider, err)
 	}
 	data, err := json.Marshal(snapshot)
 	if err != nil {
-		return err
+		return fmt.Errorf("caching snapshot for %s: %w", snapshot.Provider, err)
 	}
-	return os.WriteFile(path, data, 0o644)
+	if err := os.WriteFile(path, data, 0o644); err != nil {
+		return fmt.Errorf("caching snapshot for %s: %w", snapshot.Provider, err)
+	}
+	return nil
 }
 
 func LoadCachedSnapshot(providerID string) *models.UsageSnapshot {
@@ -45,9 +49,12 @@ func OrgIDPath(providerID string) string {
 func CacheOrgID(providerID, orgID string) error {
 	path := OrgIDPath(providerID)
 	if err := os.MkdirAll(filepath.Dir(path), 0o755); err != nil {
-		return err
+		return fmt.Errorf("caching org ID for %s: %w", providerID, err)
 	}
-	return os.WriteFile(path, []byte(orgID), 0o644)
+	if err := os.WriteFile(path, []byte(orgID), 0o644); err != nil {
+		return fmt.Errorf("caching org ID for %s: %w", providerID, err)
+	}
+	return nil
 }
 
 func LoadCachedOrgID(providerID string) string {

--- a/vibeusage-go/internal/config/config.go
+++ b/vibeusage-go/internal/config/config.go
@@ -1,6 +1,7 @@
 package config
 
 import (
+	"fmt"
 	"os"
 	"path/filepath"
 	"strings"
@@ -148,14 +149,17 @@ func Save(cfg Config, path string) error {
 		path = ConfigFile()
 	}
 	if err := os.MkdirAll(filepath.Dir(path), 0o755); err != nil {
-		return err
+		return fmt.Errorf("saving config: %w", err)
 	}
 	f, err := os.Create(path)
 	if err != nil {
-		return err
+		return fmt.Errorf("saving config: %w", err)
 	}
 	defer func() { _ = f.Close() }()
-	return toml.NewEncoder(f).Encode(cfg)
+	if err := toml.NewEncoder(f).Encode(cfg); err != nil {
+		return fmt.Errorf("saving config: %w", err)
+	}
+	return nil
 }
 
 func applyEnvOverrides(cfg Config) Config {

--- a/vibeusage-go/internal/config/credentials.go
+++ b/vibeusage-go/internal/config/credentials.go
@@ -1,6 +1,7 @@
 package config
 
 import (
+	"fmt"
 	"os"
 	"path/filepath"
 )
@@ -76,13 +77,16 @@ func FindProviderCredential(providerID string) (bool, string, string) {
 func WriteCredential(path string, content []byte) error {
 	dir := filepath.Dir(path)
 	if err := os.MkdirAll(dir, 0o755); err != nil {
-		return err
+		return fmt.Errorf("writing credential: %w", err)
 	}
 	tmp := path + ".tmp"
 	if err := os.WriteFile(tmp, content, 0o600); err != nil {
-		return err
+		return fmt.Errorf("writing credential: %w", err)
 	}
-	return os.Rename(tmp, path)
+	if err := os.Rename(tmp, path); err != nil {
+		return fmt.Errorf("writing credential: %w", err)
+	}
+	return nil
 }
 
 func ReadCredential(path string) ([]byte, error) {

--- a/vibeusage-go/internal/spinner/spinner.go
+++ b/vibeusage-go/internal/spinner/spinner.go
@@ -1,6 +1,8 @@
 package spinner
 
 import (
+	"fmt"
+
 	tea "github.com/charmbracelet/bubbletea"
 )
 
@@ -32,5 +34,8 @@ func Run(providerIDs []string, fetchFn func(onComplete func(CompletionInfo))) er
 
 	_, err := p.Run()
 	<-done
-	return err
+	if err != nil {
+		return fmt.Errorf("running spinner: %w", err)
+	}
+	return nil
 }


### PR DESCRIPTION
## Summary

Replace verbose `fmt.Printf` calls with `charmbracelet/log` structured logging and add consistent error wrapping across the Go codebase. Completes IMPROVEMENTS.md phases 9 and Bonus.

## Changes

### Structured Logging (Phase 9)

- Add `github.com/charmbracelet/log` dependency
- Create `internal/logging` package with level configuration (`--verbose` / `--quiet`)
- Replace verbose `fmt.Printf` calls with structured `log.Debug`/`log.Info` calls
- Respects `--no-color` and `--json` flags
- Comprehensive tests for log level configuration and output behavior

### Consistent Error Wrapping (Bonus)

- Add `fmt.Errorf("...: %w", err)` wrapping to all bare `return err` calls in internal packages:
  - `config.Save()` — wraps MkdirAll, Create, and Encode errors
  - `config.CacheSnapshot()` — wraps MkdirAll, Marshal, and WriteFile errors
  - `config.CacheOrgID()` — wraps MkdirAll and WriteFile errors
  - `config.WriteCredential()` — wraps MkdirAll, WriteFile, and Rename errors
  - `spinner.Run()` — wraps bubbletea program errors
  - `cmd/config reset` — wraps os.Remove errors
- 6 new TDD error wrapping tests
- Mark all 4 Bonus items complete in IMPROVEMENTS.md (itoa, fileExists, error wrapping, http.NewRequest — first three were completed in prior phases)

## Testing

- All 15 test suites pass (`go test -count=1 ./...`)
- `go vet ./...` clean
- Race detector clean (`go test -race ./...`)
