### PR TITLE
Add Minimax provider

### DIFF
--- a/PLAN.md
+++ b/PLAN.md
@@ -514,13 +514,18 @@ Branch `add-zai-provider`, 1 commit.
 - Auth flow prompts for API key from `z.ai/manage-apikey/apikey-list`
 - Handles auth error code 1001 as fatal
 
-### Phase 4: Minimax
+### Phase 4: Minimax — ✅ DONE
 
-API key auth, per-model response format verified. No blockers.
+Branch `add-minimax-provider`, 1 commit.
 
-1. Create `internal/provider/minimax/` with API key strategy
-2. Wire into CLI
-3. Test with real API key
+- APIKeyStrategy for Coding Plan keys (sk-cp- prefix validation)
+- Endpoint: `GET platform.minimax.io/v1/api/openplatform/coding_plan/remains`
+- Per-model quota parsing with summary period for multi-model responses
+- Plan tier inference from total_count (500=Starter, 1500=Plus, 5000=Max)
+- Utilization computed as usage_count / total_count * 100
+- Reset time from end_time (Unix millis)
+- Browser User-Agent header (Cloudflare bot protection)
+- Auth flow validates sk-cp- prefix, rejects standard sk-api- keys
 
 ### Phase 5: Kiro
 

--- a/cmd/key.go
+++ b/cmd/key.go
@@ -23,7 +23,7 @@ var keyCmd = &cobra.Command{
 }
 
 func init() {
-	for _, id := range []string{"antigravity", "claude", "codex", "copilot", "cursor", "gemini", "kimi", "zai"} {
+	for _, id := range []string{"antigravity", "claude", "codex", "copilot", "cursor", "gemini", "kimi", "minimax", "zai"} {
 		keyCmd.AddCommand(makeKeyProviderCmd(id))
 	}
 }
@@ -96,6 +96,7 @@ var credentialKeyMap = map[string]string{
 	"cursor":      "session_token",
 	"gemini":      "access_token",
 	"kimi":        "api_key",
+	"minimax":     "api_key",
 	"zai":         "api_key",
 }
 
@@ -104,7 +105,7 @@ func makeKeyProviderCmd(providerID string) *cobra.Command {
 	switch providerID {
 	case "antigravity", "codex", "copilot", "gemini":
 		credType = "oauth"
-	case "kimi", "zai":
+	case "kimi", "minimax", "zai":
 		credType = "apikey"
 	}
 

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -27,6 +27,7 @@ import (
 	_ "github.com/joshuadavidthomas/vibeusage/internal/provider/cursor"
 	_ "github.com/joshuadavidthomas/vibeusage/internal/provider/gemini"
 	_ "github.com/joshuadavidthomas/vibeusage/internal/provider/kimi"
+	_ "github.com/joshuadavidthomas/vibeusage/internal/provider/minimax"
 	_ "github.com/joshuadavidthomas/vibeusage/internal/provider/zai"
 )
 
@@ -43,7 +44,7 @@ var (
 var rootCmd = &cobra.Command{
 	Use:          "vibeusage",
 	Short:        "Track usage across agentic LLM providers",
-	Long:         "A unified CLI tool that aggregates usage statistics from Antigravity, Claude, Codex, Copilot, Cursor, Gemini, Kimi, and Z.ai.",
+	Long:         "A unified CLI tool that aggregates usage statistics from Antigravity, Claude, Codex, Copilot, Cursor, Gemini, Kimi, Minimax, and Z.ai.",
 	SilenceUsage: true,
 	PersistentPreRun: func(cmd *cobra.Command, args []string) {
 		if verbose && quiet {
@@ -69,7 +70,7 @@ func init() {
 	rootCmd.AddCommand(keyCmd)
 	rootCmd.AddCommand(initCmd)
 
-	for _, id := range []string{"antigravity", "claude", "codex", "copilot", "cursor", "gemini", "kimi", "zai"} {
+	for _, id := range []string{"antigravity", "claude", "codex", "copilot", "cursor", "gemini", "kimi", "minimax", "zai"} {
 		rootCmd.AddCommand(makeProviderCmd(id))
 	}
 }

--- a/internal/config/credentials.go
+++ b/internal/config/credentials.go
@@ -15,6 +15,7 @@ var ProviderCLIPaths = map[string][]string{
 	"copilot":     {"~/.config/github-copilot/hosts.json"},
 	"cursor":      {"~/.cursor/mcp-state.json"},
 	"kimi":        {"~/.kimi/credentials/kimi-code.json"},
+	"minimax":     {},
 	"zai":         {},
 }
 
@@ -27,6 +28,7 @@ var ProviderEnvVars = map[string]string{
 	"copilot":     "GITHUB_TOKEN",
 	"cursor":      "CURSOR_API_KEY",
 	"kimi":        "KIMI_CODE_API_KEY",
+	"minimax":     "MINIMAX_API_KEY",
 	"zai":         "ZAI_API_KEY",
 }
 

--- a/internal/provider/minimax/minimax.go
+++ b/internal/provider/minimax/minimax.go
@@ -1,0 +1,202 @@
+package minimax
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"os"
+	"strings"
+	"time"
+
+	"github.com/joshuadavidthomas/vibeusage/internal/config"
+	"github.com/joshuadavidthomas/vibeusage/internal/fetch"
+	"github.com/joshuadavidthomas/vibeusage/internal/httpclient"
+	"github.com/joshuadavidthomas/vibeusage/internal/models"
+	"github.com/joshuadavidthomas/vibeusage/internal/provider"
+)
+
+type Minimax struct{}
+
+func (m Minimax) Meta() provider.Metadata {
+	return provider.Metadata{
+		ID:          "minimax",
+		Name:        "Minimax",
+		Description: "Minimax AI coding assistant",
+		Homepage:    "https://www.minimax.io",
+	}
+}
+
+func (m Minimax) FetchStrategies() []fetch.Strategy {
+	return []fetch.Strategy{
+		&APIKeyStrategy{},
+	}
+}
+
+func (m Minimax) FetchStatus() models.ProviderStatus {
+	return models.ProviderStatus{Level: models.StatusUnknown}
+}
+
+func init() {
+	provider.Register(Minimax{})
+}
+
+const (
+	quotaURL = "https://platform.minimax.io/v1/api/openplatform/coding_plan/remains"
+)
+
+// APIKeyStrategy fetches Minimax usage using a coding plan API key (sk-cp-...).
+type APIKeyStrategy struct{}
+
+func (s *APIKeyStrategy) Name() string { return "api_key" }
+
+func (s *APIKeyStrategy) IsAvailable() bool {
+	return s.loadToken() != ""
+}
+
+func (s *APIKeyStrategy) Fetch(ctx context.Context) (fetch.FetchResult, error) {
+	token := s.loadToken()
+	if token == "" {
+		return fetch.ResultFail("No API key found. Set MINIMAX_API_KEY or use 'vibeusage key minimax set'"), nil
+	}
+
+	return fetchQuota(ctx, token)
+}
+
+func (s *APIKeyStrategy) loadToken() string {
+	if key := os.Getenv("MINIMAX_API_KEY"); key != "" {
+		return key
+	}
+	path := config.CredentialPath("minimax", "apikey")
+	data, err := config.ReadCredential(path)
+	if err != nil || data == nil {
+		return ""
+	}
+	var creds struct {
+		APIKey string `json:"api_key"`
+	}
+	if err := json.Unmarshal(data, &creds); err != nil {
+		return ""
+	}
+	return creds.APIKey
+}
+
+// fetchQuota makes the API call and parses the response.
+func fetchQuota(ctx context.Context, token string) (fetch.FetchResult, error) {
+	client := httpclient.NewFromConfig(config.Get().Fetch.Timeout)
+	opts := []httpclient.RequestOption{
+		httpclient.WithBearer(token),
+		httpclient.WithHeader("Content-Type", "application/json"),
+		httpclient.WithHeader("User-Agent", "Mozilla/5.0 (X11; Linux x86_64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/131.0.0.0 Safari/537.36"),
+		httpclient.WithHeader("Referer", "https://platform.minimax.io/"),
+	}
+
+	var planResp CodingPlanResponse
+	resp, err := client.GetJSONCtx(ctx, quotaURL, &planResp, opts...)
+	if err != nil {
+		return fetch.ResultFail("Request failed: " + err.Error()), nil
+	}
+
+	if resp.StatusCode == 401 || resp.StatusCode == 403 {
+		return fetch.ResultFatal("Token invalid or expired. Use 'vibeusage auth minimax' to re-authenticate."), nil
+	}
+	// Error responses use two shapes: flat (top-level status_code) or nested (base_resp.status_code).
+	apiStatusCode := planResp.StatusCode
+	if apiStatusCode == 0 {
+		apiStatusCode = planResp.BaseResp.StatusCode
+	}
+	if apiStatusCode == 1004 {
+		return fetch.ResultFatal("Invalid API key. Minimax requires a Coding Plan key (sk-cp-...). Use 'vibeusage auth minimax' to set one."), nil
+	}
+	if resp.StatusCode != 200 {
+		return fetch.ResultFail(fmt.Sprintf("Usage request failed: %d", resp.StatusCode)), nil
+	}
+	if resp.JSONErr != nil {
+		return fetch.ResultFail(fmt.Sprintf("Invalid response from Minimax API: %v", resp.JSONErr)), nil
+	}
+	if apiStatusCode != 0 {
+		msg := planResp.BaseResp.StatusMsg
+		if msg == "" {
+			msg = planResp.StatusMsg
+		}
+		if msg == "" {
+			msg = fmt.Sprintf("API error: status_code=%d", apiStatusCode)
+		}
+		return fetch.ResultFail(msg), nil
+	}
+
+	snapshot := parseResponse(planResp)
+	if snapshot == nil {
+		return fetch.ResultFail("No model data in Minimax response"), nil
+	}
+
+	return fetch.ResultOK(*snapshot), nil
+}
+
+// parseResponse converts the API response to a UsageSnapshot.
+func parseResponse(resp CodingPlanResponse) *models.UsageSnapshot {
+	if len(resp.ModelRemains) == 0 {
+		return nil
+	}
+
+	// Build a summary period from the highest utilization across all models,
+	// plus individual per-model periods.
+	var periods []models.UsagePeriod
+	maxUtil := 0
+	var summaryReset *time.Time
+	maxTotal := 0
+
+	for _, m := range resp.ModelRemains {
+		period := m.ToUsagePeriod()
+		periods = append(periods, period)
+
+		util := m.Utilization()
+		if util > maxUtil {
+			maxUtil = util
+		}
+		if m.CurrentIntervalTotalCount > maxTotal {
+			maxTotal = m.CurrentIntervalTotalCount
+		}
+		if summaryReset == nil {
+			summaryReset = m.ResetTime()
+		}
+	}
+
+	// Prepend a summary period when there are multiple models.
+	if len(periods) > 1 {
+		summary := models.UsagePeriod{
+			Name:        "Coding Plan",
+			Utilization: maxUtil,
+			PeriodType:  models.PeriodSession,
+			ResetsAt:    summaryReset,
+		}
+		periods = append([]models.UsagePeriod{summary}, periods...)
+	} else if len(periods) == 1 {
+		// Single model: use "Coding Plan" as the name instead of model name.
+		periods[0].Name = "Coding Plan"
+	}
+
+	var identity *models.ProviderIdentity
+	if plan := InferPlan(maxTotal); plan != "" {
+		identity = &models.ProviderIdentity{Plan: plan}
+	}
+
+	return &models.UsageSnapshot{
+		Provider:  "minimax",
+		FetchedAt: time.Now().UTC(),
+		Periods:   periods,
+		Identity:  identity,
+		Source:    "api_key",
+	}
+}
+
+// ValidateCodingPlanKey checks that the key has the expected sk-cp- prefix.
+func ValidateCodingPlanKey(key string) error {
+	key = strings.TrimSpace(key)
+	if key == "" {
+		return fmt.Errorf("key cannot be empty")
+	}
+	if !strings.HasPrefix(key, "sk-cp-") {
+		return fmt.Errorf("Minimax Coding Plan keys start with 'sk-cp-'. Standard API keys (sk-api-) won't work for usage tracking")
+	}
+	return nil
+}

--- a/internal/provider/minimax/response.go
+++ b/internal/provider/minimax/response.go
@@ -1,0 +1,96 @@
+package minimax
+
+import (
+	"time"
+
+	"github.com/joshuadavidthomas/vibeusage/internal/models"
+)
+
+// CodingPlanResponse represents the response from the Minimax coding plan remains endpoint.
+// On success, error info is nested in base_resp. On auth failures, status_code
+// and status_msg appear at the top level instead.
+type CodingPlanResponse struct {
+	ModelRemains []ModelRemain `json:"model_remains"`
+	BaseResp     BaseResp      `json:"base_resp"`
+	// Top-level error fields (flat error responses, e.g. invalid API key).
+	StatusCode int    `json:"status_code"`
+	StatusMsg  string `json:"status_msg"`
+}
+
+// ModelRemain represents a single model's quota within the current 5-hour window.
+type ModelRemain struct {
+	StartTime                 int64  `json:"start_time"`                   // Unix millis
+	EndTime                   int64  `json:"end_time"`                     // Unix millis
+	RemainsTime               int64  `json:"remains_time"`                 // millis remaining in window
+	CurrentIntervalTotalCount int    `json:"current_interval_total_count"` // total prompts in window
+	CurrentIntervalUsageCount int    `json:"current_interval_usage_count"` // prompts used
+	ModelName                 string `json:"model_name"`
+}
+
+// BaseResp contains the API status code and message.
+type BaseResp struct {
+	StatusCode int    `json:"status_code"`
+	StatusMsg  string `json:"status_msg"`
+}
+
+// Utilization returns the usage percentage (0-100) for this model.
+func (m ModelRemain) Utilization() int {
+	if m.CurrentIntervalTotalCount <= 0 {
+		if m.CurrentIntervalUsageCount > 0 {
+			return 100
+		}
+		return 0
+	}
+	pct := (m.CurrentIntervalUsageCount * 100) / m.CurrentIntervalTotalCount
+	if pct > 100 {
+		return 100
+	}
+	if pct < 0 {
+		return 0
+	}
+	return pct
+}
+
+// ResetTime converts end_time (Unix millis) to a time.Time pointer.
+func (m ModelRemain) ResetTime() *time.Time {
+	if m.EndTime == 0 {
+		return nil
+	}
+	t := time.Unix(m.EndTime/1000, (m.EndTime%1000)*int64(time.Millisecond))
+	return &t
+}
+
+// Remaining returns the number of unused prompts.
+func (m ModelRemain) Remaining() int {
+	r := m.CurrentIntervalTotalCount - m.CurrentIntervalUsageCount
+	if r < 0 {
+		return 0
+	}
+	return r
+}
+
+// ToUsagePeriod converts this model's quota to a UsagePeriod.
+func (m ModelRemain) ToUsagePeriod() models.UsagePeriod {
+	return models.UsagePeriod{
+		Name:        m.ModelName,
+		Utilization: m.Utilization(),
+		PeriodType:  models.PeriodSession,
+		ResetsAt:    m.ResetTime(),
+		Model:       m.ModelName,
+	}
+}
+
+// InferPlan attempts to guess the plan tier from the total prompt count.
+// Known values: 500=Starter, 1500=Plus. Others are speculative.
+func InferPlan(totalCount int) string {
+	switch {
+	case totalCount <= 500:
+		return "Starter"
+	case totalCount <= 1500:
+		return "Plus"
+	case totalCount <= 5000:
+		return "Max"
+	default:
+		return ""
+	}
+}

--- a/internal/provider/minimax/response_test.go
+++ b/internal/provider/minimax/response_test.go
@@ -1,0 +1,456 @@
+package minimax
+
+import (
+	"encoding/json"
+	"testing"
+	"time"
+
+	"github.com/joshuadavidthomas/vibeusage/internal/models"
+)
+
+func TestCodingPlanResponse_UnmarshalFullResponse(t *testing.T) {
+	raw := `{
+		"model_remains": [
+			{
+				"start_time": 1771650000000,
+				"end_time": 1771668000000,
+				"remains_time": 8196068,
+				"current_interval_total_count": 1500,
+				"current_interval_usage_count": 1500,
+				"model_name": "MiniMax-M2"
+			},
+			{
+				"start_time": 1771650000000,
+				"end_time": 1771668000000,
+				"remains_time": 8196068,
+				"current_interval_total_count": 1500,
+				"current_interval_usage_count": 1500,
+				"model_name": "MiniMax-M2.1"
+			},
+			{
+				"start_time": 1771650000000,
+				"end_time": 1771668000000,
+				"remains_time": 8196068,
+				"current_interval_total_count": 1500,
+				"current_interval_usage_count": 1500,
+				"model_name": "MiniMax-M2.5"
+			}
+		],
+		"base_resp": {
+			"status_code": 0,
+			"status_msg": "success"
+		}
+	}`
+
+	var resp CodingPlanResponse
+	if err := json.Unmarshal([]byte(raw), &resp); err != nil {
+		t.Fatalf("unmarshal failed: %v", err)
+	}
+
+	if resp.BaseResp.StatusCode != 0 {
+		t.Errorf("status_code = %d, want 0", resp.BaseResp.StatusCode)
+	}
+	if resp.BaseResp.StatusMsg != "success" {
+		t.Errorf("status_msg = %q, want %q", resp.BaseResp.StatusMsg, "success")
+	}
+	if len(resp.ModelRemains) != 3 {
+		t.Fatalf("expected 3 model_remains, got %d", len(resp.ModelRemains))
+	}
+
+	m := resp.ModelRemains[0]
+	if m.ModelName != "MiniMax-M2" {
+		t.Errorf("model_name = %q, want %q", m.ModelName, "MiniMax-M2")
+	}
+	if m.StartTime != 1771650000000 {
+		t.Errorf("start_time = %d, want 1771650000000", m.StartTime)
+	}
+	if m.EndTime != 1771668000000 {
+		t.Errorf("end_time = %d, want 1771668000000", m.EndTime)
+	}
+	if m.CurrentIntervalTotalCount != 1500 {
+		t.Errorf("total_count = %d, want 1500", m.CurrentIntervalTotalCount)
+	}
+	if m.CurrentIntervalUsageCount != 1500 {
+		t.Errorf("usage_count = %d, want 1500", m.CurrentIntervalUsageCount)
+	}
+}
+
+func TestCodingPlanResponse_UnmarshalErrorResponse(t *testing.T) {
+	raw := `{"status_code":1004,"status_msg":"cookie is missing, log in again"}`
+
+	// Error responses from Minimax use a flat structure with status_code at the
+	// top level (not nested under base_resp).
+	var resp CodingPlanResponse
+	if err := json.Unmarshal([]byte(raw), &resp); err != nil {
+		t.Fatalf("unmarshal failed: %v", err)
+	}
+
+	if len(resp.ModelRemains) != 0 {
+		t.Errorf("expected 0 model_remains, got %d", len(resp.ModelRemains))
+	}
+	if resp.StatusCode != 1004 {
+		t.Errorf("status_code = %d, want 1004", resp.StatusCode)
+	}
+	if resp.StatusMsg != "cookie is missing, log in again" {
+		t.Errorf("status_msg = %q, want %q", resp.StatusMsg, "cookie is missing, log in again")
+	}
+	// base_resp should be zero-value since it's not in the response
+	if resp.BaseResp.StatusCode != 0 {
+		t.Errorf("base_resp.status_code = %d, want 0", resp.BaseResp.StatusCode)
+	}
+}
+
+func TestModelRemain_Utilization(t *testing.T) {
+	tests := []struct {
+		name string
+		m    ModelRemain
+		want int
+	}{
+		{
+			name: "fully used",
+			m:    ModelRemain{CurrentIntervalTotalCount: 1500, CurrentIntervalUsageCount: 1500},
+			want: 100,
+		},
+		{
+			name: "half used",
+			m:    ModelRemain{CurrentIntervalTotalCount: 1500, CurrentIntervalUsageCount: 750},
+			want: 50,
+		},
+		{
+			name: "none used",
+			m:    ModelRemain{CurrentIntervalTotalCount: 1500, CurrentIntervalUsageCount: 0},
+			want: 0,
+		},
+		{
+			name: "over limit",
+			m:    ModelRemain{CurrentIntervalTotalCount: 1500, CurrentIntervalUsageCount: 2000},
+			want: 100,
+		},
+		{
+			name: "zero total with usage",
+			m:    ModelRemain{CurrentIntervalTotalCount: 0, CurrentIntervalUsageCount: 5},
+			want: 100,
+		},
+		{
+			name: "zero total zero usage",
+			m:    ModelRemain{CurrentIntervalTotalCount: 0, CurrentIntervalUsageCount: 0},
+			want: 0,
+		},
+		{
+			name: "starter tier",
+			m:    ModelRemain{CurrentIntervalTotalCount: 500, CurrentIntervalUsageCount: 100},
+			want: 20,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := tt.m.Utilization()
+			if got != tt.want {
+				t.Errorf("Utilization() = %d, want %d", got, tt.want)
+			}
+		})
+	}
+}
+
+func TestModelRemain_ResetTime(t *testing.T) {
+	tests := []struct {
+		name    string
+		endTime int64
+		wantNil bool
+		wantSec int64
+	}{
+		{
+			name:    "valid timestamp",
+			endTime: 1771668000000,
+			wantNil: false,
+			wantSec: 1771668000,
+		},
+		{
+			name:    "zero timestamp",
+			endTime: 0,
+			wantNil: true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			m := ModelRemain{EndTime: tt.endTime}
+			got := m.ResetTime()
+			if tt.wantNil {
+				if got != nil {
+					t.Error("expected nil, got non-nil")
+				}
+				return
+			}
+			if got == nil {
+				t.Fatal("expected non-nil, got nil")
+			}
+			if got.Unix() != tt.wantSec {
+				t.Errorf("Unix() = %d, want %d", got.Unix(), tt.wantSec)
+			}
+		})
+	}
+}
+
+func TestModelRemain_Remaining(t *testing.T) {
+	tests := []struct {
+		name string
+		m    ModelRemain
+		want int
+	}{
+		{
+			name: "some remaining",
+			m:    ModelRemain{CurrentIntervalTotalCount: 1500, CurrentIntervalUsageCount: 1000},
+			want: 500,
+		},
+		{
+			name: "none remaining",
+			m:    ModelRemain{CurrentIntervalTotalCount: 1500, CurrentIntervalUsageCount: 1500},
+			want: 0,
+		},
+		{
+			name: "over limit clamps to zero",
+			m:    ModelRemain{CurrentIntervalTotalCount: 1500, CurrentIntervalUsageCount: 2000},
+			want: 0,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := tt.m.Remaining()
+			if got != tt.want {
+				t.Errorf("Remaining() = %d, want %d", got, tt.want)
+			}
+		})
+	}
+}
+
+func TestModelRemain_ToUsagePeriod(t *testing.T) {
+	m := ModelRemain{
+		StartTime:                 1771650000000,
+		EndTime:                   1771668000000,
+		CurrentIntervalTotalCount: 1500,
+		CurrentIntervalUsageCount: 750,
+		ModelName:                 "MiniMax-M2.5",
+	}
+
+	period := m.ToUsagePeriod()
+
+	if period.Name != "MiniMax-M2.5" {
+		t.Errorf("name = %q, want %q", period.Name, "MiniMax-M2.5")
+	}
+	if period.Utilization != 50 {
+		t.Errorf("utilization = %d, want 50", period.Utilization)
+	}
+	if period.PeriodType != models.PeriodSession {
+		t.Errorf("periodType = %q, want %q", period.PeriodType, models.PeriodSession)
+	}
+	if period.Model != "MiniMax-M2.5" {
+		t.Errorf("model = %q, want %q", period.Model, "MiniMax-M2.5")
+	}
+	if period.ResetsAt == nil {
+		t.Fatal("expected resetsAt")
+	}
+	if period.ResetsAt.Unix() != 1771668000 {
+		t.Errorf("resetsAt unix = %d, want 1771668000", period.ResetsAt.Unix())
+	}
+}
+
+func TestInferPlan(t *testing.T) {
+	tests := []struct {
+		total int
+		want  string
+	}{
+		{500, "Starter"},
+		{100, "Starter"},
+		{1500, "Plus"},
+		{1000, "Plus"},
+		{5000, "Max"},
+		{3000, "Max"},
+		{10000, ""},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.want, func(t *testing.T) {
+			got := InferPlan(tt.total)
+			if got != tt.want {
+				t.Errorf("InferPlan(%d) = %q, want %q", tt.total, got, tt.want)
+			}
+		})
+	}
+}
+
+func TestParseResponse_MultiModel(t *testing.T) {
+	resp := CodingPlanResponse{
+		ModelRemains: []ModelRemain{
+			{
+				StartTime:                 1771650000000,
+				EndTime:                   1771668000000,
+				RemainsTime:               8196068,
+				CurrentIntervalTotalCount: 1500,
+				CurrentIntervalUsageCount: 750,
+				ModelName:                 "MiniMax-M2",
+			},
+			{
+				StartTime:                 1771650000000,
+				EndTime:                   1771668000000,
+				RemainsTime:               8196068,
+				CurrentIntervalTotalCount: 1500,
+				CurrentIntervalUsageCount: 1500,
+				ModelName:                 "MiniMax-M2.5",
+			},
+		},
+		BaseResp: BaseResp{StatusCode: 0, StatusMsg: "success"},
+	}
+
+	snapshot := parseResponse(resp)
+	if snapshot == nil {
+		t.Fatal("expected snapshot, got nil")
+	}
+
+	if snapshot.Provider != "minimax" {
+		t.Errorf("provider = %q, want %q", snapshot.Provider, "minimax")
+	}
+
+	// Summary + 2 model periods
+	if len(snapshot.Periods) != 3 {
+		t.Fatalf("expected 3 periods, got %d", len(snapshot.Periods))
+	}
+
+	// Summary takes highest utilization
+	summary := snapshot.Periods[0]
+	if summary.Name != "Coding Plan" {
+		t.Errorf("summary name = %q, want %q", summary.Name, "Coding Plan")
+	}
+	if summary.Utilization != 100 {
+		t.Errorf("summary utilization = %d, want 100", summary.Utilization)
+	}
+	if summary.PeriodType != models.PeriodSession {
+		t.Errorf("summary periodType = %q, want %q", summary.PeriodType, models.PeriodSession)
+	}
+
+	// Per-model periods
+	m1 := snapshot.Periods[1]
+	if m1.Name != "MiniMax-M2" {
+		t.Errorf("m1 name = %q, want %q", m1.Name, "MiniMax-M2")
+	}
+	if m1.Utilization != 50 {
+		t.Errorf("m1 utilization = %d, want 50", m1.Utilization)
+	}
+
+	m2 := snapshot.Periods[2]
+	if m2.Name != "MiniMax-M2.5" {
+		t.Errorf("m2 name = %q, want %q", m2.Name, "MiniMax-M2.5")
+	}
+	if m2.Utilization != 100 {
+		t.Errorf("m2 utilization = %d, want 100", m2.Utilization)
+	}
+
+	// Identity
+	if snapshot.Identity == nil {
+		t.Fatal("expected identity")
+	}
+	if snapshot.Identity.Plan != "Plus" {
+		t.Errorf("plan = %q, want %q", snapshot.Identity.Plan, "Plus")
+	}
+}
+
+func TestParseResponse_SingleModel(t *testing.T) {
+	resp := CodingPlanResponse{
+		ModelRemains: []ModelRemain{
+			{
+				StartTime:                 1771650000000,
+				EndTime:                   1771668000000,
+				CurrentIntervalTotalCount: 500,
+				CurrentIntervalUsageCount: 100,
+				ModelName:                 "MiniMax-M2.5",
+			},
+		},
+		BaseResp: BaseResp{StatusCode: 0, StatusMsg: "success"},
+	}
+
+	snapshot := parseResponse(resp)
+	if snapshot == nil {
+		t.Fatal("expected snapshot, got nil")
+	}
+
+	// Single model: just one period named "Coding Plan"
+	if len(snapshot.Periods) != 1 {
+		t.Fatalf("expected 1 period, got %d", len(snapshot.Periods))
+	}
+
+	period := snapshot.Periods[0]
+	if period.Name != "Coding Plan" {
+		t.Errorf("name = %q, want %q", period.Name, "Coding Plan")
+	}
+	if period.Utilization != 20 {
+		t.Errorf("utilization = %d, want 20", period.Utilization)
+	}
+
+	if snapshot.Identity == nil {
+		t.Fatal("expected identity")
+	}
+	if snapshot.Identity.Plan != "Starter" {
+		t.Errorf("plan = %q, want %q", snapshot.Identity.Plan, "Starter")
+	}
+}
+
+func TestParseResponse_Empty(t *testing.T) {
+	resp := CodingPlanResponse{
+		ModelRemains: []ModelRemain{},
+		BaseResp:     BaseResp{StatusCode: 0, StatusMsg: "success"},
+	}
+
+	snapshot := parseResponse(resp)
+	if snapshot != nil {
+		t.Error("expected nil snapshot for empty model_remains")
+	}
+}
+
+func TestParseResponse_FetchedAtIsRecent(t *testing.T) {
+	resp := CodingPlanResponse{
+		ModelRemains: []ModelRemain{
+			{
+				EndTime:                   1771668000000,
+				CurrentIntervalTotalCount: 1500,
+				CurrentIntervalUsageCount: 0,
+				ModelName:                 "MiniMax-M2.5",
+			},
+		},
+		BaseResp: BaseResp{StatusCode: 0, StatusMsg: "success"},
+	}
+
+	before := time.Now().UTC()
+	snapshot := parseResponse(resp)
+	after := time.Now().UTC()
+
+	if snapshot == nil {
+		t.Fatal("expected snapshot")
+	}
+	if snapshot.FetchedAt.Before(before) || snapshot.FetchedAt.After(after) {
+		t.Errorf("fetchedAt = %v, expected between %v and %v", snapshot.FetchedAt, before, after)
+	}
+}
+
+func TestValidateCodingPlanKey(t *testing.T) {
+	tests := []struct {
+		name    string
+		key     string
+		wantErr bool
+	}{
+		{"valid key", "sk-cp-abc123", false},
+		{"empty", "", true},
+		{"standard api key", "sk-api-abc123", true},
+		{"whitespace trimmed valid", "  sk-cp-abc123  ", false},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			err := ValidateCodingPlanKey(tt.key)
+			if (err != nil) != tt.wantErr {
+				t.Errorf("ValidateCodingPlanKey(%q) error = %v, wantErr %v", tt.key, err, tt.wantErr)
+			}
+		})
+	}
+}


### PR DESCRIPTION
## Summary

Add Minimax as a new provider for tracking coding plan usage.

## What's included

- **`APIKeyStrategy`** for Coding Plan keys (`sk-cp-` prefix)
- **Endpoint**: `GET platform.minimax.io/v1/api/openplatform/coding_plan/remains`
- **Per-model quota parsing** with summary period for multi-model responses
- **Plan tier inference** from `total_count` (500=Starter, 1500=Plus, 5000=Max)
- **Utilization** computed as `usage_count / total_count * 100`
- **Reset time** from `end_time` (Unix millis)
- **Browser User-Agent** header required (Cloudflare bot protection)
- **Dual error response handling**: Minimax uses flat top-level `status_code` for auth errors vs nested `base_resp.status_code` for success — both are handled
- **Auth flow** validates `sk-cp-` prefix, rejects standard `sk-api-` keys with a helpful message
- **Wired into CLI**: root, auth, key, credentials

## New files

- `internal/provider/minimax/minimax.go` — Provider, strategy, fetch, parse
- `internal/provider/minimax/response.go` — Response types and methods
- `internal/provider/minimax/response_test.go` — Comprehensive tests

## Wiring

| File | Change |
|---|---|
| `cmd/root.go` | Blank import + provider list |
| `cmd/auth.go` | `authMinimax()` with key validation |
| `cmd/key.go` | Key loop + `credentialKeyMap` + `credType` |
| `internal/config/credentials.go` | `ProviderCLIPaths` + `ProviderEnvVars` |
| `PLAN.md` | Phase 4 marked done |