### PR TITLE
Add model routing command

### DIFF
--- a/cmd/root.go
+++ b/cmd/root.go
@@ -69,6 +69,7 @@ func init() {
 	rootCmd.AddCommand(cacheCmd)
 	rootCmd.AddCommand(keyCmd)
 	rootCmd.AddCommand(initCmd)
+	rootCmd.AddCommand(routeCmd)
 
 	for _, id := range []string{"antigravity", "claude", "codex", "copilot", "cursor", "gemini", "kimi", "minimax", "zai"} {
 		rootCmd.AddCommand(makeProviderCmd(id))

--- a/cmd/route.go
+++ b/cmd/route.go
@@ -1,0 +1,280 @@
+package cmd
+
+import (
+	"fmt"
+	"sort"
+	"strings"
+	"time"
+
+	"github.com/spf13/cobra"
+
+	"github.com/joshuadavidthomas/vibeusage/internal/display"
+	"github.com/joshuadavidthomas/vibeusage/internal/fetch"
+	"github.com/joshuadavidthomas/vibeusage/internal/modelmap"
+	"github.com/joshuadavidthomas/vibeusage/internal/models"
+	"github.com/joshuadavidthomas/vibeusage/internal/provider"
+	"github.com/joshuadavidthomas/vibeusage/internal/routing"
+	"github.com/joshuadavidthomas/vibeusage/internal/spinner"
+	"github.com/joshuadavidthomas/vibeusage/internal/strutil"
+)
+
+var routeCmd = &cobra.Command{
+	Use:   "route <model>",
+	Short: "Pick the best provider for a model based on available headroom",
+	Long: `Given a model name (e.g. "sonnet-4.5", "gpt-4o", "gemini"), fetches usage
+from all configured providers that offer it and recommends the one with the
+most remaining capacity.
+
+Use "vibeusage route --list" to see all known models and their providers.
+Use "vibeusage route --list <provider>" to see models for a specific provider.`,
+	Args: cobra.MaximumNArgs(1),
+	RunE: func(cmd *cobra.Command, args []string) error {
+		listFlag, _ := cmd.Flags().GetBool("list")
+
+		if listFlag {
+			providerFilter := ""
+			if len(args) > 0 {
+				providerFilter = args[0]
+			}
+			return listModels(providerFilter)
+		}
+
+		if len(args) == 0 {
+			return fmt.Errorf("model name required. Use 'vibeusage route --list' to see available models")
+		}
+
+		return routeModel(cmd, args[0])
+	},
+}
+
+func init() {
+	routeCmd.Flags().BoolP("list", "l", false, "List known models and their providers")
+}
+
+func listModels(providerFilter string) error {
+	var allModels []modelmap.ModelInfo
+
+	if providerFilter != "" {
+		allModels = modelmap.ListModelsForProvider(providerFilter)
+		if len(allModels) == 0 {
+			return fmt.Errorf("no models found for provider %q", providerFilter)
+		}
+	} else {
+		allModels = modelmap.ListModels()
+	}
+
+	if jsonOutput {
+		type jsonModel struct {
+			ID        string   `json:"id"`
+			Name      string   `json:"name"`
+			Providers []string `json:"providers"`
+		}
+		var data []jsonModel
+		for _, m := range allModels {
+			data = append(data, jsonModel{
+				ID:        m.ID,
+				Name:      m.Name,
+				Providers: m.Providers,
+			})
+		}
+		display.OutputJSON(outWriter, data)
+		return nil
+	}
+
+	if quiet {
+		for _, m := range allModels {
+			out("%s %s\n", m.ID, strings.Join(m.Providers, ","))
+		}
+		return nil
+	}
+
+	var rows [][]string
+	for _, m := range allModels {
+		rows = append(rows, []string{m.ID, m.Name, strings.Join(m.Providers, ", ")})
+	}
+
+	title := "Known Models"
+	if providerFilter != "" {
+		title = fmt.Sprintf("Models for %s", strutil.TitleCase(providerFilter))
+	}
+
+	outln(display.NewTableWithOptions(
+		[]string{"ID", "Name", "Providers"},
+		rows,
+		display.TableOptions{Title: title, NoColor: noColor},
+	))
+
+	return nil
+}
+
+func routeModel(cmd *cobra.Command, query string) error {
+	info := modelmap.Lookup(query)
+	if info == nil {
+		// Try search for suggestions.
+		suggestions := modelmap.Search(query)
+		if len(suggestions) > 0 {
+			msg := fmt.Sprintf("unknown model %q. Did you mean:", query)
+			for _, s := range suggestions {
+				if len(msg) > 200 {
+					break
+				}
+				msg += fmt.Sprintf("\n  %s (%s)", s.ID, s.Name)
+			}
+			return fmt.Errorf("%s", msg)
+		}
+		return fmt.Errorf("unknown model %q. Use 'vibeusage route --list' to see available models", query)
+	}
+
+	// Filter to only configured providers.
+	var configuredIDs []string
+	for _, pid := range info.Providers {
+		p, ok := provider.Get(pid)
+		if !ok {
+			continue
+		}
+		for _, s := range p.FetchStrategies() {
+			if s.IsAvailable() {
+				configuredIDs = append(configuredIDs, pid)
+				break
+			}
+		}
+	}
+
+	if len(configuredIDs) == 0 {
+		return fmt.Errorf(
+			"%s is available from %s, but none are configured.\nSet up a provider with: vibeusage auth <provider>",
+			info.Name, strings.Join(info.Providers, ", "),
+		)
+	}
+
+	// Build strategy map for only the relevant providers.
+	strategyMap := make(map[string][]fetch.Strategy)
+	for _, pid := range configuredIDs {
+		p, _ := provider.Get(pid)
+		strategyMap[pid] = p.FetchStrategies()
+	}
+
+	// Fetch usage from all relevant providers.
+	ctx := cmd.Context()
+	var outcomes map[string]fetch.FetchOutcome
+
+	if spinner.ShouldShow(quiet, jsonOutput, !isTerminal()) {
+		err := spinner.Run(configuredIDs, func(onComplete func(spinner.CompletionInfo)) {
+			outcomes = fetch.FetchAllProviders(ctx, strategyMap, !refresh, func(o fetch.FetchOutcome) {
+				onComplete(outcomeToCompletion(o))
+			})
+		})
+		if err != nil {
+			return fmt.Errorf("spinner error: %w", err)
+		}
+	} else {
+		outcomes = fetch.FetchAllProviders(ctx, strategyMap, !refresh, nil)
+	}
+
+	// Build provider data for ranking.
+	providerData := make(map[string]routing.ProviderData)
+	for pid, outcome := range outcomes {
+		if outcome.Success && outcome.Snapshot != nil {
+			providerData[pid] = routing.ProviderData{
+				Snapshot: outcome.Snapshot,
+				Cached:   outcome.Cached,
+			}
+		}
+	}
+
+	candidates, unavailable := routing.Rank(configuredIDs, providerData)
+
+	rec := routing.Recommendation{
+		ModelID:     info.ID,
+		ModelName:   info.Name,
+		Candidates:  candidates,
+		Unavailable: unavailable,
+	}
+	if len(candidates) > 0 {
+		rec.Best = &candidates[0]
+	}
+
+	if jsonOutput {
+		display.OutputJSON(outWriter, rec)
+		return nil
+	}
+
+	if quiet {
+		if rec.Best != nil {
+			out("%s\n", rec.Best.ProviderID)
+		}
+		return nil
+	}
+
+	return displayRecommendation(rec)
+}
+
+func displayRecommendation(rec routing.Recommendation) error {
+	if rec.Best == nil {
+		out("No usage data available for %s from any configured provider.\n", rec.ModelName)
+		if len(rec.Unavailable) > 0 {
+			out("Failed to fetch: %s\n", strings.Join(rec.Unavailable, ", "))
+		}
+		return nil
+	}
+
+	out("Route: %s\n\n", rec.ModelName)
+
+	// Ranked table.
+	var rows [][]string
+	for i, c := range rec.Candidates {
+		name := strutil.TitleCase(c.ProviderID)
+
+		headroom := fmt.Sprintf("%d%%", c.Headroom)
+		bar := display.RenderBar(c.Utilization, 15, models.PaceToColor(nil, c.Utilization))
+		util := fmt.Sprintf("%d%%", c.Utilization)
+
+		reset := ""
+		if d := timeUntilReset(c.ResetsAt); d != nil {
+			reset = models.FormatResetCountdown(d)
+		}
+
+		plan := c.Plan
+		if plan == "" {
+			plan = "—"
+		}
+
+		tag := ""
+		if i == 0 {
+			tag = "← best"
+		}
+		if c.Cached {
+			if tag != "" {
+				tag += " (cached)"
+			} else {
+				tag = "(cached)"
+			}
+		}
+
+		rows = append(rows, []string{name, bar + " " + util, headroom, string(c.PeriodType), reset, plan, tag})
+	}
+
+	outln(display.NewTableWithOptions(
+		[]string{"Provider", "Usage", "Headroom", "Period", "Resets In", "Plan", ""},
+		rows,
+		display.TableOptions{NoColor: noColor},
+	))
+
+	if len(rec.Unavailable) > 0 {
+		sort.Strings(rec.Unavailable)
+		out("\nUnavailable: %s\n", strings.Join(rec.Unavailable, ", "))
+	}
+
+	return nil
+}
+
+func timeUntilReset(t *time.Time) *time.Duration {
+	if t == nil {
+		return nil
+	}
+	d := time.Until(*t)
+	if d < 0 {
+		d = 0
+	}
+	return &d
+}

--- a/internal/modelmap/modelmap.go
+++ b/internal/modelmap/modelmap.go
@@ -1,0 +1,114 @@
+package modelmap
+
+import (
+	"sort"
+	"strings"
+)
+
+// ModelInfo describes a model and which providers offer it.
+type ModelInfo struct {
+	// ID is the canonical model identifier (e.g. "claude-sonnet-4-5").
+	ID string
+	// Name is the human-readable display name (e.g. "Claude Sonnet 4.5").
+	Name string
+	// Providers lists provider IDs that offer this model.
+	Providers []string
+}
+
+// Lookup resolves a model query (canonical ID or alias) to a ModelInfo.
+// Returns nil if the model is not found.
+func Lookup(query string) *ModelInfo {
+	q := normalize(query)
+
+	// Direct canonical match.
+	if info, ok := models[q]; ok {
+		return &info
+	}
+
+	// Alias match.
+	if canonical, ok := aliases[q]; ok {
+		if info, found := models[canonical]; found {
+			return &info
+		}
+	}
+
+	return nil
+}
+
+// Search returns all models whose ID or name contains the query substring.
+// Useful for fuzzy "did you mean?" suggestions.
+func Search(query string) []ModelInfo {
+	q := normalize(query)
+	var results []ModelInfo
+
+	seen := make(map[string]bool)
+	for id, info := range models {
+		if strings.Contains(id, q) || strings.Contains(normalize(info.Name), q) {
+			if !seen[info.ID] {
+				results = append(results, info)
+				seen[info.ID] = true
+			}
+		}
+	}
+
+	// Also search aliases.
+	for alias, canonical := range aliases {
+		if strings.Contains(alias, q) {
+			if info, ok := models[canonical]; ok && !seen[info.ID] {
+				results = append(results, info)
+				seen[info.ID] = true
+			}
+		}
+	}
+
+	sort.Slice(results, func(i, j int) bool {
+		return results[i].ID < results[j].ID
+	})
+
+	return results
+}
+
+// ProvidersForModel returns the provider IDs that offer the given model.
+// Returns nil if the model is not found.
+func ProvidersForModel(query string) []string {
+	info := Lookup(query)
+	if info == nil {
+		return nil
+	}
+	result := make([]string, len(info.Providers))
+	copy(result, info.Providers)
+	return result
+}
+
+// ListModels returns all known models, sorted by ID.
+func ListModels() []ModelInfo {
+	var result []ModelInfo
+	for _, info := range models {
+		result = append(result, info)
+	}
+	sort.Slice(result, func(i, j int) bool {
+		return result[i].ID < result[j].ID
+	})
+	return result
+}
+
+// ListModelsForProvider returns all models available through a given provider.
+func ListModelsForProvider(providerID string) []ModelInfo {
+	var result []ModelInfo
+	for _, info := range models {
+		for _, pid := range info.Providers {
+			if pid == providerID {
+				result = append(result, info)
+				break
+			}
+		}
+	}
+	sort.Slice(result, func(i, j int) bool {
+		return result[i].ID < result[j].ID
+	})
+	return result
+}
+
+func normalize(s string) string {
+	return strings.ToLower(strings.TrimSpace(s))
+}

--- a/internal/modelmap/modelmap_test.go
+++ b/internal/modelmap/modelmap_test.go
@@ -1,0 +1,206 @@
+package modelmap
+
+import (
+	"testing"
+)
+
+func TestLookup_CanonicalID(t *testing.T) {
+	info := Lookup("claude-sonnet-4-5")
+	if info == nil {
+		t.Fatal("expected model info, got nil")
+	}
+	if info.ID != "claude-sonnet-4-5" {
+		t.Errorf("ID = %q, want %q", info.ID, "claude-sonnet-4-5")
+	}
+	if info.Name != "Claude Sonnet 4.5" {
+		t.Errorf("Name = %q, want %q", info.Name, "Claude Sonnet 4.5")
+	}
+	if len(info.Providers) == 0 {
+		t.Error("expected providers, got none")
+	}
+}
+
+func TestLookup_Alias(t *testing.T) {
+	tests := []struct {
+		query    string
+		wantID   string
+		wantName string
+	}{
+		{"sonnet-4.5", "claude-sonnet-4-5", "Claude Sonnet 4.5"},
+		{"sonnet", "claude-sonnet-4", "Claude Sonnet 4"},
+		{"opus", "claude-opus-4", "Claude Opus 4"},
+		{"haiku", "claude-haiku-3-5", "Claude Haiku 3.5"},
+		{"4o", "gpt-4o", "GPT-4o"},
+		{"gemini", "gemini-2-5-pro", "Gemini 2.5 Pro"},
+		{"flash", "gemini-2-5-flash", "Gemini 2.5 Flash"},
+		{"kimi", "k2-5", "Kimi K2.5"},
+		{"m2.5", "minimax-m2-5", "MiniMax M2.5"},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.query, func(t *testing.T) {
+			info := Lookup(tt.query)
+			if info == nil {
+				t.Fatalf("Lookup(%q) returned nil", tt.query)
+			}
+			if info.ID != tt.wantID {
+				t.Errorf("ID = %q, want %q", info.ID, tt.wantID)
+			}
+			if info.Name != tt.wantName {
+				t.Errorf("Name = %q, want %q", info.Name, tt.wantName)
+			}
+		})
+	}
+}
+
+func TestLookup_CaseInsensitive(t *testing.T) {
+	info := Lookup("SONNET-4.5")
+	if info == nil {
+		t.Fatal("expected case-insensitive match")
+	}
+	if info.ID != "claude-sonnet-4-5" {
+		t.Errorf("ID = %q, want %q", info.ID, "claude-sonnet-4-5")
+	}
+}
+
+func TestLookup_NotFound(t *testing.T) {
+	info := Lookup("nonexistent-model")
+	if info != nil {
+		t.Errorf("expected nil, got %+v", info)
+	}
+}
+
+func TestProvidersForModel(t *testing.T) {
+	providers := ProvidersForModel("claude-sonnet-4-5")
+	if len(providers) == 0 {
+		t.Fatal("expected providers")
+	}
+
+	has := func(pid string) bool {
+		for _, p := range providers {
+			if p == pid {
+				return true
+			}
+		}
+		return false
+	}
+	if !has("claude") {
+		t.Error("expected claude in providers")
+	}
+	if !has("copilot") {
+		t.Error("expected copilot in providers")
+	}
+}
+
+func TestProvidersForModel_NotFound(t *testing.T) {
+	providers := ProvidersForModel("nonexistent")
+	if providers != nil {
+		t.Errorf("expected nil, got %v", providers)
+	}
+}
+
+func TestSearch(t *testing.T) {
+	results := Search("sonnet")
+	if len(results) == 0 {
+		t.Fatal("expected search results for 'sonnet'")
+	}
+
+	ids := make(map[string]bool)
+	for _, r := range results {
+		ids[r.ID] = true
+	}
+
+	if !ids["claude-sonnet-4-5"] {
+		t.Error("expected claude-sonnet-4-5 in results")
+	}
+	if !ids["claude-sonnet-4"] {
+		t.Error("expected claude-sonnet-4 in results")
+	}
+}
+
+func TestSearch_NoResults(t *testing.T) {
+	results := Search("zzzzz-nonexistent")
+	if len(results) != 0 {
+		t.Errorf("expected no results, got %d", len(results))
+	}
+}
+
+func TestSearch_MatchesAlias(t *testing.T) {
+	results := Search("haiku")
+	if len(results) == 0 {
+		t.Fatal("expected search results for alias 'haiku'")
+	}
+
+	found := false
+	for _, r := range results {
+		if r.ID == "claude-haiku-3-5" {
+			found = true
+		}
+	}
+	if !found {
+		t.Error("expected claude-haiku-3-5 in alias search results")
+	}
+}
+
+func TestListModels(t *testing.T) {
+	all := ListModels()
+	if len(all) == 0 {
+		t.Fatal("expected models")
+	}
+
+	// Verify sorted.
+	for i := 1; i < len(all); i++ {
+		if all[i].ID < all[i-1].ID {
+			t.Errorf("not sorted: %q before %q", all[i-1].ID, all[i].ID)
+		}
+	}
+}
+
+func TestListModelsForProvider(t *testing.T) {
+	claudeModels := ListModelsForProvider("claude")
+	if len(claudeModels) == 0 {
+		t.Fatal("expected claude models")
+	}
+
+	for _, m := range claudeModels {
+		found := false
+		for _, pid := range m.Providers {
+			if pid == "claude" {
+				found = true
+				break
+			}
+		}
+		if !found {
+			t.Errorf("model %q doesn't list claude as provider", m.ID)
+		}
+	}
+}
+
+func TestListModelsForProvider_Unknown(t *testing.T) {
+	result := ListModelsForProvider("nonexistent")
+	if len(result) != 0 {
+		t.Errorf("expected no models, got %d", len(result))
+	}
+}
+
+func TestRegistryConsistency(t *testing.T) {
+	// Every alias should resolve to a valid canonical model.
+	for alias, canonical := range aliases {
+		if _, ok := models[canonical]; !ok {
+			t.Errorf("alias %q points to non-existent model %q", alias, canonical)
+		}
+	}
+
+	// Every model should have at least one provider.
+	for id, info := range models {
+		if len(info.Providers) == 0 {
+			t.Errorf("model %q has no providers", id)
+		}
+		if info.ID != id {
+			t.Errorf("model key %q has mismatched ID %q", id, info.ID)
+		}
+		if info.Name == "" {
+			t.Errorf("model %q has empty name", id)
+		}
+	}
+}

--- a/internal/modelmap/registry.go
+++ b/internal/modelmap/registry.go
@@ -1,0 +1,161 @@
+package modelmap
+
+// models is the canonical model registry.
+// Provider IDs must match what's registered in the provider package.
+var models = map[string]ModelInfo{
+	// Anthropic Claude
+	"claude-sonnet-4-5": {
+		ID:        "claude-sonnet-4-5",
+		Name:      "Claude Sonnet 4.5",
+		Providers: []string{"claude", "copilot", "cursor", "antigravity"},
+	},
+	"claude-sonnet-4": {
+		ID:        "claude-sonnet-4",
+		Name:      "Claude Sonnet 4",
+		Providers: []string{"claude", "copilot", "cursor", "antigravity"},
+	},
+	"claude-opus-4": {
+		ID:        "claude-opus-4",
+		Name:      "Claude Opus 4",
+		Providers: []string{"claude", "copilot", "cursor", "antigravity"},
+	},
+	"claude-haiku-3-5": {
+		ID:        "claude-haiku-3-5",
+		Name:      "Claude Haiku 3.5",
+		Providers: []string{"claude", "copilot", "cursor", "antigravity"},
+	},
+
+	// OpenAI GPT
+	"gpt-4o": {
+		ID:        "gpt-4o",
+		Name:      "GPT-4o",
+		Providers: []string{"copilot", "cursor", "codex"},
+	},
+	"gpt-4o-mini": {
+		ID:        "gpt-4o-mini",
+		Name:      "GPT-4o mini",
+		Providers: []string{"copilot", "cursor", "codex"},
+	},
+	"gpt-4-1": {
+		ID:        "gpt-4-1",
+		Name:      "GPT-4.1",
+		Providers: []string{"copilot", "cursor", "codex"},
+	},
+	"gpt-4-1-mini": {
+		ID:        "gpt-4-1-mini",
+		Name:      "GPT-4.1 mini",
+		Providers: []string{"copilot", "cursor", "codex"},
+	},
+	"gpt-4-1-nano": {
+		ID:        "gpt-4-1-nano",
+		Name:      "GPT-4.1 nano",
+		Providers: []string{"copilot", "cursor", "codex"},
+	},
+
+	// OpenAI o-series
+	"o3": {
+		ID:        "o3",
+		Name:      "o3",
+		Providers: []string{"copilot", "cursor", "codex"},
+	},
+	"o3-mini": {
+		ID:        "o3-mini",
+		Name:      "o3-mini",
+		Providers: []string{"copilot", "cursor", "codex"},
+	},
+	"o4-mini": {
+		ID:        "o4-mini",
+		Name:      "o4-mini",
+		Providers: []string{"copilot", "cursor", "codex"},
+	},
+
+	// Google Gemini
+	"gemini-2-5-pro": {
+		ID:        "gemini-2-5-pro",
+		Name:      "Gemini 2.5 Pro",
+		Providers: []string{"gemini", "copilot", "cursor", "antigravity"},
+	},
+	"gemini-2-5-flash": {
+		ID:        "gemini-2-5-flash",
+		Name:      "Gemini 2.5 Flash",
+		Providers: []string{"gemini", "copilot", "cursor", "antigravity"},
+	},
+	"gemini-2-0-flash": {
+		ID:        "gemini-2-0-flash",
+		Name:      "Gemini 2.0 Flash",
+		Providers: []string{"gemini", "copilot", "cursor", "antigravity"},
+	},
+
+	// Kimi / Moonshot
+	"k2-5": {
+		ID:        "k2-5",
+		Name:      "Kimi K2.5",
+		Providers: []string{"kimi"},
+	},
+
+	// Minimax
+	"minimax-m2-5": {
+		ID:        "minimax-m2-5",
+		Name:      "MiniMax M2.5",
+		Providers: []string{"minimax"},
+	},
+	"minimax-m2-1": {
+		ID:        "minimax-m2-1",
+		Name:      "MiniMax M2.1",
+		Providers: []string{"minimax"},
+	},
+	"minimax-m2": {
+		ID:        "minimax-m2",
+		Name:      "MiniMax M2",
+		Providers: []string{"minimax"},
+	},
+}
+
+// aliases maps informal/shorthand names to canonical model IDs.
+var aliases = map[string]string{
+	// Claude shortcuts
+	"sonnet":        "claude-sonnet-4",
+	"sonnet-4":      "claude-sonnet-4",
+	"sonnet-4.5":    "claude-sonnet-4-5",
+	"sonnet-4-5":    "claude-sonnet-4-5",
+	"sonnet4.5":     "claude-sonnet-4-5",
+	"opus":          "claude-opus-4",
+	"opus-4":        "claude-opus-4",
+	"haiku":         "claude-haiku-3-5",
+	"haiku-3.5":     "claude-haiku-3-5",
+	"haiku-3-5":     "claude-haiku-3-5",
+	"claude-3-5":    "claude-haiku-3-5",
+	"claude-sonnet": "claude-sonnet-4",
+	"claude-opus":   "claude-opus-4",
+	"claude-haiku":  "claude-haiku-3-5",
+
+	// GPT shortcuts
+	"4o":           "gpt-4o",
+	"4o-mini":      "gpt-4o-mini",
+	"gpt4o":        "gpt-4o",
+	"gpt-4.1":      "gpt-4-1",
+	"gpt4.1":       "gpt-4-1",
+	"gpt-4.1-mini": "gpt-4-1-mini",
+	"gpt-4.1-nano": "gpt-4-1-nano",
+
+	// o-series
+	"o3mini": "o3-mini",
+	"o4mini": "o4-mini",
+
+	// Gemini shortcuts
+	"gemini":         "gemini-2-5-pro",
+	"gemini-pro":     "gemini-2-5-pro",
+	"gemini-flash":   "gemini-2-5-flash",
+	"gemini-2.5-pro": "gemini-2-5-pro",
+	"gemini-2.5":     "gemini-2-5-pro",
+	"flash":          "gemini-2-5-flash",
+
+	// Kimi shortcuts
+	"kimi": "k2-5",
+	"k2.5": "k2-5",
+
+	// Minimax shortcuts
+	"m2.5": "minimax-m2-5",
+	"m2.1": "minimax-m2-1",
+	"m2":   "minimax-m2",
+}

--- a/internal/routing/routing.go
+++ b/internal/routing/routing.go
@@ -1,0 +1,93 @@
+package routing
+
+import (
+	"sort"
+	"time"
+
+	"github.com/joshuadavidthomas/vibeusage/internal/models"
+)
+
+// Candidate represents a provider that can serve a given model,
+// along with its current usage headroom.
+type Candidate struct {
+	// ProviderID is the provider identifier (e.g. "claude", "copilot").
+	ProviderID string `json:"provider_id"`
+	// Headroom is remaining capacity (100 - utilization). Higher is better.
+	Headroom int `json:"headroom"`
+	// Utilization is the current usage percentage (0-100).
+	Utilization int `json:"utilization"`
+	// PeriodType indicates the quota window type.
+	PeriodType models.PeriodType `json:"period_type"`
+	// ResetsAt is when the quota window resets, if known.
+	ResetsAt *time.Time `json:"resets_at,omitempty"`
+	// Plan is the subscription tier, if known.
+	Plan string `json:"plan,omitempty"`
+	// Cached indicates this data came from cache rather than a live fetch.
+	Cached bool `json:"cached"`
+}
+
+// Recommendation is the result of routing a model query across providers.
+type Recommendation struct {
+	// ModelID is the canonical model identifier that was resolved.
+	ModelID string `json:"model_id"`
+	// ModelName is the human-readable model name.
+	ModelName string `json:"model_name"`
+	// Best is the top-ranked candidate (most headroom). Nil if no providers have data.
+	Best *Candidate `json:"best,omitempty"`
+	// Candidates is all providers ranked by headroom (descending).
+	Candidates []Candidate `json:"candidates"`
+	// Unavailable lists provider IDs that offer the model but had no usage data.
+	Unavailable []string `json:"unavailable,omitempty"`
+}
+
+// Rank takes a set of provider snapshots and the list of provider IDs that
+// offer a model, and returns candidates sorted by headroom (most first).
+// Providers without successful snapshots are returned in the unavailable list.
+func Rank(providerIDs []string, snapshots map[string]ProviderData) (candidates []Candidate, unavailable []string) {
+	for _, pid := range providerIDs {
+		data, ok := snapshots[pid]
+		if !ok || data.Snapshot == nil {
+			unavailable = append(unavailable, pid)
+			continue
+		}
+
+		snap := data.Snapshot
+		primary := snap.PrimaryPeriod()
+		if primary == nil {
+			unavailable = append(unavailable, pid)
+			continue
+		}
+
+		var plan string
+		if snap.Identity != nil {
+			plan = snap.Identity.Plan
+		}
+
+		candidates = append(candidates, Candidate{
+			ProviderID:  pid,
+			Headroom:    primary.Remaining(),
+			Utilization: primary.Utilization,
+			PeriodType:  primary.PeriodType,
+			ResetsAt:    primary.ResetsAt,
+			Plan:        plan,
+			Cached:      data.Cached,
+		})
+	}
+
+	// Sort by headroom descending, then provider ID ascending for stability.
+	sort.Slice(candidates, func(i, j int) bool {
+		if candidates[i].Headroom != candidates[j].Headroom {
+			return candidates[i].Headroom > candidates[j].Headroom
+		}
+		return candidates[i].ProviderID < candidates[j].ProviderID
+	})
+
+	sort.Strings(unavailable)
+	return candidates, unavailable
+}
+
+// ProviderData bundles a snapshot with its cache status.
+type ProviderData struct {
+	Snapshot *models.UsageSnapshot
+	Cached   bool
+}

--- a/internal/routing/routing_test.go
+++ b/internal/routing/routing_test.go
@@ -1,0 +1,211 @@
+package routing
+
+import (
+	"testing"
+	"time"
+
+	"github.com/joshuadavidthomas/vibeusage/internal/models"
+)
+
+func makeSnapshot(providerID string, utilization int, periodType models.PeriodType, plan string) *models.UsageSnapshot {
+	reset := time.Now().Add(2 * time.Hour)
+	return &models.UsageSnapshot{
+		Provider:  providerID,
+		FetchedAt: time.Now().UTC(),
+		Periods: []models.UsagePeriod{
+			{
+				Name:        "Usage",
+				Utilization: utilization,
+				PeriodType:  periodType,
+				ResetsAt:    &reset,
+			},
+		},
+		Identity: &models.ProviderIdentity{Plan: plan},
+	}
+}
+
+func TestRank_SortsByHeadroom(t *testing.T) {
+	providerIDs := []string{"claude", "copilot", "cursor"}
+	snapshots := map[string]ProviderData{
+		"claude":  {Snapshot: makeSnapshot("claude", 80, models.PeriodSession, "Pro")},
+		"copilot": {Snapshot: makeSnapshot("copilot", 20, models.PeriodMonthly, "Business")},
+		"cursor":  {Snapshot: makeSnapshot("cursor", 50, models.PeriodMonthly, "Pro")},
+	}
+
+	candidates, unavailable := Rank(providerIDs, snapshots)
+
+	if len(unavailable) != 0 {
+		t.Errorf("expected 0 unavailable, got %d", len(unavailable))
+	}
+	if len(candidates) != 3 {
+		t.Fatalf("expected 3 candidates, got %d", len(candidates))
+	}
+
+	// copilot (80 headroom) > cursor (50) > claude (20)
+	if candidates[0].ProviderID != "copilot" {
+		t.Errorf("first = %q, want copilot", candidates[0].ProviderID)
+	}
+	if candidates[0].Headroom != 80 {
+		t.Errorf("first headroom = %d, want 80", candidates[0].Headroom)
+	}
+	if candidates[1].ProviderID != "cursor" {
+		t.Errorf("second = %q, want cursor", candidates[1].ProviderID)
+	}
+	if candidates[2].ProviderID != "claude" {
+		t.Errorf("third = %q, want claude", candidates[2].ProviderID)
+	}
+}
+
+func TestRank_TiebreaksByProviderID(t *testing.T) {
+	providerIDs := []string{"cursor", "claude"}
+	snapshots := map[string]ProviderData{
+		"claude": {Snapshot: makeSnapshot("claude", 50, models.PeriodSession, "")},
+		"cursor": {Snapshot: makeSnapshot("cursor", 50, models.PeriodMonthly, "")},
+	}
+
+	candidates, _ := Rank(providerIDs, snapshots)
+
+	if len(candidates) != 2 {
+		t.Fatalf("expected 2 candidates, got %d", len(candidates))
+	}
+	// Same headroom → alphabetical: claude before cursor
+	if candidates[0].ProviderID != "claude" {
+		t.Errorf("first = %q, want claude (alphabetical tiebreak)", candidates[0].ProviderID)
+	}
+}
+
+func TestRank_MissingProviders(t *testing.T) {
+	providerIDs := []string{"claude", "copilot", "cursor"}
+	snapshots := map[string]ProviderData{
+		"claude": {Snapshot: makeSnapshot("claude", 30, models.PeriodSession, "")},
+		// copilot and cursor missing
+	}
+
+	candidates, unavailable := Rank(providerIDs, snapshots)
+
+	if len(candidates) != 1 {
+		t.Fatalf("expected 1 candidate, got %d", len(candidates))
+	}
+	if candidates[0].ProviderID != "claude" {
+		t.Errorf("candidate = %q, want claude", candidates[0].ProviderID)
+	}
+	if len(unavailable) != 2 {
+		t.Fatalf("expected 2 unavailable, got %d", len(unavailable))
+	}
+	// Sorted alphabetically
+	if unavailable[0] != "copilot" || unavailable[1] != "cursor" {
+		t.Errorf("unavailable = %v, want [copilot cursor]", unavailable)
+	}
+}
+
+func TestRank_NilSnapshot(t *testing.T) {
+	providerIDs := []string{"claude"}
+	snapshots := map[string]ProviderData{
+		"claude": {Snapshot: nil},
+	}
+
+	candidates, unavailable := Rank(providerIDs, snapshots)
+
+	if len(candidates) != 0 {
+		t.Errorf("expected 0 candidates, got %d", len(candidates))
+	}
+	if len(unavailable) != 1 {
+		t.Fatalf("expected 1 unavailable, got %d", len(unavailable))
+	}
+}
+
+func TestRank_EmptyPeriods(t *testing.T) {
+	providerIDs := []string{"claude"}
+	snapshots := map[string]ProviderData{
+		"claude": {
+			Snapshot: &models.UsageSnapshot{
+				Provider:  "claude",
+				FetchedAt: time.Now().UTC(),
+				Periods:   []models.UsagePeriod{},
+			},
+		},
+	}
+
+	candidates, unavailable := Rank(providerIDs, snapshots)
+
+	if len(candidates) != 0 {
+		t.Errorf("expected 0 candidates, got %d", len(candidates))
+	}
+	if len(unavailable) != 1 {
+		t.Fatalf("expected 1 unavailable, got %d", len(unavailable))
+	}
+}
+
+func TestRank_CachedFlag(t *testing.T) {
+	providerIDs := []string{"claude"}
+	snapshots := map[string]ProviderData{
+		"claude": {
+			Snapshot: makeSnapshot("claude", 40, models.PeriodSession, ""),
+			Cached:   true,
+		},
+	}
+
+	candidates, _ := Rank(providerIDs, snapshots)
+
+	if len(candidates) != 1 {
+		t.Fatalf("expected 1 candidate, got %d", len(candidates))
+	}
+	if !candidates[0].Cached {
+		t.Error("expected cached = true")
+	}
+}
+
+func TestRank_PlanPropagated(t *testing.T) {
+	providerIDs := []string{"claude"}
+	snapshots := map[string]ProviderData{
+		"claude": {Snapshot: makeSnapshot("claude", 10, models.PeriodSession, "Max")},
+	}
+
+	candidates, _ := Rank(providerIDs, snapshots)
+
+	if len(candidates) != 1 {
+		t.Fatalf("expected 1 candidate, got %d", len(candidates))
+	}
+	if candidates[0].Plan != "Max" {
+		t.Errorf("plan = %q, want %q", candidates[0].Plan, "Max")
+	}
+}
+
+func TestRank_AllProvidersMissing(t *testing.T) {
+	providerIDs := []string{"claude", "copilot"}
+	snapshots := map[string]ProviderData{}
+
+	candidates, unavailable := Rank(providerIDs, snapshots)
+
+	if len(candidates) != 0 {
+		t.Errorf("expected 0 candidates, got %d", len(candidates))
+	}
+	if len(unavailable) != 2 {
+		t.Errorf("expected 2 unavailable, got %d", len(unavailable))
+	}
+}
+
+func TestRank_FullyUsedProvider(t *testing.T) {
+	providerIDs := []string{"claude", "copilot"}
+	snapshots := map[string]ProviderData{
+		"claude":  {Snapshot: makeSnapshot("claude", 100, models.PeriodSession, "")},
+		"copilot": {Snapshot: makeSnapshot("copilot", 60, models.PeriodMonthly, "")},
+	}
+
+	candidates, _ := Rank(providerIDs, snapshots)
+
+	if len(candidates) != 2 {
+		t.Fatalf("expected 2 candidates, got %d", len(candidates))
+	}
+	// copilot has more headroom
+	if candidates[0].ProviderID != "copilot" {
+		t.Errorf("first = %q, want copilot", candidates[0].ProviderID)
+	}
+	// claude is fully used but still a candidate (headroom 0)
+	if candidates[1].ProviderID != "claude" {
+		t.Errorf("second = %q, want claude", candidates[1].ProviderID)
+	}
+	if candidates[1].Headroom != 0 {
+		t.Errorf("claude headroom = %d, want 0", candidates[1].Headroom)
+	}
+}


### PR DESCRIPTION
## Summary

New `vibeusage route <model>` command that picks the best provider for a given model based on available headroom (remaining quota capacity).

## Motivation

Many providers offer the same models (e.g. Claude Sonnet 4.5 is available through Anthropic, Copilot, Cursor, and Antigravity). This command lets you spread usage across providers by recommending the one with the most remaining capacity.

## Usage

```bash
# Pick best provider for a model
vibeusage route sonnet-4.5

# Machine-readable output (just the provider ID — pipe into other tools)
vibeusage route sonnet-4.5 -q
# → antigravity

# Full JSON with all candidates ranked by headroom
vibeusage route sonnet-4.5 -j

# List all known models and their providers
vibeusage route --list

# Filter models by provider
vibeusage route --list copilot
```

Aliases are supported — `sonnet-4.5`, `opus`, `haiku`, `4o`, `gemini`, `flash`, `kimi`, `m2.5`, etc.

Unknown models get fuzzy "did you mean?" suggestions:
```
$ vibeusage route gem
Error: unknown model "gem". Did you mean:
  gemini-2-0-flash (Gemini 2.0 Flash)
  gemini-2-5-flash (Gemini 2.5 Flash)
  gemini-2-5-pro (Gemini 2.5 Pro)
```

## Architecture

| Package | Responsibility |
|---|---|
| `internal/modelmap/` | Static model→provider registry, alias resolution, fuzzy search |
| `internal/routing/` | Ranking: sort providers by headroom (100 - utilization), stable tiebreak |
| `cmd/route.go` | CLI wiring: resolve model, fetch usage, rank, display |

The routing is purely informational — callers decide what to do with the recommendation. Supports all output modes (table, JSON, quiet) and respects `--refresh`, cache fallback, and spinner settings.