### PR TITLE
Dynamic model registry from models.dev, multiplier-aware routing

### DIFF
--- a/cmd/auth.go
+++ b/cmd/auth.go
@@ -101,7 +101,7 @@ func authStatusCommand() error {
 	outln(display.NewTableWithOptions(
 		[]string{"Provider", "Status", "Source"},
 		rows,
-		display.TableOptions{Title: "Authentication Status", NoColor: noColor},
+		display.TableOptions{Title: "Authentication Status", NoColor: noColor, Width: display.TerminalWidth()},
 	))
 
 	if len(unconfigured) > 0 {

--- a/cmd/cache.go
+++ b/cmd/cache.go
@@ -106,7 +106,7 @@ var cacheShowCmd = &cobra.Command{
 		outln(display.NewTableWithOptions(
 			[]string{"Provider", "Snapshot", "Org ID", "Age"},
 			rows,
-			display.TableOptions{Title: "Cache Status", NoColor: noColor},
+			display.TableOptions{Title: "Cache Status", NoColor: noColor, Width: display.TerminalWidth()},
 		))
 
 		out("\nCache directory: %s\n", config.CacheDir())

--- a/cmd/key.go
+++ b/cmd/key.go
@@ -77,7 +77,7 @@ func displayAllCredentialStatus() error {
 	outln(display.NewTableWithOptions(
 		[]string{"Provider", "Status", "Source"},
 		rows,
-		display.TableOptions{Title: "Credential Status", NoColor: noColor},
+		display.TableOptions{Title: "Credential Status", NoColor: noColor, Width: display.TerminalWidth()},
 	))
 
 	outln()

--- a/cmd/status.go
+++ b/cmd/status.go
@@ -84,7 +84,7 @@ func displayStatusTable(statuses map[string]models.ProviderStatus, durationMs in
 	outln(display.NewTableWithOptions(
 		[]string{"Provider", "Status", "Description", "Updated"},
 		rows,
-		display.TableOptions{Title: "Provider Status", NoColor: noColor},
+		display.TableOptions{Title: "Provider Status", NoColor: noColor, Width: display.TerminalWidth()},
 	))
 
 	if durationMs > 0 {

--- a/go.mod
+++ b/go.mod
@@ -9,6 +9,7 @@ require (
 	github.com/charmbracelet/huh v0.8.0
 	github.com/charmbracelet/lipgloss v1.1.0
 	github.com/charmbracelet/log v0.4.2
+	github.com/charmbracelet/x/term v0.2.1
 	github.com/mattn/go-isatty v0.0.20
 	github.com/muesli/termenv v0.16.0
 	github.com/spf13/cobra v1.10.2
@@ -23,7 +24,6 @@ require (
 	github.com/charmbracelet/x/ansi v0.9.3 // indirect
 	github.com/charmbracelet/x/cellbuf v0.0.13 // indirect
 	github.com/charmbracelet/x/exp/strings v0.0.0-20240722160745-212f7b056ed0 // indirect
-	github.com/charmbracelet/x/term v0.2.1 // indirect
 	github.com/dustin/go-humanize v1.0.1 // indirect
 	github.com/erikgeiser/coninput v0.0.0-20211004153227-1c3628e74d0f // indirect
 	github.com/go-logfmt/logfmt v0.6.0 // indirect

--- a/internal/config/cache.go
+++ b/internal/config/cache.go
@@ -92,6 +92,11 @@ func ClearSnapshotCache(providerID string) {
 	}
 }
 
+func ClearModelsCache() {
+	_ = os.Remove(ModelsFile())
+	_ = os.Remove(MultipliersFile())
+}
+
 func ClearAllCache(providerID string) {
 	if providerID != "" {
 		ClearProviderCache(providerID)
@@ -99,4 +104,5 @@ func ClearAllCache(providerID string) {
 	}
 	ClearSnapshotCache("")
 	ClearOrgIDCache("")
+	ClearModelsCache()
 }

--- a/internal/config/paths.go
+++ b/internal/config/paths.go
@@ -21,10 +21,12 @@ func CacheDir() string {
 	return filepath.Join(userCacheDir(), appName)
 }
 
-func CredentialsDir() string { return filepath.Join(ConfigDir(), "credentials") }
-func SnapshotsDir() string   { return filepath.Join(CacheDir(), "snapshots") }
-func OrgIDsDir() string      { return filepath.Join(CacheDir(), "org-ids") }
-func ConfigFile() string     { return filepath.Join(ConfigDir(), "config.toml") }
+func CredentialsDir() string  { return filepath.Join(ConfigDir(), "credentials") }
+func SnapshotsDir() string    { return filepath.Join(CacheDir(), "snapshots") }
+func OrgIDsDir() string       { return filepath.Join(CacheDir(), "org-ids") }
+func ModelsFile() string      { return filepath.Join(CacheDir(), "models.json") }
+func MultipliersFile() string { return filepath.Join(CacheDir(), "multipliers.json") }
+func ConfigFile() string      { return filepath.Join(ConfigDir(), "config.toml") }
 
 func userConfigDir() string {
 	if d, err := os.UserConfigDir(); err == nil {

--- a/internal/display/table.go
+++ b/internal/display/table.go
@@ -5,10 +5,21 @@ import (
 	"github.com/charmbracelet/lipgloss/table"
 )
 
+// RowStyle controls per-row styling.
+type RowStyle int
+
+const (
+	RowNormal RowStyle = iota
+	RowBold
+	RowDim
+)
+
 // TableOptions configures table rendering.
 type TableOptions struct {
-	Title   string
-	NoColor bool
+	Title     string
+	NoColor   bool
+	Width     int        // If > 0, constrain table to this width.
+	RowStyles []RowStyle // Per-row styles (indexed by data row, not header).
 }
 
 // NewTable creates a styled table with headers and rows using lipgloss/table.
@@ -20,10 +31,14 @@ func NewTable(headers []string, rows [][]string) string {
 func NewTableWithOptions(headers []string, rows [][]string, opts TableOptions) string {
 	headerStyle := lipgloss.NewStyle().Bold(true).Padding(0, 1)
 	cellStyle := lipgloss.NewStyle().Padding(0, 1)
+	boldStyle := lipgloss.NewStyle().Bold(true).Padding(0, 1)
+	dimStyle := lipgloss.NewStyle().Faint(true).Italic(true).Padding(0, 1)
 	borderStyle := lipgloss.NewStyle().Foreground(lipgloss.Color("240"))
 
 	if opts.NoColor {
 		headerStyle = lipgloss.NewStyle().Padding(0, 1)
+		boldStyle = lipgloss.NewStyle().Padding(0, 1)
+		dimStyle = lipgloss.NewStyle().Padding(0, 1)
 		borderStyle = lipgloss.NewStyle()
 	}
 
@@ -35,8 +50,21 @@ func NewTableWithOptions(headers []string, rows [][]string, opts TableOptions) s
 			if row == table.HeaderRow {
 				return headerStyle
 			}
+			// Data rows are 0-indexed (HeaderRow is -1).
+			if row >= 0 && row < len(opts.RowStyles) {
+				switch opts.RowStyles[row] {
+				case RowBold:
+					return boldStyle
+				case RowDim:
+					return dimStyle
+				}
+			}
 			return cellStyle
 		})
+
+	if opts.Width > 0 {
+		t.Width(opts.Width)
+	}
 
 	for _, row := range rows {
 		t.Row(row...)

--- a/internal/display/terminal.go
+++ b/internal/display/terminal.go
@@ -1,0 +1,16 @@
+package display
+
+import (
+	"os"
+
+	"github.com/charmbracelet/x/term"
+)
+
+// TerminalWidth returns the current terminal width, or 80 as a fallback.
+func TerminalWidth() int {
+	w, _, err := term.GetSize(os.Stdout.Fd())
+	if err != nil || w <= 0 {
+		return 80
+	}
+	return w
+}

--- a/internal/modelmap/fetch.go
+++ b/internal/modelmap/fetch.go
@@ -1,0 +1,99 @@
+package modelmap
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"os"
+	"time"
+
+	"github.com/joshuadavidthomas/vibeusage/internal/config"
+	"github.com/joshuadavidthomas/vibeusage/internal/httpclient"
+)
+
+const (
+	modelsDevURL = "https://models.dev/api.json"
+	cacheTTL     = 24 * time.Hour
+)
+
+// modelsDevProvider is the top-level entry for a provider in the models.dev API.
+type modelsDevProvider struct {
+	ID     string                    `json:"id"`
+	Name   string                    `json:"name"`
+	Models map[string]modelsDevModel `json:"models"`
+}
+
+// modelsDevModel is a single model entry from models.dev.
+type modelsDevModel struct {
+	ID     string `json:"id"`
+	Name   string `json:"name"`
+	Family string `json:"family"`
+}
+
+// loadModelsDevData returns the parsed models.dev data, using the cache when
+// fresh and fetching from the network otherwise. Returns nil on any failure.
+func loadModelsDevData() map[string]modelsDevProvider {
+	path := config.ModelsFile()
+
+	if data := readCacheIfFresh(path); data != nil {
+		return data
+	}
+
+	raw, err := fetchModelsDevAPI()
+	if err != nil {
+		// Network failed — serve stale cache if it exists.
+		if data := readCache(path); data != nil {
+			return data
+		}
+		return nil
+	}
+
+	_ = writeCache(path, raw)
+	return parseModelsDevJSON(raw)
+}
+
+func readCacheIfFresh(path string) map[string]modelsDevProvider {
+	info, err := os.Stat(path)
+	if err != nil {
+		return nil
+	}
+	if time.Since(info.ModTime()) > cacheTTL {
+		return nil
+	}
+	return readCache(path)
+}
+
+func readCache(path string) map[string]modelsDevProvider {
+	raw, err := os.ReadFile(path)
+	if err != nil {
+		return nil
+	}
+	return parseModelsDevJSON(raw)
+}
+
+func writeCache(path string, data []byte) error {
+	if err := os.MkdirAll(config.CacheDir(), 0o755); err != nil {
+		return err
+	}
+	return os.WriteFile(path, data, 0o644)
+}
+
+func fetchModelsDevAPI() ([]byte, error) {
+	client := httpclient.NewWithTimeout(15 * time.Second)
+	resp, err := client.DoCtx(context.Background(), "GET", modelsDevURL, nil)
+	if err != nil {
+		return nil, fmt.Errorf("fetching models.dev: %w", err)
+	}
+	if resp.StatusCode != 200 {
+		return nil, fmt.Errorf("fetching models.dev: HTTP %d", resp.StatusCode)
+	}
+	return resp.Body, nil
+}
+
+func parseModelsDevJSON(raw []byte) map[string]modelsDevProvider {
+	var data map[string]modelsDevProvider
+	if err := json.Unmarshal(raw, &data); err != nil {
+		return nil
+	}
+	return data
+}

--- a/internal/modelmap/modelmap.go
+++ b/internal/modelmap/modelmap.go
@@ -3,31 +3,78 @@ package modelmap
 import (
 	"sort"
 	"strings"
+	"sync"
 )
 
 // ModelInfo describes a model and which providers offer it.
 type ModelInfo struct {
-	// ID is the canonical model identifier (e.g. "claude-sonnet-4-5").
+	// ID is the canonical model identifier (e.g. "claude-sonnet-4-6").
 	ID string
-	// Name is the human-readable display name (e.g. "Claude Sonnet 4.5").
+	// Name is the human-readable display name (e.g. "Claude Sonnet 4.6").
 	Name string
 	// Providers lists provider IDs that offer this model.
 	Providers []string
 }
 
+var (
+	initOnce       sync.Once
+	registryModels map[string]ModelInfo
+	registryAlias  map[string]string
+
+	// dataLoader is the function that loads models.dev data.
+	// Tests can override this to avoid network calls.
+	dataLoader = loadModelsDevData
+)
+
+func ensureLoaded() {
+	initOnce.Do(func() {
+		data := dataLoader()
+		if data != nil {
+			registryModels, registryAlias = buildRegistry(data)
+		}
+		if registryModels == nil {
+			registryModels = make(map[string]ModelInfo)
+		}
+		if registryAlias == nil {
+			registryAlias = make(map[string]string)
+		}
+	})
+}
+
+// ResetForTesting clears the cached registry so the next call re-initializes.
+// Only use in tests.
+func ResetForTesting() {
+	initOnce = sync.Once{}
+	registryModels = nil
+	registryAlias = nil
+}
+
+// SetLoaderForTesting overrides the data loader for tests.
+// Returns a cleanup function that restores the original loader.
+func SetLoaderForTesting(loader func() map[string]modelsDevProvider) func() {
+	old := dataLoader
+	dataLoader = loader
+	ResetForTesting()
+	return func() {
+		dataLoader = old
+		ResetForTesting()
+	}
+}
+
 // Lookup resolves a model query (canonical ID or alias) to a ModelInfo.
 // Returns nil if the model is not found.
 func Lookup(query string) *ModelInfo {
+	ensureLoaded()
 	q := normalize(query)
 
 	// Direct canonical match.
-	if info, ok := models[q]; ok {
+	if info, ok := registryModels[q]; ok {
 		return &info
 	}
 
 	// Alias match.
-	if canonical, ok := aliases[q]; ok {
-		if info, found := models[canonical]; found {
+	if canonical, ok := registryAlias[q]; ok {
+		if info, found := registryModels[canonical]; found {
 			return &info
 		}
 	}
@@ -38,11 +85,12 @@ func Lookup(query string) *ModelInfo {
 // Search returns all models whose ID or name contains the query substring.
 // Useful for fuzzy "did you mean?" suggestions.
 func Search(query string) []ModelInfo {
+	ensureLoaded()
 	q := normalize(query)
 	var results []ModelInfo
 
 	seen := make(map[string]bool)
-	for id, info := range models {
+	for id, info := range registryModels {
 		if strings.Contains(id, q) || strings.Contains(normalize(info.Name), q) {
 			if !seen[info.ID] {
 				results = append(results, info)
@@ -52,9 +100,9 @@ func Search(query string) []ModelInfo {
 	}
 
 	// Also search aliases.
-	for alias, canonical := range aliases {
+	for alias, canonical := range registryAlias {
 		if strings.Contains(alias, q) {
-			if info, ok := models[canonical]; ok && !seen[info.ID] {
+			if info, ok := registryModels[canonical]; ok && !seen[info.ID] {
 				results = append(results, info)
 				seen[info.ID] = true
 			}
@@ -82,8 +130,9 @@ func ProvidersForModel(query string) []string {
 
 // ListModels returns all known models, sorted by ID.
 func ListModels() []ModelInfo {
+	ensureLoaded()
 	var result []ModelInfo
-	for _, info := range models {
+	for _, info := range registryModels {
 		result = append(result, info)
 	}
 	sort.Slice(result, func(i, j int) bool {
@@ -94,8 +143,9 @@ func ListModels() []ModelInfo {
 
 // ListModelsForProvider returns all models available through a given provider.
 func ListModelsForProvider(providerID string) []ModelInfo {
+	ensureLoaded()
 	var result []ModelInfo
-	for _, info := range models {
+	for _, info := range registryModels {
 		for _, pid := range info.Providers {
 			if pid == providerID {
 				result = append(result, info)

--- a/internal/modelmap/modelmap_test.go
+++ b/internal/modelmap/modelmap_test.go
@@ -4,16 +4,90 @@ import (
 	"testing"
 )
 
+// testData returns a minimal models.dev-shaped fixture for testing.
+func testData() map[string]modelsDevProvider {
+	return map[string]modelsDevProvider{
+		"anthropic": {
+			ID:   "anthropic",
+			Name: "Anthropic",
+			Models: map[string]modelsDevModel{
+				"claude-sonnet-4-5": {ID: "claude-sonnet-4-5", Name: "Claude Sonnet 4.5", Family: "claude-sonnet"},
+				"claude-sonnet-4-6": {ID: "claude-sonnet-4-6", Name: "Claude Sonnet 4.6", Family: "claude-sonnet"},
+				"claude-opus-4-0":   {ID: "claude-opus-4-0", Name: "Claude Opus 4", Family: "claude-opus"},
+				"claude-haiku-4-5":  {ID: "claude-haiku-4-5", Name: "Claude Haiku 4.5", Family: "claude-haiku"},
+			},
+		},
+		"openai": {
+			ID:   "openai",
+			Name: "OpenAI",
+			Models: map[string]modelsDevModel{
+				"gpt-4o":                 {ID: "gpt-4o", Name: "GPT-4o", Family: "gpt"},
+				"gpt-5.2":                {ID: "gpt-5.2", Name: "GPT-5.2", Family: "gpt"},
+				"o4-mini":                {ID: "o4-mini", Name: "o4-mini", Family: "o-mini"},
+				"text-embedding-3-small": {ID: "text-embedding-3-small", Name: "text-embedding-3-small", Family: "text-embedding"},
+			},
+		},
+		"google": {
+			ID:   "google",
+			Name: "Google",
+			Models: map[string]modelsDevModel{
+				"gemini-2.5-pro":   {ID: "gemini-2.5-pro", Name: "Gemini 2.5 Pro", Family: "gemini-pro"},
+				"gemini-2.5-flash": {ID: "gemini-2.5-flash", Name: "Gemini 2.5 Flash", Family: "gemini-flash"},
+			},
+		},
+		"github-copilot": {
+			ID:   "github-copilot",
+			Name: "GitHub Copilot",
+			Models: map[string]modelsDevModel{
+				"claude-sonnet-4.5": {ID: "claude-sonnet-4.5", Name: "Claude Sonnet 4.5", Family: "claude-sonnet"},
+				"claude-sonnet-4.6": {ID: "claude-sonnet-4.6", Name: "Claude Sonnet 4.6", Family: "claude-sonnet"},
+				"gpt-4o":            {ID: "gpt-4o", Name: "GPT-4o", Family: "gpt"},
+				"gpt-5.2":           {ID: "gpt-5.2", Name: "GPT-5.2", Family: "gpt"},
+				"gemini-2.5-pro":    {ID: "gemini-2.5-pro", Name: "Gemini 2.5 Pro", Family: "gemini-pro"},
+			},
+		},
+		"moonshotai": {
+			ID:   "moonshotai",
+			Name: "Moonshot AI",
+			Models: map[string]modelsDevModel{
+				"kimi-k2.5": {ID: "kimi-k2.5", Name: "Kimi K2.5", Family: "kimi"},
+			},
+		},
+		"minimax": {
+			ID:   "minimax",
+			Name: "MiniMax",
+			Models: map[string]modelsDevModel{
+				"MiniMax-M2.5": {ID: "MiniMax-M2.5", Name: "MiniMax-M2.5", Family: "minimax"},
+			},
+		},
+		"zai": {
+			ID:   "zai",
+			Name: "Z.AI",
+			Models: map[string]modelsDevModel{
+				"glm-4.7": {ID: "glm-4.7", Name: "GLM-4.7", Family: "glm"},
+			},
+		},
+	}
+}
+
+func setupTest(t *testing.T) {
+	t.Helper()
+	cleanup := SetLoaderForTesting(testData)
+	t.Cleanup(cleanup)
+}
+
 func TestLookup_CanonicalID(t *testing.T) {
-	info := Lookup("claude-sonnet-4-5")
+	setupTest(t)
+
+	info := Lookup("claude-sonnet-4-6")
 	if info == nil {
 		t.Fatal("expected model info, got nil")
 	}
-	if info.ID != "claude-sonnet-4-5" {
-		t.Errorf("ID = %q, want %q", info.ID, "claude-sonnet-4-5")
+	if info.ID != "claude-sonnet-4-6" {
+		t.Errorf("ID = %q, want %q", info.ID, "claude-sonnet-4-6")
 	}
-	if info.Name != "Claude Sonnet 4.5" {
-		t.Errorf("Name = %q, want %q", info.Name, "Claude Sonnet 4.5")
+	if info.Name != "Claude Sonnet 4.6" {
+		t.Errorf("Name = %q, want %q", info.Name, "Claude Sonnet 4.6")
 	}
 	if len(info.Providers) == 0 {
 		t.Error("expected providers, got none")
@@ -21,56 +95,51 @@ func TestLookup_CanonicalID(t *testing.T) {
 }
 
 func TestLookup_Alias(t *testing.T) {
-	tests := []struct {
-		query    string
-		wantID   string
-		wantName string
-	}{
-		{"sonnet-4.5", "claude-sonnet-4-5", "Claude Sonnet 4.5"},
-		{"sonnet", "claude-sonnet-4", "Claude Sonnet 4"},
-		{"opus", "claude-opus-4", "Claude Opus 4"},
-		{"haiku", "claude-haiku-3-5", "Claude Haiku 3.5"},
-		{"4o", "gpt-4o", "GPT-4o"},
-		{"gemini", "gemini-2-5-pro", "Gemini 2.5 Pro"},
-		{"flash", "gemini-2-5-flash", "Gemini 2.5 Flash"},
-		{"kimi", "k2-5", "Kimi K2.5"},
-		{"m2.5", "minimax-m2-5", "MiniMax M2.5"},
-	}
+	setupTest(t)
 
-	for _, tt := range tests {
-		t.Run(tt.query, func(t *testing.T) {
-			info := Lookup(tt.query)
-			if info == nil {
-				t.Fatalf("Lookup(%q) returned nil", tt.query)
-			}
-			if info.ID != tt.wantID {
-				t.Errorf("ID = %q, want %q", info.ID, tt.wantID)
-			}
-			if info.Name != tt.wantName {
-				t.Errorf("Name = %q, want %q", info.Name, tt.wantName)
-			}
-		})
+	// Copilot uses "claude-sonnet-4.6" but canonical is "claude-sonnet-4-6".
+	info := Lookup("claude-sonnet-4.6")
+	if info == nil {
+		t.Fatal("expected alias match, got nil")
+	}
+	if info.ID != "claude-sonnet-4-6" {
+		t.Errorf("ID = %q, want canonical %q", info.ID, "claude-sonnet-4-6")
 	}
 }
 
 func TestLookup_CaseInsensitive(t *testing.T) {
-	info := Lookup("SONNET-4.5")
+	setupTest(t)
+
+	info := Lookup("CLAUDE-SONNET-4-6")
 	if info == nil {
 		t.Fatal("expected case-insensitive match")
 	}
-	if info.ID != "claude-sonnet-4-5" {
-		t.Errorf("ID = %q, want %q", info.ID, "claude-sonnet-4-5")
+	if info.ID != "claude-sonnet-4-6" {
+		t.Errorf("ID = %q, want %q", info.ID, "claude-sonnet-4-6")
 	}
 }
 
 func TestLookup_NotFound(t *testing.T) {
+	setupTest(t)
+
 	info := Lookup("nonexistent-model")
 	if info != nil {
 		t.Errorf("expected nil, got %+v", info)
 	}
 }
 
+func TestLookup_SkipsEmbeddings(t *testing.T) {
+	setupTest(t)
+
+	info := Lookup("text-embedding-3-small")
+	if info != nil {
+		t.Errorf("expected nil for embedding model, got %+v", info)
+	}
+}
+
 func TestProvidersForModel(t *testing.T) {
+	setupTest(t)
+
 	providers := ProvidersForModel("claude-sonnet-4-5")
 	if len(providers) == 0 {
 		t.Fatal("expected providers")
@@ -90,9 +159,19 @@ func TestProvidersForModel(t *testing.T) {
 	if !has("copilot") {
 		t.Error("expected copilot in providers")
 	}
+	// Antigravity infers from anthropic.
+	if !has("antigravity") {
+		t.Error("expected antigravity in providers (inferred from anthropic)")
+	}
+	// Cursor infers from anthropic.
+	if !has("cursor") {
+		t.Error("expected cursor in providers (inferred from anthropic)")
+	}
 }
 
 func TestProvidersForModel_NotFound(t *testing.T) {
+	setupTest(t)
+
 	providers := ProvidersForModel("nonexistent")
 	if providers != nil {
 		t.Errorf("expected nil, got %v", providers)
@@ -100,6 +179,8 @@ func TestProvidersForModel_NotFound(t *testing.T) {
 }
 
 func TestSearch(t *testing.T) {
+	setupTest(t)
+
 	results := Search("sonnet")
 	if len(results) == 0 {
 		t.Fatal("expected search results for 'sonnet'")
@@ -113,36 +194,23 @@ func TestSearch(t *testing.T) {
 	if !ids["claude-sonnet-4-5"] {
 		t.Error("expected claude-sonnet-4-5 in results")
 	}
-	if !ids["claude-sonnet-4"] {
-		t.Error("expected claude-sonnet-4 in results")
+	if !ids["claude-sonnet-4-6"] {
+		t.Error("expected claude-sonnet-4-6 in results")
 	}
 }
 
 func TestSearch_NoResults(t *testing.T) {
+	setupTest(t)
+
 	results := Search("zzzzz-nonexistent")
 	if len(results) != 0 {
 		t.Errorf("expected no results, got %d", len(results))
 	}
 }
 
-func TestSearch_MatchesAlias(t *testing.T) {
-	results := Search("haiku")
-	if len(results) == 0 {
-		t.Fatal("expected search results for alias 'haiku'")
-	}
-
-	found := false
-	for _, r := range results {
-		if r.ID == "claude-haiku-3-5" {
-			found = true
-		}
-	}
-	if !found {
-		t.Error("expected claude-haiku-3-5 in alias search results")
-	}
-}
-
 func TestListModels(t *testing.T) {
+	setupTest(t)
+
 	all := ListModels()
 	if len(all) == 0 {
 		t.Fatal("expected models")
@@ -157,6 +225,8 @@ func TestListModels(t *testing.T) {
 }
 
 func TestListModelsForProvider(t *testing.T) {
+	setupTest(t)
+
 	claudeModels := ListModelsForProvider("claude")
 	if len(claudeModels) == 0 {
 		t.Fatal("expected claude models")
@@ -177,6 +247,8 @@ func TestListModelsForProvider(t *testing.T) {
 }
 
 func TestListModelsForProvider_Unknown(t *testing.T) {
+	setupTest(t)
+
 	result := ListModelsForProvider("nonexistent")
 	if len(result) != 0 {
 		t.Errorf("expected no models, got %d", len(result))
@@ -184,15 +256,18 @@ func TestListModelsForProvider_Unknown(t *testing.T) {
 }
 
 func TestRegistryConsistency(t *testing.T) {
+	setupTest(t)
+	ensureLoaded()
+
 	// Every alias should resolve to a valid canonical model.
-	for alias, canonical := range aliases {
-		if _, ok := models[canonical]; !ok {
+	for alias, canonical := range registryAlias {
+		if _, ok := registryModels[canonical]; !ok {
 			t.Errorf("alias %q points to non-existent model %q", alias, canonical)
 		}
 	}
 
 	// Every model should have at least one provider.
-	for id, info := range models {
+	for id, info := range registryModels {
 		if len(info.Providers) == 0 {
 			t.Errorf("model %q has no providers", id)
 		}
@@ -202,5 +277,81 @@ func TestRegistryConsistency(t *testing.T) {
 		if info.Name == "" {
 			t.Errorf("model %q has empty name", id)
 		}
+	}
+}
+
+func TestProviderMerging(t *testing.T) {
+	setupTest(t)
+
+	// GPT-4o should be available from codex (openai) and copilot (github-copilot)
+	// and also cursor (inferred from openai).
+	info := Lookup("gpt-4o")
+	if info == nil {
+		t.Fatal("expected gpt-4o, got nil")
+	}
+
+	has := func(pid string) bool {
+		for _, p := range info.Providers {
+			if p == pid {
+				return true
+			}
+		}
+		return false
+	}
+
+	if !has("codex") {
+		t.Error("expected codex in gpt-4o providers")
+	}
+	if !has("copilot") {
+		t.Error("expected copilot in gpt-4o providers")
+	}
+	if !has("cursor") {
+		t.Error("expected cursor in gpt-4o providers (inferred from openai)")
+	}
+}
+
+func TestInferredProviders(t *testing.T) {
+	setupTest(t)
+
+	// Gemini models should be available from antigravity (inferred from google).
+	info := Lookup("gemini-2.5-pro")
+	if info == nil {
+		t.Fatal("expected gemini-2.5-pro, got nil")
+	}
+
+	has := func(pid string) bool {
+		for _, p := range info.Providers {
+			if p == pid {
+				return true
+			}
+		}
+		return false
+	}
+
+	if !has("gemini") {
+		t.Error("expected gemini in providers")
+	}
+	if !has("antigravity") {
+		t.Error("expected antigravity in providers (inferred from google)")
+	}
+	if !has("cursor") {
+		t.Error("expected cursor in providers (inferred from google)")
+	}
+}
+
+func TestEmptyData(t *testing.T) {
+	cleanup := SetLoaderForTesting(func() map[string]modelsDevProvider {
+		return nil
+	})
+	t.Cleanup(cleanup)
+
+	all := ListModels()
+	if len(all) != 0 {
+		t.Errorf("expected 0 models with nil data, got %d", len(all))
+	}
+
+	info := Lookup("anything")
+	if info != nil {
+		t.Errorf("expected nil lookup with no data, got %+v", info)
 	}
 }

--- a/internal/modelmap/multipliers.go
+++ b/internal/modelmap/multipliers.go
@@ -1,0 +1,192 @@
+package modelmap
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"os"
+	"strconv"
+	"strings"
+	"sync"
+	"time"
+
+	"github.com/joshuadavidthomas/vibeusage/internal/config"
+	"github.com/joshuadavidthomas/vibeusage/internal/httpclient"
+)
+
+const multipliersURL = "https://raw.githubusercontent.com/github/docs/main/data/tables/copilot/model-multipliers.yml"
+
+// ModelMultiplier holds the premium request multipliers for a Copilot model.
+type ModelMultiplier struct {
+	Name string   `json:"name"`
+	Paid *float64 `json:"paid,omitempty"` // nil = "Not applicable"
+	Free *float64 `json:"free,omitempty"` // nil = "Not applicable"
+}
+
+var (
+	multipliersOnce   sync.Once
+	multipliersByName map[string]ModelMultiplier
+)
+
+func ensureMultipliersLoaded() {
+	multipliersOnce.Do(func() {
+		multipliersByName = loadMultipliers()
+		if multipliersByName == nil {
+			multipliersByName = make(map[string]ModelMultiplier)
+		}
+	})
+}
+
+// LookupMultiplier returns the paid-plan multiplier for a model on copilot.
+// Returns nil if the model has no multiplier data (non-copilot provider or
+// unknown model). Returns a pointer to 0 for free models (0x cost).
+func LookupMultiplier(modelName string) *float64 {
+	ensureMultipliersLoaded()
+
+	// Try exact match first.
+	if m, ok := multipliersByName[modelName]; ok {
+		return m.Paid
+	}
+
+	// Try normalized match (case-insensitive, hyphens = spaces).
+	key := normalizeName(modelName)
+	for name, m := range multipliersByName {
+		if normalizeName(name) == key {
+			return m.Paid
+		}
+	}
+
+	return nil
+}
+
+// ResetMultipliersForTesting clears cached multiplier data.
+func ResetMultipliersForTesting() {
+	multipliersOnce = sync.Once{}
+	multipliersByName = nil
+}
+
+func loadMultipliers() map[string]ModelMultiplier {
+	path := config.MultipliersFile()
+
+	if data := readMultipliersCacheIfFresh(path); data != nil {
+		return data
+	}
+
+	raw, err := fetchMultipliersYAML()
+	if err != nil {
+		// Network failed — serve stale cache.
+		if data := readMultipliersCache(path); data != nil {
+			return data
+		}
+		return nil
+	}
+
+	entries := parseMultipliersYAML(raw)
+	if entries == nil {
+		return nil
+	}
+
+	_ = writeMultipliersCache(path, entries)
+	return indexByName(entries)
+}
+
+func readMultipliersCacheIfFresh(path string) map[string]ModelMultiplier {
+	info, err := os.Stat(path)
+	if err != nil {
+		return nil
+	}
+	if time.Since(info.ModTime()) > cacheTTL {
+		return nil
+	}
+	return readMultipliersCache(path)
+}
+
+func readMultipliersCache(path string) map[string]ModelMultiplier {
+	data, err := os.ReadFile(path)
+	if err != nil {
+		return nil
+	}
+	var entries []ModelMultiplier
+	if err := json.Unmarshal(data, &entries); err != nil {
+		return nil
+	}
+	return indexByName(entries)
+}
+
+func writeMultipliersCache(path string, entries []ModelMultiplier) error {
+	if err := os.MkdirAll(config.CacheDir(), 0o755); err != nil {
+		return err
+	}
+	data, err := json.Marshal(entries)
+	if err != nil {
+		return err
+	}
+	return os.WriteFile(path, data, 0o644)
+}
+
+func fetchMultipliersYAML() (string, error) {
+	client := httpclient.NewWithTimeout(15 * time.Second)
+	resp, err := client.DoCtx(context.Background(), "GET", multipliersURL, nil)
+	if err != nil {
+		return "", fmt.Errorf("fetching copilot multipliers: %w", err)
+	}
+	if resp.StatusCode != 200 {
+		return "", fmt.Errorf("fetching copilot multipliers: HTTP %d", resp.StatusCode)
+	}
+	return string(resp.Body), nil
+}
+
+// parseMultipliersYAML parses the simple YAML format from github/docs.
+// Each entry is:
+//
+//   - name: MODEL_NAME
+//     multiplier_paid: NUMBER_OR_NOT_APPLICABLE
+//     multiplier_free: NUMBER_OR_NOT_APPLICABLE
+func parseMultipliersYAML(raw string) []ModelMultiplier {
+	var entries []ModelMultiplier
+	var current *ModelMultiplier
+
+	for _, line := range strings.Split(raw, "\n") {
+		trimmed := strings.TrimSpace(line)
+		if trimmed == "" || strings.HasPrefix(trimmed, "#") {
+			continue
+		}
+
+		if strings.HasPrefix(trimmed, "- name:") {
+			if current != nil {
+				entries = append(entries, *current)
+			}
+			current = &ModelMultiplier{
+				Name: strings.TrimSpace(strings.TrimPrefix(trimmed, "- name:")),
+			}
+		} else if current != nil && strings.HasPrefix(trimmed, "multiplier_paid:") {
+			current.Paid = parseMultiplierValue(strings.TrimSpace(strings.TrimPrefix(trimmed, "multiplier_paid:")))
+		} else if current != nil && strings.HasPrefix(trimmed, "multiplier_free:") {
+			current.Free = parseMultiplierValue(strings.TrimSpace(strings.TrimPrefix(trimmed, "multiplier_free:")))
+		}
+	}
+	if current != nil {
+		entries = append(entries, *current)
+	}
+
+	return entries
+}
+
+func parseMultiplierValue(s string) *float64 {
+	if strings.EqualFold(s, "not applicable") || s == "" {
+		return nil
+	}
+	v, err := strconv.ParseFloat(s, 64)
+	if err != nil {
+		return nil
+	}
+	return &v
+}
+
+func indexByName(entries []ModelMultiplier) map[string]ModelMultiplier {
+	m := make(map[string]ModelMultiplier, len(entries))
+	for _, e := range entries {
+		m[e.Name] = e
+	}
+	return m
+}

--- a/internal/modelmap/multipliers_test.go
+++ b/internal/modelmap/multipliers_test.go
@@ -1,0 +1,68 @@
+package modelmap
+
+import (
+	"testing"
+)
+
+func TestParseMultipliersYAML(t *testing.T) {
+	yaml := `# Comment
+- name: Claude Sonnet 4.6
+  multiplier_paid: 1
+  multiplier_free: Not applicable
+
+- name: GPT-4o
+  multiplier_paid: 0
+  multiplier_free: 1
+
+- name: Claude Opus 4.6
+  multiplier_paid: 3
+  multiplier_free: Not applicable
+
+- name: Claude Haiku 4.5
+  multiplier_paid: 0.33
+  multiplier_free: 1
+
+- name: Goldeneye
+  multiplier_paid: Not applicable
+  multiplier_free: 1
+`
+	entries := parseMultipliersYAML(yaml)
+
+	if len(entries) != 5 {
+		t.Fatalf("expected 5 entries, got %d", len(entries))
+	}
+
+	// Claude Sonnet 4.6: paid=1, free=nil
+	if entries[0].Name != "Claude Sonnet 4.6" {
+		t.Errorf("entry 0 name = %q", entries[0].Name)
+	}
+	if entries[0].Paid == nil || *entries[0].Paid != 1 {
+		t.Errorf("entry 0 paid = %v, want 1", entries[0].Paid)
+	}
+	if entries[0].Free != nil {
+		t.Errorf("entry 0 free = %v, want nil (Not applicable)", entries[0].Free)
+	}
+
+	// GPT-4o: paid=0, free=1
+	if entries[1].Paid == nil || *entries[1].Paid != 0 {
+		t.Errorf("GPT-4o paid = %v, want 0", entries[1].Paid)
+	}
+	if entries[1].Free == nil || *entries[1].Free != 1 {
+		t.Errorf("GPT-4o free = %v, want 1", entries[1].Free)
+	}
+
+	// Claude Opus 4.6: paid=3
+	if entries[2].Paid == nil || *entries[2].Paid != 3 {
+		t.Errorf("Opus paid = %v, want 3", entries[2].Paid)
+	}
+
+	// Claude Haiku 4.5: paid=0.33
+	if entries[3].Paid == nil || *entries[3].Paid != 0.33 {
+		t.Errorf("Haiku paid = %v, want 0.33", entries[3].Paid)
+	}
+
+	// Goldeneye: paid=nil (Not applicable)
+	if entries[4].Paid != nil {
+		t.Errorf("Goldeneye paid = %v, want nil", entries[4].Paid)
+	}
+}

--- a/internal/models/models.go
+++ b/internal/models/models.go
@@ -161,6 +161,22 @@ func (s UsageSnapshot) PrimaryPeriod() *UsagePeriod {
 	return &s.Periods[best]
 }
 
+// BottleneckPeriod returns the period with the least remaining headroom
+// (highest utilization). For routing, this is the constraining limit — if
+// session is at 2% but weekly is at 62%, effective headroom is 38%.
+func (s UsageSnapshot) BottleneckPeriod() *UsagePeriod {
+	if len(s.Periods) == 0 {
+		return nil
+	}
+	best := 0
+	for i, p := range s.Periods {
+		if p.Utilization > s.Periods[best].Utilization {
+			best = i
+		}
+	}
+	return &s.Periods[best]
+}
+
 func (s UsageSnapshot) ModelPeriods() []UsagePeriod {
 	var result []UsagePeriod
 	for _, p := range s.Periods {

--- a/internal/provider/claude/response.go
+++ b/internal/provider/claude/response.go
@@ -28,6 +28,8 @@ type OAuthUsageResponse struct {
 	SevenDayOpus   *UsagePeriodResponse `json:"seven_day_opus,omitempty"`
 	SevenDayHaiku  *UsagePeriodResponse `json:"seven_day_haiku,omitempty"`
 	ExtraUsage     *ExtraUsageResponse  `json:"extra_usage,omitempty"`
+	Plan           string               `json:"plan,omitempty"`
+	BillingType    string               `json:"billing_type,omitempty"`
 }
 
 // OAuthTokenResponse represents the response from /oauth/token.

--- a/internal/routing/routing.go
+++ b/internal/routing/routing.go
@@ -1,6 +1,7 @@
 package routing
 
 import (
+	"math"
 	"sort"
 	"time"
 
@@ -16,6 +17,13 @@ type Candidate struct {
 	Headroom int `json:"headroom"`
 	// Utilization is the current usage percentage (0-100).
 	Utilization int `json:"utilization"`
+	// Multiplier is the premium request cost multiplier (e.g. 3.0 for expensive
+	// models on Copilot). Nil means no multiplier applies.
+	Multiplier *float64 `json:"multiplier,omitempty"`
+	// EffectiveHeadroom is headroom adjusted for multiplier cost. For providers
+	// without multipliers, this equals Headroom. For multiplier 0 (free models),
+	// this is 100. For multiplier > 0, this is headroom / multiplier, capped at 100.
+	EffectiveHeadroom int `json:"effective_headroom"`
 	// PeriodType indicates the quota window type.
 	PeriodType models.PeriodType `json:"period_type"`
 	// ResetsAt is when the quota window resets, if known.
@@ -32,18 +40,20 @@ type Recommendation struct {
 	ModelID string `json:"model_id"`
 	// ModelName is the human-readable model name.
 	ModelName string `json:"model_name"`
-	// Best is the top-ranked candidate (most headroom). Nil if no providers have data.
+	// Best is the top-ranked candidate (most effective headroom). Nil if no providers have data.
 	Best *Candidate `json:"best,omitempty"`
-	// Candidates is all providers ranked by headroom (descending).
+	// Candidates is all providers ranked by effective headroom (descending).
 	Candidates []Candidate `json:"candidates"`
 	// Unavailable lists provider IDs that offer the model but had no usage data.
 	Unavailable []string `json:"unavailable,omitempty"`
 }
 
 // Rank takes a set of provider snapshots and the list of provider IDs that
-// offer a model, and returns candidates sorted by headroom (most first).
-// Providers without successful snapshots are returned in the unavailable list.
-func Rank(providerIDs []string, snapshots map[string]ProviderData) (candidates []Candidate, unavailable []string) {
+// offer a model, and returns candidates sorted by effective headroom (most first).
+// The multipliers map provides per-provider premium request cost multipliers
+// (e.g. from Copilot). Providers without successful snapshots are returned
+// in the unavailable list.
+func Rank(providerIDs []string, snapshots map[string]ProviderData, multipliers map[string]*float64) (candidates []Candidate, unavailable []string) {
 	for _, pid := range providerIDs {
 		data, ok := snapshots[pid]
 		if !ok || data.Snapshot == nil {
@@ -52,7 +62,7 @@ func Rank(providerIDs []string, snapshots map[string]ProviderData) (candidates [
 		}
 
 		snap := data.Snapshot
-		primary := snap.PrimaryPeriod()
+		primary := snap.BottleneckPeriod()
 		if primary == nil {
 			unavailable = append(unavailable, pid)
 			continue
@@ -63,27 +73,48 @@ func Rank(providerIDs []string, snapshots map[string]ProviderData) (candidates [
 			plan = snap.Identity.Plan
 		}
 
+		headroom := primary.Remaining()
+		mult := multipliers[pid]
+		effectiveHeadroom := computeEffectiveHeadroom(headroom, mult)
+
 		candidates = append(candidates, Candidate{
-			ProviderID:  pid,
-			Headroom:    primary.Remaining(),
-			Utilization: primary.Utilization,
-			PeriodType:  primary.PeriodType,
-			ResetsAt:    primary.ResetsAt,
-			Plan:        plan,
-			Cached:      data.Cached,
+			ProviderID:        pid,
+			Headroom:          headroom,
+			Utilization:       primary.Utilization,
+			Multiplier:        mult,
+			EffectiveHeadroom: effectiveHeadroom,
+			PeriodType:        primary.PeriodType,
+			ResetsAt:          primary.ResetsAt,
+			Plan:              plan,
+			Cached:            data.Cached,
 		})
 	}
 
-	// Sort by headroom descending, then provider ID ascending for stability.
+	// Sort by effective headroom descending, then provider ID ascending for stability.
 	sort.Slice(candidates, func(i, j int) bool {
-		if candidates[i].Headroom != candidates[j].Headroom {
-			return candidates[i].Headroom > candidates[j].Headroom
+		if candidates[i].EffectiveHeadroom != candidates[j].EffectiveHeadroom {
+			return candidates[i].EffectiveHeadroom > candidates[j].EffectiveHeadroom
 		}
 		return candidates[i].ProviderID < candidates[j].ProviderID
 	})
 
 	sort.Strings(unavailable)
 	return candidates, unavailable
+}
+
+// computeEffectiveHeadroom adjusts raw headroom for multiplier cost.
+//   - nil multiplier (non-copilot): headroom is used as-is
+//   - multiplier == 0: model is free, effective headroom is 100
+//   - multiplier > 0: headroom / multiplier, capped at 100
+func computeEffectiveHeadroom(headroom int, multiplier *float64) int {
+	if multiplier == nil {
+		return headroom
+	}
+	if *multiplier == 0 {
+		return 100
+	}
+	eff := float64(headroom) / *multiplier
+	return int(math.Min(eff, 100))
 }
 
 // ProviderData bundles a snapshot with its cache status.


### PR DESCRIPTION
## Summary

Replace the hardcoded model registry with a dynamic one fetched from [models.dev](https://models.dev/api.json), add Copilot premium request multiplier-aware routing, and improve display.

### Model registry
- Fetch and cache models.dev API data to `~/.cache/vibeusage/models.json` with 24h TTL
- Build model→provider mapping dynamically with cross-provider name dedup
- Map vibeusage providers to models.dev providers (`claude`→`anthropic`, `copilot`→`github-copilot`, `codex`→`openai`, `gemini`→`google`, etc.)
- Infer providers not in models.dev (`antigravity`, `cursor`)
- Filter non-chat models (embeddings, TTS, image-gen, live/audio)
- Graceful fallback: stale cache on network failure, empty registry on cold start

### Copilot premium request multipliers
- Fetch multiplier data from `github/docs` repo [model-multipliers.yml](https://raw.githubusercontent.com/github/docs/main/data/tables/copilot/model-multipliers.yml), cache as JSON
- Effective headroom = raw headroom / multiplier (free models → 100%)
- Ranking uses effective headroom — expensive models (3x Opus) rank lower
- Route table shows Cost column (`free`/`1x`/`3x`/etc.) when multipliers apply

### Routing fix
- Use `BottleneckPeriod()` instead of `PrimaryPeriod()` — routes by the most constrained limit (e.g. weekly at 62%) not the shortest window (e.g. session at 2%)

### Display improvements
- Tables respect terminal width (no more overflow on narrow terminals)
- Route table: best row bold, unavailable providers as dim/italic rows at bottom
- `route --list`: dropped Name column, lowercase IDs, filtered to configured providers only
- Claude OAuth strategy now infers plan (Pro) from usage features