### PR TITLE
Fix overage amounts: convert cents to dollars from API responses

### DIFF
--- a/internal/provider/claude/oauth.go
+++ b/internal/provider/claude/oauth.go
@@ -229,8 +229,8 @@ func (s *OAuthStrategy) parseOAuthUsageResponse(resp OAuthUsageResponse) *models
 	var overage *models.OverageUsage
 	if resp.ExtraUsage != nil && resp.ExtraUsage.IsEnabled {
 		overage = &models.OverageUsage{
-			Used:      resp.ExtraUsage.UsedCredits,
-			Limit:     resp.ExtraUsage.MonthlyLimit,
+			Used:      resp.ExtraUsage.UsedCredits / 100.0,
+			Limit:     resp.ExtraUsage.MonthlyLimit / 100.0,
 			Currency:  "USD",
 			IsEnabled: true,
 		}

--- a/internal/provider/claude/oauth_test.go
+++ b/internal/provider/claude/oauth_test.go
@@ -35,8 +35,8 @@ func TestParseOAuthUsageResponse_FullResponse(t *testing.T) {
 		},
 		ExtraUsage: &ExtraUsageResponse{
 			IsEnabled:    true,
-			UsedCredits:  5.50,
-			MonthlyLimit: 100.0,
+			UsedCredits:  550,
+			MonthlyLimit: 10000,
 		},
 	}
 

--- a/internal/provider/claude/response.go
+++ b/internal/provider/claude/response.go
@@ -108,8 +108,8 @@ func (r *WebOverageResponse) ToOverageUsage() *models.OverageUsage {
 		return nil
 	}
 	return &models.OverageUsage{
-		Used:      r.CurrentSpend,
-		Limit:     r.HardLimit,
+		Used:      r.CurrentSpend / 100.0,
+		Limit:     r.HardLimit / 100.0,
 		Currency:  "USD",
 		IsEnabled: true,
 	}

--- a/internal/provider/claude/response_test.go
+++ b/internal/provider/claude/response_test.go
@@ -13,7 +13,7 @@ func TestOAuthUsageResponse_UnmarshalFullResponse(t *testing.T) {
 		"seven_day_sonnet": {"utilization": 60.0, "resets_at": "2025-02-26T00:00:00Z"},
 		"seven_day_opus": {"utilization": 10.0, "resets_at": "2025-02-26T00:00:00Z"},
 		"seven_day_haiku": {"utilization": 90.0, "resets_at": "2025-02-26T00:00:00Z"},
-		"extra_usage": {"is_enabled": true, "used_credits": 5.50, "monthly_limit": 100.0}
+		"extra_usage": {"is_enabled": true, "used_credits": 550, "monthly_limit": 10000}
 	}`
 
 	var resp OAuthUsageResponse
@@ -75,11 +75,11 @@ func TestOAuthUsageResponse_UnmarshalFullResponse(t *testing.T) {
 	if !resp.ExtraUsage.IsEnabled {
 		t.Error("expected extra_usage.is_enabled to be true")
 	}
-	if resp.ExtraUsage.UsedCredits != 5.50 {
-		t.Errorf("extra_usage.used_credits = %v, want 5.50", resp.ExtraUsage.UsedCredits)
+	if resp.ExtraUsage.UsedCredits != 550 {
+		t.Errorf("extra_usage.used_credits = %v, want 550", resp.ExtraUsage.UsedCredits)
 	}
-	if resp.ExtraUsage.MonthlyLimit != 100.0 {
-		t.Errorf("extra_usage.monthly_limit = %v, want 100.0", resp.ExtraUsage.MonthlyLimit)
+	if resp.ExtraUsage.MonthlyLimit != 10000 {
+		t.Errorf("extra_usage.monthly_limit = %v, want 10000", resp.ExtraUsage.MonthlyLimit)
 	}
 }
 

--- a/internal/provider/claude/web_response_test.go
+++ b/internal/provider/claude/web_response_test.go
@@ -109,8 +109,8 @@ func TestWebUsageResponse_UnmarshalZeroLimit(t *testing.T) {
 func TestWebOverageResponse_UnmarshalWithHardLimit(t *testing.T) {
 	raw := `{
 		"has_hard_limit": true,
-		"current_spend": 25.50,
-		"hard_limit": 100.0
+		"current_spend": 2550,
+		"hard_limit": 10000
 	}`
 
 	var resp WebOverageResponse
@@ -121,11 +121,11 @@ func TestWebOverageResponse_UnmarshalWithHardLimit(t *testing.T) {
 	if !resp.HasHardLimit {
 		t.Error("expected has_hard_limit to be true")
 	}
-	if resp.CurrentSpend != 25.50 {
-		t.Errorf("current_spend = %v, want 25.50", resp.CurrentSpend)
+	if resp.CurrentSpend != 2550 {
+		t.Errorf("current_spend = %v, want 2550", resp.CurrentSpend)
 	}
-	if resp.HardLimit != 100.0 {
-		t.Errorf("hard_limit = %v, want 100.0", resp.HardLimit)
+	if resp.HardLimit != 10000 {
+		t.Errorf("hard_limit = %v, want 10000", resp.HardLimit)
 	}
 }
 
@@ -400,8 +400,8 @@ func TestWebOverageResponse_ToOverageUsage(t *testing.T) {
 			name: "with hard limit",
 			resp: WebOverageResponse{
 				HasHardLimit: true,
-				CurrentSpend: 25.50,
-				HardLimit:    100.0,
+				CurrentSpend: 2550,
+				HardLimit:    10000,
 			},
 			wantNil:  false,
 			wantUsed: 25.50,

--- a/internal/provider/claude/web_test.go
+++ b/internal/provider/claude/web_test.go
@@ -81,7 +81,7 @@ func TestParseWebUsageResponse_WithOverage(t *testing.T) {
 	}
 	overage := &models.OverageUsage{
 		Used:      25.50,
-		Limit:     100.0,
+		Limit:     100.00,
 		Currency:  "USD",
 		IsEnabled: true,
 	}


### PR DESCRIPTION
The Anthropic API returns `used_credits`, `monthly_limit` (OAuth) and `current_spend`, `hard_limit` (web) in cents. Divide by 100 when converting to the internal `OverageUsage` model so display values are correct (e.g., API returns `550` → displayed as `$5.50`).