### PR TITLE
Warn on malformed config instead of silently falling back to defaults

### DIFF
--- a/IDIOMATIC_PLAN.md
+++ b/IDIOMATIC_PLAN.md
@@ -74,7 +74,7 @@ Findings from reviewing the codebase against canonical Go best practices (Effect
 
 ### 7. Warn on Malformed Config
 
-- [ ] `config.Load()`: When `toml.Decode` fails, log a warning (via the logger or return the error) instead of silently falling back to defaults
+- [x] `config.Load()`: When `toml.Decode` fails, log a warning (via the logger or return the error) instead of silently falling back to defaults
 
 ### 8. Make `modelmap` Init Explicit
 

--- a/cmd/helpers_test.go
+++ b/cmd/helpers_test.go
@@ -5,5 +5,5 @@ import "github.com/joshuadavidthomas/vibeusage/internal/config"
 // reloadConfig forces a config reload. Used by tests that modify
 // VIBEUSAGE_CONFIG_DIR via t.Setenv before exercising commands.
 func reloadConfig() {
-	config.Reload()
+	_, _ = config.Reload()
 }

--- a/cmd/init.go
+++ b/cmd/init.go
@@ -159,7 +159,8 @@ func seedDefaultRoles() {
 		// Non-fatal — roles are a convenience, not a requirement.
 		return
 	}
-	config.Reload()
+	// We just saved this config, so a parse error here would be unexpected.
+	_, _ = config.Reload()
 
 	outln()
 	outln("  Default roles added to config:")

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -53,6 +53,11 @@ var rootCmd = &cobra.Command{
 		l := newConfiguredLogger()
 		ctx := logging.WithLogger(cmd.Context(), l)
 		cmd.SetContext(ctx)
+
+		// Eagerly load config so malformed files surface a warning.
+		if _, err := config.Reload(); err != nil {
+			l.Warn("config file is malformed, using defaults", "err", err)
+		}
 	},
 	RunE: runDefaultUsage,
 }


### PR DESCRIPTION
## Summary

`config.Load()` previously silently discarded TOML parse errors and returned defaults with no indication to the user that their config file was malformed. This change surfaces those errors.

## Changes

- **`config.Load()`** now returns `(Config, error)` — defaults + a wrapped error when `toml.Decode` fails
- **`config.Reload()`** also returns `(Config, error)` so callers can surface the warning
- **`config.Get()`** stays returning just `Config` (lazy init, discards error)
- **Root command `PersistentPreRun`** eagerly loads config and logs a warning via `charmbracelet/log` when the file is malformed
- Updated all callers and tests (TDD red/green)

Completes IDIOMATIC_PLAN.md Phase 7, item 1.