### PR TITLE
refactor: move credential system into provider interface

### DIFF
--- a/FIXIT_PLAN.md
+++ b/FIXIT_PLAN.md
@@ -55,17 +55,17 @@ Adding a provider means updating both the provider package AND the credential ma
 
 Move credential knowledge into the provider interface. Each provider already knows its credential paths (strategy `IsAvailable()` checks them) and env vars.
 
-- [ ] Add `CredentialSources() CredentialInfo` to the `Provider` interface (or a new optional interface)
+- [x] Add `CredentialSources() CredentialInfo` to the `Provider` interface (or a new optional interface)
   ```go
   type CredentialInfo struct {
       CLIPaths []string // e.g. {"~/.claude/.credentials.json"}
       EnvVar   string   // e.g. "ANTHROPIC_API_KEY"
   }
   ```
-- [ ] Implement on each provider
-- [ ] Replace `ProviderCLIPaths` / `ProviderEnvVars` maps with calls to the registry
-- [ ] `IsFirstRun()`, `CountConfiguredProviders()`, `GetAllCredentialStatus()` iterate `provider.All()` instead of a hardcoded map
-- [ ] Delete the maps from `config/credentials.go`
+- [x] Implement on each provider
+- [x] Replace `ProviderCLIPaths` / `ProviderEnvVars` maps with calls to the registry
+- [x] `IsFirstRun()`, `CountConfiguredProviders()`, `GetAllCredentialStatus()` iterate `provider.All()` instead of a hardcoded map
+- [x] Delete the maps from `config/credentials.go`
 
 ## 3. Test file organization in `internal/cli/`
 

--- a/internal/cli/auth.go
+++ b/internal/cli/auth.go
@@ -46,7 +46,7 @@ func authStatusCommand() error {
 	if jsonOutput {
 		data := make(map[string]display.AuthStatusEntryJSON)
 		for _, pid := range allProviders {
-			hasCreds, source := config.CheckProviderCredentials(pid)
+			hasCreds, source := provider.CheckCredentials(pid)
 			data[pid] = display.AuthStatusEntryJSON{
 				Authenticated: hasCreds,
 				Source:        sourceToLabel(source),
@@ -57,7 +57,7 @@ func authStatusCommand() error {
 
 	if quiet {
 		for _, pid := range allProviders {
-			hasCreds, _ := config.CheckProviderCredentials(pid)
+			hasCreds, _ := provider.CheckCredentials(pid)
 			status := "not configured"
 			if hasCreds {
 				status = "authenticated"
@@ -70,7 +70,7 @@ func authStatusCommand() error {
 	var rows [][]string
 	var unconfigured []string
 	for _, pid := range allProviders {
-		hasCreds, source := config.CheckProviderCredentials(pid)
+		hasCreds, source := provider.CheckCredentials(pid)
 		if hasCreds {
 			rows = append(rows, []string{pid, "✓ Authenticated", sourceToLabel(source)})
 		} else {
@@ -121,7 +121,7 @@ func authProvider(providerID string, p provider.Provider) error {
 
 // authDeviceFlow runs an OAuth/device-code flow with re-auth check.
 func authDeviceFlow(providerID string, flow provider.DeviceAuthFlow) error {
-	hasCreds, source := config.CheckProviderCredentials(providerID)
+	hasCreds, source := provider.CheckCredentials(providerID)
 	if hasCreds && !quiet {
 		out("✓ %s is already authenticated (%s)\n",
 			strutil.TitleCase(providerID), sourceToLabel(source))
@@ -149,7 +149,7 @@ func authDeviceFlow(providerID string, flow provider.DeviceAuthFlow) error {
 
 // authManualKey runs an interactive manual-key input flow.
 func authManualKey(providerID string, flow provider.ManualKeyAuthFlow) error {
-	hasCreds, source := config.CheckProviderCredentials(providerID)
+	hasCreds, source := provider.CheckCredentials(providerID)
 	if hasCreds && !quiet {
 		out("✓ %s is already authenticated (%s)\n",
 			strutil.TitleCase(providerID), sourceToLabel(source))
@@ -192,7 +192,7 @@ func authManualKey(providerID string, flow provider.ManualKeyAuthFlow) error {
 }
 
 func authGeneric(providerID string) error {
-	hasCreds, source := config.CheckProviderCredentials(providerID)
+	hasCreds, source := provider.CheckCredentials(providerID)
 
 	if hasCreds {
 		if !quiet {

--- a/internal/cli/init.go
+++ b/internal/cli/init.go
@@ -28,8 +28,8 @@ var initCmd = &cobra.Command{
 
 		if jsonOutput {
 			return display.OutputJSON(outWriter, display.InitStatusJSON{
-				FirstRun:            config.IsFirstRun(),
-				ConfiguredProviders: config.CountConfiguredProviders(),
+				FirstRun:            provider.IsFirstRun(),
+				ConfiguredProviders: provider.CountConfigured(),
 				AvailableProviders:  provider.ListIDs(),
 			})
 		}
@@ -56,7 +56,7 @@ func quickSetup() error {
 	outln("Claude is the most popular AI assistant for agentic workflows.")
 	outln()
 
-	hasCreds, _ := config.CheckProviderCredentials("claude")
+	hasCreds, _ := provider.CheckCredentials("claude")
 	if hasCreds {
 		outln("✓ Claude is already configured!")
 		outln("\nRun 'vibeusage' to see your usage.")
@@ -88,7 +88,7 @@ func interactiveWizard() error {
 	// Build options for multi-select
 	options := make([]prompt.SelectOption, 0, len(allProviders))
 	for _, pid := range allProviders {
-		hasCreds, _ := config.CheckProviderCredentials(pid)
+		hasCreds, _ := provider.CheckCredentials(pid)
 		status := ""
 		if hasCreds {
 			status = "✓ "
@@ -121,7 +121,7 @@ func interactiveWizard() error {
 	out("\nSet up %d provider(s):\n\n", len(selected))
 
 	for _, pid := range selected {
-		hasCreds, _ := config.CheckProviderCredentials(pid)
+		hasCreds, _ := provider.CheckCredentials(pid)
 		if hasCreds {
 			out("  ✓ %s already configured\n", pid)
 		} else {

--- a/internal/cli/key.go
+++ b/internal/cli/key.go
@@ -11,6 +11,7 @@ import (
 	"github.com/joshuadavidthomas/vibeusage/internal/config"
 	"github.com/joshuadavidthomas/vibeusage/internal/display"
 	"github.com/joshuadavidthomas/vibeusage/internal/prompt"
+	"github.com/joshuadavidthomas/vibeusage/internal/provider"
 	"github.com/joshuadavidthomas/vibeusage/internal/strutil"
 )
 
@@ -29,7 +30,7 @@ func init() {
 }
 
 func displayAllCredentialStatus() error {
-	allStatus := config.GetAllCredentialStatus()
+	allStatus := provider.GetAllCredentialStatus()
 
 	if jsonOutput {
 		data := make(map[string]display.KeyStatusEntryJSON)
@@ -114,7 +115,7 @@ func makeKeyProviderCmd(providerID string) *cobra.Command {
 		Use:   providerID,
 		Short: fmt.Sprintf("Manage %s credentials", titleName),
 		RunE: func(cmd *cobra.Command, args []string) error {
-			found, source, path := config.FindProviderCredential(providerID)
+			found, source, path := provider.FindCredential(providerID)
 
 			if jsonOutput {
 				return display.OutputJSON(outWriter, display.KeyDetailJSON{

--- a/internal/cli/root.go
+++ b/internal/cli/root.go
@@ -101,7 +101,7 @@ func runDefaultUsage(cmd *cobra.Command, args []string) error {
 		return nil
 	}
 
-	if config.IsFirstRun() && !jsonOutput && !quiet {
+	if provider.IsFirstRun() && !jsonOutput && !quiet {
 		showFirstRunMessage()
 		return nil
 	}

--- a/internal/cli/status_test.go
+++ b/internal/cli/status_test.go
@@ -268,6 +268,10 @@ func (s *statusStubProvider) Meta() provider.Metadata {
 	return provider.Metadata{ID: s.id, Name: s.id}
 }
 
+func (s *statusStubProvider) CredentialSources() provider.CredentialInfo {
+	return provider.CredentialInfo{}
+}
+
 func (s *statusStubProvider) FetchStrategies() []fetch.Strategy {
 	return nil
 }

--- a/internal/provider/antigravity/antigravity.go
+++ b/internal/provider/antigravity/antigravity.go
@@ -32,6 +32,13 @@ func (a Antigravity) Meta() provider.Metadata {
 	}
 }
 
+func (a Antigravity) CredentialSources() provider.CredentialInfo {
+	return provider.CredentialInfo{
+		CLIPaths: []string{"~/.config/Antigravity/credentials.json"},
+		EnvVars:  []string{"ANTIGRAVITY_API_KEY"},
+	}
+}
+
 func (a Antigravity) FetchStrategies() []fetch.Strategy {
 	timeout := config.Get().Fetch.Timeout
 	return []fetch.Strategy{

--- a/internal/provider/claude/claude.go
+++ b/internal/provider/claude/claude.go
@@ -30,6 +30,13 @@ func (c Claude) Meta() provider.Metadata {
 	}
 }
 
+func (c Claude) CredentialSources() provider.CredentialInfo {
+	return provider.CredentialInfo{
+		CLIPaths: []string{"~/.claude/.credentials.json"},
+		EnvVars:  []string{"ANTHROPIC_API_KEY"},
+	}
+}
+
 func (c Claude) FetchStrategies() []fetch.Strategy {
 	timeout := config.Get().Fetch.Timeout
 	return []fetch.Strategy{

--- a/internal/provider/codex/codex.go
+++ b/internal/provider/codex/codex.go
@@ -29,6 +29,13 @@ func (c Codex) Meta() provider.Metadata {
 	}
 }
 
+func (c Codex) CredentialSources() provider.CredentialInfo {
+	return provider.CredentialInfo{
+		CLIPaths: []string{"~/.codex/auth.json"},
+		EnvVars:  []string{"OPENAI_API_KEY"},
+	}
+}
+
 func (c Codex) FetchStrategies() []fetch.Strategy {
 	timeout := config.Get().Fetch.Timeout
 	return []fetch.Strategy{&OAuthStrategy{HTTPTimeout: timeout}}

--- a/internal/provider/copilot/copilot.go
+++ b/internal/provider/copilot/copilot.go
@@ -28,6 +28,13 @@ func (c Copilot) Meta() provider.Metadata {
 	}
 }
 
+func (c Copilot) CredentialSources() provider.CredentialInfo {
+	return provider.CredentialInfo{
+		CLIPaths: []string{"~/.config/github-copilot/hosts.json"},
+		EnvVars:  []string{"GITHUB_TOKEN"},
+	}
+}
+
 func (c Copilot) FetchStrategies() []fetch.Strategy {
 	timeout := config.Get().Fetch.Timeout
 	return []fetch.Strategy{&DeviceFlowStrategy{HTTPTimeout: timeout}}

--- a/internal/provider/credentials_test.go
+++ b/internal/provider/credentials_test.go
@@ -1,0 +1,248 @@
+package provider
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/joshuadavidthomas/vibeusage/internal/config"
+)
+
+// withIsolatedRegistry replaces the global registry for the duration of
+// the test and restores it on cleanup.
+func withIsolatedRegistry(t *testing.T) {
+	t.Helper()
+	orig := registry
+	registry = map[string]Provider{}
+	t.Cleanup(func() { registry = orig })
+}
+
+// withTempCredentialDir points vibeusage credential storage at a temp
+// directory so tests don't touch real files.
+func withTempCredentialDir(t *testing.T) {
+	t.Helper()
+	dir := t.TempDir()
+	t.Setenv("VIBEUSAGE_CONFIG_DIR", filepath.Join(dir, "config"))
+	t.Setenv("VIBEUSAGE_CACHE_DIR", filepath.Join(dir, "cache"))
+	// Force config reload so paths pick up the new env.
+	if _, err := config.Reload(); err != nil {
+		t.Fatalf("config.Reload: %v", err)
+	}
+}
+
+func TestFindCredential_VibeusageStorage(t *testing.T) {
+	withIsolatedRegistry(t)
+	withTempCredentialDir(t)
+
+	Register(&stubProvider{
+		id:    "testprov",
+		creds: CredentialInfo{EnvVars: []string{"TEST_KEY"}},
+	})
+
+	credPath := config.CredentialPath("testprov", "oauth")
+	if err := config.WriteCredential(credPath, []byte(`{"token":"x"}`)); err != nil {
+		t.Fatalf("WriteCredential: %v", err)
+	}
+
+	found, source, path := FindCredential("testprov")
+	if !found {
+		t.Fatal("expected credential to be found")
+	}
+	if source != "vibeusage" {
+		t.Errorf("source = %q, want vibeusage", source)
+	}
+	if path != credPath {
+		t.Errorf("path = %q, want %q", path, credPath)
+	}
+}
+
+func TestFindCredential_EnvVar(t *testing.T) {
+	withIsolatedRegistry(t)
+	withTempCredentialDir(t)
+
+	Register(&stubProvider{
+		id:    "testprov",
+		creds: CredentialInfo{EnvVars: []string{"MY_TEST_KEY"}},
+	})
+
+	t.Setenv("MY_TEST_KEY", "secret")
+
+	found, source, _ := FindCredential("testprov")
+	if !found {
+		t.Fatal("expected credential to be found via env var")
+	}
+	if source != "env" {
+		t.Errorf("source = %q, want env", source)
+	}
+}
+
+func TestFindCredential_UnknownProvider(t *testing.T) {
+	withIsolatedRegistry(t)
+	withTempCredentialDir(t)
+
+	found, source, path := FindCredential("nonexistent")
+	if found {
+		t.Error("expected no credential for unknown provider")
+	}
+	if source != "" {
+		t.Errorf("source = %q, want empty", source)
+	}
+	if path != "" {
+		t.Errorf("path = %q, want empty", path)
+	}
+}
+
+func TestFindCredential_VibeusageTakesPrecedenceOverEnv(t *testing.T) {
+	withIsolatedRegistry(t)
+	withTempCredentialDir(t)
+
+	Register(&stubProvider{
+		id:    "testprov",
+		creds: CredentialInfo{EnvVars: []string{"MY_TEST_KEY"}},
+	})
+
+	t.Setenv("MY_TEST_KEY", "secret")
+	credPath := config.CredentialPath("testprov", "session")
+	_ = config.WriteCredential(credPath, []byte(`{"key":"val"}`))
+
+	_, source, _ := FindCredential("testprov")
+	if source != "vibeusage" {
+		t.Errorf("vibeusage storage should take precedence, got source = %q", source)
+	}
+}
+
+func TestFindCredential_CLIPaths(t *testing.T) {
+	withIsolatedRegistry(t)
+	withTempCredentialDir(t)
+
+	// Create a fake CLI credential file
+	cliDir := t.TempDir()
+	cliFile := filepath.Join(cliDir, "creds.json")
+	if err := os.WriteFile(cliFile, []byte(`{}`), 0o600); err != nil {
+		t.Fatalf("WriteFile: %v", err)
+	}
+
+	Register(&stubProvider{
+		id:    "testprov",
+		creds: CredentialInfo{CLIPaths: []string{cliFile}},
+	})
+
+	// Enable reuse of provider credentials
+	cfg := config.Get()
+	cfg.Credentials.ReuseProviderCredentials = true
+	if err := config.Save(cfg, ""); err != nil {
+		t.Fatalf("config.Save: %v", err)
+	}
+	if _, err := config.Reload(); err != nil {
+		t.Fatalf("config.Reload: %v", err)
+	}
+
+	found, source, _ := FindCredential("testprov")
+	if !found {
+		t.Fatal("expected credential to be found via CLI path")
+	}
+	if source != "provider_cli" {
+		t.Errorf("source = %q, want provider_cli", source)
+	}
+}
+
+func TestCheckCredentials(t *testing.T) {
+	withIsolatedRegistry(t)
+	withTempCredentialDir(t)
+
+	Register(&stubProvider{id: "prov1"})
+	Register(&stubProvider{
+		id:    "prov2",
+		creds: CredentialInfo{EnvVars: []string{"PROV2_KEY"}},
+	})
+
+	// prov1 has no credentials
+	hasCreds, _ := CheckCredentials("prov1")
+	if hasCreds {
+		t.Error("prov1 should not have credentials")
+	}
+
+	// prov2 via env
+	t.Setenv("PROV2_KEY", "secret")
+	hasCreds, source := CheckCredentials("prov2")
+	if !hasCreds {
+		t.Error("prov2 should have credentials")
+	}
+	if source != "env" {
+		t.Errorf("source = %q, want env", source)
+	}
+}
+
+func TestGetAllCredentialStatus(t *testing.T) {
+	withIsolatedRegistry(t)
+	withTempCredentialDir(t)
+
+	Register(&stubProvider{id: "alpha"})
+	Register(&stubProvider{id: "beta"})
+
+	_ = config.WriteCredential(config.CredentialPath("alpha", "oauth"), []byte(`{}`))
+
+	status := GetAllCredentialStatus()
+
+	if len(status) != 2 {
+		t.Fatalf("expected 2 entries, got %d", len(status))
+	}
+	if !status["alpha"].HasCredentials {
+		t.Error("alpha should have credentials")
+	}
+	if status["beta"].HasCredentials {
+		t.Error("beta should not have credentials")
+	}
+}
+
+func TestIsFirstRun_NoCreds(t *testing.T) {
+	withIsolatedRegistry(t)
+	withTempCredentialDir(t)
+
+	Register(&stubProvider{id: "prov1"})
+	Register(&stubProvider{id: "prov2"})
+
+	if !IsFirstRun() {
+		t.Error("IsFirstRun should be true when no credentials exist")
+	}
+}
+
+func TestIsFirstRun_WithCreds(t *testing.T) {
+	withIsolatedRegistry(t)
+	withTempCredentialDir(t)
+
+	Register(&stubProvider{id: "prov1"})
+
+	_ = config.WriteCredential(config.CredentialPath("prov1", "apikey"), []byte(`{}`))
+
+	if IsFirstRun() {
+		t.Error("IsFirstRun should be false when credentials exist")
+	}
+}
+
+func TestCountConfigured_None(t *testing.T) {
+	withIsolatedRegistry(t)
+	withTempCredentialDir(t)
+
+	Register(&stubProvider{id: "prov1"})
+
+	if got := CountConfigured(); got != 0 {
+		t.Errorf("CountConfigured() = %d, want 0", got)
+	}
+}
+
+func TestCountConfigured_Some(t *testing.T) {
+	withIsolatedRegistry(t)
+	withTempCredentialDir(t)
+
+	Register(&stubProvider{id: "prov1"})
+	Register(&stubProvider{id: "prov2"})
+	Register(&stubProvider{id: "prov3"})
+
+	_ = config.WriteCredential(config.CredentialPath("prov1", "oauth"), []byte(`{}`))
+	_ = config.WriteCredential(config.CredentialPath("prov3", "session"), []byte(`{}`))
+
+	if got := CountConfigured(); got != 2 {
+		t.Errorf("CountConfigured() = %d, want 2", got)
+	}
+}

--- a/internal/provider/cursor/cursor.go
+++ b/internal/provider/cursor/cursor.go
@@ -29,6 +29,12 @@ func (c Cursor) Meta() provider.Metadata {
 	}
 }
 
+func (c Cursor) CredentialSources() provider.CredentialInfo {
+	return provider.CredentialInfo{
+		EnvVars: []string{"CURSOR_API_KEY"},
+	}
+}
+
 func (c Cursor) FetchStrategies() []fetch.Strategy {
 	timeout := config.Get().Fetch.Timeout
 	return []fetch.Strategy{&WebStrategy{HTTPTimeout: timeout}}

--- a/internal/provider/gemini/gemini.go
+++ b/internal/provider/gemini/gemini.go
@@ -31,6 +31,13 @@ func (g Gemini) Meta() provider.Metadata {
 	}
 }
 
+func (g Gemini) CredentialSources() provider.CredentialInfo {
+	return provider.CredentialInfo{
+		CLIPaths: []string{"~/.gemini/oauth_creds.json"},
+		EnvVars:  []string{"GEMINI_API_KEY"},
+	}
+}
+
 func (g Gemini) FetchStrategies() []fetch.Strategy {
 	timeout := config.Get().Fetch.Timeout
 	return []fetch.Strategy{

--- a/internal/provider/kimi/kimi.go
+++ b/internal/provider/kimi/kimi.go
@@ -29,6 +29,13 @@ func (k Kimi) Meta() provider.Metadata {
 	}
 }
 
+func (k Kimi) CredentialSources() provider.CredentialInfo {
+	return provider.CredentialInfo{
+		CLIPaths: []string{"~/.kimi/credentials/kimi-code.json"},
+		EnvVars:  []string{"KIMI_CODE_API_KEY"},
+	}
+}
+
 func (k Kimi) FetchStrategies() []fetch.Strategy {
 	timeout := config.Get().Fetch.Timeout
 	return []fetch.Strategy{

--- a/internal/provider/minimax/minimax.go
+++ b/internal/provider/minimax/minimax.go
@@ -26,6 +26,12 @@ func (m Minimax) Meta() provider.Metadata {
 	}
 }
 
+func (m Minimax) CredentialSources() provider.CredentialInfo {
+	return provider.CredentialInfo{
+		EnvVars: []string{"MINIMAX_API_KEY"},
+	}
+}
+
 func (m Minimax) FetchStrategies() []fetch.Strategy {
 	timeout := config.Get().Fetch.Timeout
 	return []fetch.Strategy{

--- a/internal/provider/provider.go
+++ b/internal/provider/provider.go
@@ -3,6 +3,7 @@ package provider
 import (
 	"context"
 
+	"github.com/joshuadavidthomas/vibeusage/internal/config"
 	"github.com/joshuadavidthomas/vibeusage/internal/fetch"
 	"github.com/joshuadavidthomas/vibeusage/internal/models"
 )
@@ -16,8 +17,18 @@ type Metadata struct {
 	DashboardURL string
 }
 
+// CredentialInfo describes where a provider's credentials can be found
+// outside of vibeusage's own storage.
+type CredentialInfo struct {
+	// CLIPaths are external CLI credential file paths (e.g. ~/.claude/.credentials.json).
+	CLIPaths []string
+	// EnvVars are environment variable names (e.g. ANTHROPIC_API_KEY).
+	EnvVars []string
+}
+
 type Provider interface {
 	Meta() Metadata
+	CredentialSources() CredentialInfo
 	FetchStrategies() []fetch.Strategy
 	FetchStatus(ctx context.Context) models.ProviderStatus
 }
@@ -66,4 +77,62 @@ func ConfiguredIDs(providerIDs []string) []string {
 		}
 	}
 	return result
+}
+
+// FindCredential checks for credentials for the given provider in
+// vibeusage storage, provider CLI paths, and environment variables.
+// Returns (found, source, path).
+func FindCredential(providerID string) (bool, string, string) {
+	p, ok := Get(providerID)
+	if !ok {
+		return false, "", ""
+	}
+	info := p.CredentialSources()
+	return config.FindProviderCredential(providerID, info.CLIPaths, info.EnvVars)
+}
+
+// CheckCredentials reports whether the given provider has credentials
+// and where they came from.
+func CheckCredentials(providerID string) (bool, string) {
+	found, source, _ := FindCredential(providerID)
+	return found, source
+}
+
+// GetAllCredentialStatus returns the credential status for every
+// registered provider.
+func GetAllCredentialStatus() map[string]config.CredentialStatus {
+	all := All()
+	status := make(map[string]config.CredentialStatus, len(all))
+	for id := range all {
+		hasCreds, source := CheckCredentials(id)
+		status[id] = config.CredentialStatus{
+			HasCredentials: hasCreds,
+			Source:         source,
+		}
+	}
+	return status
+}
+
+// IsFirstRun returns true if no registered provider has credentials.
+func IsFirstRun() bool {
+	for id := range All() {
+		hasCreds, _ := CheckCredentials(id)
+		if hasCreds {
+			return false
+		}
+	}
+	return true
+}
+
+// CountConfigured returns the number of registered providers that
+// have credentials.
+func CountConfigured() int {
+	count := 0
+	for id := range All() {
+		hasCreds, _ := CheckCredentials(id)
+		if hasCreds {
+			count++
+		}
+	}
+	return count
 }

--- a/internal/provider/provider_test.go
+++ b/internal/provider/provider_test.go
@@ -12,10 +12,15 @@ import (
 type stubProvider struct {
 	id         string
 	strategies []fetch.Strategy
+	creds      CredentialInfo
 }
 
 func (s *stubProvider) Meta() Metadata {
 	return Metadata{ID: s.id, Name: s.id}
+}
+
+func (s *stubProvider) CredentialSources() CredentialInfo {
+	return s.creds
 }
 
 func (s *stubProvider) FetchStrategies() []fetch.Strategy {

--- a/internal/provider/zai/zai.go
+++ b/internal/provider/zai/zai.go
@@ -26,6 +26,12 @@ func (z Zai) Meta() provider.Metadata {
 	}
 }
 
+func (z Zai) CredentialSources() provider.CredentialInfo {
+	return provider.CredentialInfo{
+		EnvVars: []string{"ZAI_API_KEY"},
+	}
+}
+
 func (z Zai) FetchStrategies() []fetch.Strategy {
 	timeout := config.Get().Fetch.Timeout
 	return []fetch.Strategy{


### PR DESCRIPTION
## Summary

Move credential knowledge (CLI paths, env vars) from hardcoded maps in `config/credentials.go` into each provider via a new `CredentialSources()` method on the `Provider` interface.

## What changed

### Provider interface
- Added `CredentialInfo` struct with `CLIPaths` and `EnvVars` fields
- Added `CredentialSources()` to the `Provider` interface
- Implemented on all 9 providers (antigravity, claude, codex, copilot, cursor, gemini, kimi, minimax, zai)

### Credential lookup
- `config.FindProviderCredential()` now takes CLI paths and env vars as parameters instead of reading from hardcoded maps
- New convenience functions on `provider` package: `FindCredential`, `CheckCredentials`, `GetAllCredentialStatus`, `IsFirstRun`, `CountConfigured`

### Deleted
- `config.ProviderCLIPaths` map
- `config.ProviderEnvVars` map
- `config.CheckProviderCredentials()`
- `config.GetAllCredentialStatus()`
- `config.IsFirstRun()`
- `config.CountConfiguredProviders()`

### CLI callers updated
- `auth.go`, `init.go`, `key.go`, `root.go` now use `provider.CheckCredentials()`, `provider.IsFirstRun()`, etc.

## Motivation

Adding a provider previously required updating both the provider package AND the credential maps in `config/credentials.go`. Now credential knowledge lives in a single place: the provider's `CredentialSources()` method.

Completes FIXIT_PLAN.md Phase 2.