### PR TITLE
fix: exhausted quota (100%) is always red regardless of pace

### DIFF
--- a/internal/models/models.go
+++ b/internal/models/models.go
@@ -216,6 +216,10 @@ func formatHM(h, m int) string { return strconv.Itoa(h) + "h " + strconv.Itoa(m)
 func formatM(m int) string     { return strconv.Itoa(m) + "m" }
 
 func PaceToColor(paceRatio *float64, utilization int) string {
+	// Exhausted quota is always red — you're blocked regardless of pace.
+	if utilization >= 100 {
+		return "red"
+	}
 	if paceRatio == nil {
 		if utilization < 50 {
 			return "green"

--- a/internal/models/models_test.go
+++ b/internal/models/models_test.go
@@ -608,6 +608,12 @@ func TestPaceToColor(t *testing.T) {
 		{"pace 1.30 yellow boundary", pf(1.30), 70, "yellow"},
 		{"pace 1.31 red", pf(1.31), 70, "red"},
 		{"pace 2.0 red", pf(2.0), 80, "red"},
+
+		// exhausted quota — always red regardless of pace
+		// at 100% you're blocked; "on pace" is irrelevant
+		{"pace 1.0 util 100 red", pf(1.0), 100, "red"},
+		{"pace 1.05 util 100 red", pf(1.05), 100, "red"},
+		{"pace 0.5 util 100 red", pf(0.5), 100, "red"},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {


### PR DESCRIPTION
## Bug

Codex (and any provider) showing 100% utilization was colored green when the pace ratio happened to be ≤ 1.15. For example: 100% utilization at 90% elapsed gives `paceRatio = 100/90 ≈ 1.11` → green.

## Root cause

`PaceToColor` with a non-nil `paceRatio` only evaluated the ratio, never the utilization. The pace ratio answers _"are you burning faster than expected?"_ — at 100% utilization that question is moot because you've hit the hard limit and can't make more requests until the window resets.

## Fix

One guard at the top of `PaceToColor`:

```go
if utilization >= 100 {
    return "red"
}
```

This is consistent with the `paceRatio == nil` branch, which already returns red for `utilization >= 80`.