### PR TITLE
fix: zai period labels match what the website shows

### DIFF
--- a/internal/provider/zai/zai_test.go
+++ b/internal/provider/zai/zai_test.go
@@ -91,8 +91,8 @@ func TestParseQuotaResponse_PeriodFields(t *testing.T) {
 	}
 
 	p := snapshot.Periods[0]
-	if p.Name != "Token Quota" {
-		t.Errorf("Name = %q, want %q", p.Name, "Token Quota")
+	if p.Name != "Session (5h)" {
+		t.Errorf("Name = %q, want %q", p.Name, "Session (5h)")
 	}
 	if p.Utilization != 75 {
 		t.Errorf("Utilization = %d, want 75", p.Utilization)


### PR DESCRIPTION
Two display name mismatches corrected.

## Before / After

| Limit type | Website | Before | After |
|---|---|---|---|
| `TOKENS_LIMIT` (unit=hours, number=5) | "5 Hours Quota" | "Token Quota" | **"Session (5h)"** |
| `TIME_LIMIT` (unit=months) | "Monthly Web Search / Reader / Zread Quota" | "MCP Usage" | **"Monthly Tools"** |

## Why each was wrong

**TOKENS_LIMIT → "Session (5h)":** The Z.ai website calls this "5 Hours Quota", which is better than "Token Quota", but the right label is "Session (5h)" — the same convention Claude and Antigravity already use for their rolling session periods. Consistent across providers, and still conveys the window length.

For non-hourly token windows (days, months) it falls back to a period-prefixed label like "Monthly Quota".

**TIME_LIMIT → "Monthly Tools":** These are Z.ai web tools (`search-prime`, `web-reader`, `zread`), not MCP protocol tools. The name now derives from the period so "Daily Tools" also works if the window ever changes.