### PR TITLE
fix: near-exhaustion (≥90%) is always at least yellow regardless of pace

### DIFF
--- a/internal/models/models.go
+++ b/internal/models/models.go
@@ -229,6 +229,16 @@ func PaceToColor(paceRatio *float64, utilization int) string {
 		}
 		return "red"
 	}
+	// Near-exhaustion floor: ≥90% utilization is always at least yellow.
+	// Pace ratio captures burn rate, not how much budget remains. At 90%+
+	// you have ≤10% left regardless of pace, which warrants a caution signal.
+	// Pace can still escalate near-exhaustion to red, but not rescue it to green.
+	if utilization >= 90 {
+		if *paceRatio > 1.15 {
+			return "red"
+		}
+		return "yellow"
+	}
 	if *paceRatio <= 1.15 {
 		return "green"
 	}

--- a/internal/models/models_test.go
+++ b/internal/models/models_test.go
@@ -614,6 +614,15 @@ func TestPaceToColor(t *testing.T) {
 		{"pace 1.0 util 100 red", pf(1.0), 100, "red"},
 		{"pace 1.05 util 100 red", pf(1.05), 100, "red"},
 		{"pace 0.5 util 100 red", pf(0.5), 100, "red"},
+
+		// near-exhaustion (≥90%) floor — pace can escalate to red but not rescue to green
+		// e.g. 99% at 86% elapsed = paceRatio 1.149 (just under 1.15), must be yellow not green
+		{"pace 1.0 util 90 yellow", pf(1.0), 90, "yellow"},
+		{"pace 1.0 util 99 yellow", pf(1.0), 99, "yellow"},
+		{"pace 0.5 util 95 yellow", pf(0.5), 95, "yellow"},
+		{"pace 1.149 util 99 yellow", pf(1.149), 99, "yellow"},
+		{"pace 1.16 util 92 red", pf(1.16), 92, "red"},
+		{"pace 2.0 util 90 red", pf(2.0), 90, "red"},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {


### PR DESCRIPTION
## Bug

Claude Weekly showing 99% utilization with 23h13m until reset displayed as **green**.

## Why it happened

`PaceToColor` with a non-nil `paceRatio` evaluated the ratio alone:

```
elapsed     = (168 - 23.22) / 168 = 86.18%
paceRatio   = 99 / 86.18 = 1.1487
threshold   = ≤1.15 → green   (misses by 0.0013)
```

The pace ratio answers _"are you burning faster than expected?"_ — a useful signal, but it says nothing about how much budget remains. At 99% utilization with a day to go, you have 1% left. That's a caution signal regardless of burn rate.

## Fix

```
utilization ≥ 90%  →  at minimum yellow
             pace can still escalate to red (paceRatio > 1.15)
             pace cannot rescue it to green
```

The 90% threshold means "≤10% of budget remaining" — meaningful regardless of how long the window lasts or how quickly you got there.

## Color matrix after fix

| Utilization | paceRatio | Before | After |
|---|---|---|---|
| 99% | 1.149 | 🟢 green | 🟡 yellow |
| 90% | 1.0 | 🟢 green | 🟡 yellow |
| 95% | 0.5 | 🟢 green | 🟡 yellow |
| 92% | 1.16 | 🟡 yellow | 🔴 red |
| 60% | 1.0 | 🟢 green | 🟢 green (unchanged) |
| 100% | any | 🔴 red | 🔴 red (unchanged) |