### PR TITLE
explicit modelmap init and yaml.v3 multiplier parser

### DIFF
--- a/IDIOMATIC_PLAN.md
+++ b/IDIOMATIC_PLAN.md
@@ -80,8 +80,8 @@ Findings from reviewing the codebase against canonical Go best practices (Effect
 
 > *"Dependencies are passed explicitly, granting the caller complete control."*
 
-- [ ] Consider making the initial `models.dev` fetch explicit (called during startup with spinner feedback) rather than lazy-loading on first `Lookup()` with no user feedback
-- [ ] Replace hand-rolled YAML parser in `multipliers.go` with a proper YAML library
+- [x] Consider making the initial `models.dev` fetch explicit (called during startup with spinner feedback) rather than lazy-loading on first `Lookup()` with no user feedback
+- [x] Replace hand-rolled YAML parser in `multipliers.go` with a proper YAML library
 
 ### 9. Reduce Display Logic Duplication in `cmd/route.go`
 

--- a/go.mod
+++ b/go.mod
@@ -14,6 +14,7 @@ require (
 	github.com/muesli/termenv v0.16.0
 	github.com/spf13/cobra v1.10.2
 	google.golang.org/protobuf v1.36.11
+	gopkg.in/yaml.v3 v3.0.1
 )
 
 require (

--- a/go.sum
+++ b/go.sum
@@ -96,6 +96,7 @@ golang.org/x/text v0.23.0 h1:D71I7dUrlY+VX0gQShAThNGHFxZ13dGLBHQLVl1mJlY=
 golang.org/x/text v0.23.0/go.mod h1:/BLNzu4aZCJ1+kcD0DNRotWKage4q2rGVAg4o22unh4=
 google.golang.org/protobuf v1.36.11 h1:fV6ZwhNocDyBLK0dj+fg8ektcVegBBuEolpbTQyBNVE=
 google.golang.org/protobuf v1.36.11/go.mod h1:HTf+CrKn2C3g5S8VImy6tdcUvCska2kB7j23XfzDpco=
+gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405 h1:yhCVgyC4o1eVCa2tZl7eS0r+SDo693bJlVdllGtEeKM=
 gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=
 gopkg.in/yaml.v3 v3.0.1 h1:fxVm/GzAzEWqLHuvctI91KS9hhNmmWOoWu0XTYJS7CA=
 gopkg.in/yaml.v3 v3.0.1/go.mod h1:K4uyk7z7BCEPqu6E+C64Yfv1cQ7kz7rIZviUmN+EgEM=


### PR DESCRIPTION
## What

Implements IDIOMATIC_PLAN.md Phase 8 — the two remaining unchecked items.

### Make modelmap init explicit

Previously `modelmap.Lookup` (and friends) silently triggered a `models.dev` network fetch on first call via `sync.Once`, with no user feedback. If the cache was stale, the `route` command would silently hang for up to 15 seconds.

- Added `modelmap.Preload(ctx context.Context)` — explicit entry point that loads both the model registry and Copilot multipliers. Subsequent calls are no-ops (sync.Once).
- Added `modelmap.CacheIsFresh() bool` — checks whether both cache files are within their 24h TTL. Lets callers decide whether a network fetch is likely.
- Wired `Preload` into `routeCmd.RunE` via a `preloadModelData(ctx)` helper that shows a brief `models.dev` spinner on TTY when the cache is stale/absent, and loads silently when the cache is fresh.

### Replace hand-rolled YAML parser

The `parseMultipliersYAML` function was a manual line-scanner that split on newlines and used `strings.HasPrefix` to detect fields. It was fragile (no comment handling past `#` at line start, no multi-document support).

- Added `gopkg.in/yaml.v3` as a direct dependency.
- Replaced the scanner with `yaml.Unmarshal` into a `yamlMultiplierEntry` struct with `interface{}` fields for the multiplier values.
- `convertYAMLMultiplier` handles the three types yaml.v3 produces for bare scalars: `int`, `float64`, `string` (for "Not applicable").
- Existing `TestParseMultipliersYAML` passes unchanged — it was the spec.

## Tests

- `TestPreload_MakesDataAvailable` — Preload populates the registry
- `TestPreload_Idempotent` — double-call doesn't reset or panic
- `TestCacheIsFresh_NoFiles` — false with no cache files
- `TestCacheIsFresh_FreshFiles` — true with fresh files
- `TestCacheIsFresh_StaleModelsFile` — false when models.json is >24h old
- `TestCacheIsFresh_StaleMultipliersFile` — false when multipliers.json is >24h old
- `TestParseMultipliersYAML` — unchanged, still passes with yaml.v3 backend