### PR TITLE
refactor: extract renderRouteTable, reduce display duplication

### DIFF
--- a/IDIOMATIC_PLAN.md
+++ b/IDIOMATIC_PLAN.md
@@ -85,9 +85,9 @@ Findings from reviewing the codebase against canonical Go best practices (Effect
 
 ### 9. Reduce Display Logic Duplication in `cmd/route.go`
 
-- [ ] `displayRecommendation` and `displayRoleRecommendation` are ~80% identical
-- [ ] Extract `formatCost(*float64) string` helper
-- [ ] Unify the table construction into a single function parameterized by whether a "Model" column is present
+- [x] `displayRecommendation` and `displayRoleRecommendation` are ~80% identical — shared `renderRouteTable` helper extracted in `internal/cli/route.go`
+- [x] Extract `formatCost(*float64) string` helper — done as `routing.FormatMultiplier` in `internal/routing/format.go`
+- [x] Unify the table construction into a single function parameterized by whether a "Model" column is present — done via `buildHeaders`, `formatCandidateRow`, `unavailableRow` in `internal/routing/display.go`
 
 ## Things Already Done Well ✅
 

--- a/internal/cli/route.go
+++ b/internal/cli/route.go
@@ -281,15 +281,7 @@ func displayRecommendation(rec routing.Recommendation) error {
 	}
 
 	out("Route: %s\n\n", rec.ModelName)
-
-	ft := routing.FormatRecommendationRows(rec, routeRenderBar, routeFormatReset)
-
-	outln(display.NewTableWithOptions(
-		ft.Headers,
-		ft.Rows,
-		display.TableOptions{NoColor: noColor, Width: display.TerminalWidth(), RowStyles: toDisplayStyles(ft.Styles)},
-	))
-
+	renderRouteTable(routing.FormatRecommendationRows(rec, routeRenderBar, routeFormatReset))
 	return nil
 }
 
@@ -376,15 +368,7 @@ func displayRoleRecommendation(rec routing.RoleRecommendation) error {
 	}
 
 	out("Route: %s (role)\n\n", rec.Role)
-
-	ft := routing.FormatRoleRecommendationRows(rec, routeRenderBar, routeFormatReset)
-
-	outln(display.NewTableWithOptions(
-		ft.Headers,
-		ft.Rows,
-		display.TableOptions{NoColor: noColor, Width: display.TerminalWidth(), RowStyles: toDisplayStyles(ft.Styles)},
-	))
-
+	renderRouteTable(routing.FormatRoleRecommendationRows(rec, routeRenderBar, routeFormatReset))
 	return nil
 }
 
@@ -414,6 +398,16 @@ func adaptMatchPrefix(prefix string) []routing.ModelInfo {
 		out[i] = routing.ModelInfo{ID: r.ID, Name: r.Name, Providers: r.Providers}
 	}
 	return out
+}
+
+// renderRouteTable renders a FormattedTable to the output writer using the
+// shared route table options (noColor flag, terminal width, row styles).
+func renderRouteTable(ft routing.FormattedTable) {
+	outln(display.NewTableWithOptions(
+		ft.Headers,
+		ft.Rows,
+		display.TableOptions{NoColor: noColor, Width: display.TerminalWidth(), RowStyles: toDisplayStyles(ft.Styles)},
+	))
 }
 
 // routeRenderBar renders a utilization bar with color for the route table.

--- a/internal/cli/route_test.go
+++ b/internal/cli/route_test.go
@@ -1,0 +1,174 @@
+package cli
+
+import (
+	"bytes"
+	"os"
+	"strings"
+	"testing"
+
+	"github.com/joshuadavidthomas/vibeusage/internal/models"
+	"github.com/joshuadavidthomas/vibeusage/internal/routing"
+)
+
+func TestDisplayRecommendation_NoBest(t *testing.T) {
+	rec := routing.Recommendation{
+		ModelName:   "claude-sonnet-4-5",
+		Unavailable: []string{"cursor", "copilot"},
+	}
+
+	var buf bytes.Buffer
+	outWriter = &buf
+	defer func() { outWriter = os.Stdout }()
+
+	if err := displayRecommendation(rec); err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	got := buf.String()
+	if !strings.Contains(got, "No usage data available") {
+		t.Errorf("expected no-data message, got:\n%s", got)
+	}
+	if !strings.Contains(got, "claude-sonnet-4-5") {
+		t.Errorf("expected model name in output, got:\n%s", got)
+	}
+	if !strings.Contains(got, "cursor") || !strings.Contains(got, "copilot") {
+		t.Errorf("expected unavailable providers in output, got:\n%s", got)
+	}
+}
+
+func TestDisplayRecommendation_WithCandidates(t *testing.T) {
+	best := &routing.Candidate{
+		ProviderID:        "claude",
+		Utilization:       40,
+		Headroom:          60,
+		EffectiveHeadroom: 60,
+		PeriodType:        models.PeriodMonthly,
+	}
+	rec := routing.Recommendation{
+		ModelID:    "claude-sonnet-4-5",
+		ModelName:  "Claude Sonnet 4.5",
+		Best:       best,
+		Candidates: []routing.Candidate{*best},
+	}
+
+	var buf bytes.Buffer
+	outWriter = &buf
+	defer func() { outWriter = os.Stdout }()
+
+	oldNoColor := noColor
+	noColor = true
+	defer func() { noColor = oldNoColor }()
+
+	if err := displayRecommendation(rec); err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	got := buf.String()
+	if !strings.Contains(got, "Route: Claude Sonnet 4.5") {
+		t.Errorf("expected route header, got:\n%s", got)
+	}
+	// Table headers may be truncated at narrow terminal widths; check prefix.
+	for _, header := range []string{"Provid", "Usage", "Head"} {
+		if !strings.Contains(got, header) {
+			t.Errorf("expected table header prefix %q in output, got:\n%s", header, got)
+		}
+	}
+}
+
+func TestDisplayRoleRecommendation_NoBest(t *testing.T) {
+	rec := routing.RoleRecommendation{
+		Role: "thinking",
+		Unavailable: []routing.RoleUnavailable{
+			{ModelID: "claude-opus-4", ProviderID: "claude"},
+		},
+	}
+
+	var buf bytes.Buffer
+	outWriter = &buf
+	defer func() { outWriter = os.Stdout }()
+
+	if err := displayRoleRecommendation(rec); err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	got := buf.String()
+	if !strings.Contains(got, "No usage data available") {
+		t.Errorf("expected no-data message, got:\n%s", got)
+	}
+	if !strings.Contains(got, "thinking") {
+		t.Errorf("expected role name in output, got:\n%s", got)
+	}
+	if !strings.Contains(got, "claude-opus-4") {
+		t.Errorf("expected unavailable model in output, got:\n%s", got)
+	}
+}
+
+func TestDisplayRoleRecommendation_WithCandidates(t *testing.T) {
+	bestRole := &routing.RoleCandidate{
+		Candidate: routing.Candidate{
+			ProviderID:        "cursor",
+			Utilization:       30,
+			Headroom:          70,
+			EffectiveHeadroom: 70,
+			PeriodType:        models.PeriodMonthly,
+		},
+		ModelID:   "claude-sonnet-4-5",
+		ModelName: "Claude Sonnet 4.5",
+	}
+	rec := routing.RoleRecommendation{
+		Role:       "thinking",
+		Best:       bestRole,
+		Candidates: []routing.RoleCandidate{*bestRole},
+	}
+
+	var buf bytes.Buffer
+	outWriter = &buf
+	defer func() { outWriter = os.Stdout }()
+
+	oldNoColor := noColor
+	noColor = true
+	defer func() { noColor = oldNoColor }()
+
+	if err := displayRoleRecommendation(rec); err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	got := buf.String()
+	if !strings.Contains(got, "Route: thinking (role)") {
+		t.Errorf("expected role route header, got:\n%s", got)
+	}
+	// Table headers may be truncated at narrow terminal widths; check prefix.
+	for _, header := range []string{"Model", "Usage", "Head"} {
+		if !strings.Contains(got, header) {
+			t.Errorf("expected table header prefix %q in output, got:\n%s", header, got)
+		}
+	}
+}
+
+func TestRenderRouteTable_RendersHeaders(t *testing.T) {
+	ft := routing.FormattedTable{
+		Headers: []string{"Provider", "Usage", "Headroom"},
+		Rows:    [][]string{{"Claude", "40%", "60%"}},
+		Styles:  []routing.RowStyle{routing.RowBold},
+	}
+
+	var buf bytes.Buffer
+	outWriter = &buf
+	defer func() { outWriter = os.Stdout }()
+
+	oldNoColor := noColor
+	noColor = true
+	defer func() { noColor = oldNoColor }()
+
+	renderRouteTable(ft)
+
+	got := buf.String()
+	for _, header := range ft.Headers {
+		if !strings.Contains(got, header) {
+			t.Errorf("expected header %q in table output, got:\n%s", header, got)
+		}
+	}
+	if !strings.Contains(got, "Claude") {
+		t.Errorf("expected row data in table output, got:\n%s", got)
+	}
+}


### PR DESCRIPTION
## Summary

Phase 9 of the idiomatic Go refactoring plan: reduce display logic duplication in the route command.

### Changes

**`internal/cli/route.go`**
- Extract `renderRouteTable(ft routing.FormattedTable)` helper that owns the shared `display.NewTableWithOptions` call with route-specific options (noColor, terminal width, row styles)
- Simplify `displayRecommendation` and `displayRoleRecommendation` to call `renderRouteTable` — each function now only specifies what's different (title string, no-data message, and which `Format*` function to call)

**`internal/cli/route_test.go`** (new)
- TDD-first tests added before the helper was extracted (confirmed red → green)
- `TestDisplayRecommendation_NoBest` / `TestDisplayRecommendation_WithCandidates`
- `TestDisplayRoleRecommendation_NoBest` / `TestDisplayRoleRecommendation_WithCandidates`
- `TestRenderRouteTable_RendersHeaders`

### Plan notes

The other two phase-9 sub-items (`formatCost` helper and unified table column construction) were already complete from prior refactoring:
- `formatCost` → `routing.FormatMultiplier` in `internal/routing/format.go`
- Unified table construction → `buildHeaders`, `formatCandidateRow`, `unavailableRow` in `internal/routing/display.go`

All three items are now marked done in `IDIOMATIC_PLAN.md`. The entire plan is complete.