### PR TITLE
Add OpenRouter, Warp, Kimi K2, and Amp providers

### DIFF
--- a/PARITY_PLAN.md
+++ b/PARITY_PLAN.md
@@ -275,11 +275,11 @@ We prioritize providers by:
 
 ### Milestone A (P0)
 
-- [ ] OpenRouter
-- [ ] Warp
-- [ ] KimiK2
-- [ ] Amp
-- [ ] Docs and auth/key UX updates for all P0 providers
+- [x] OpenRouter
+- [x] Warp
+- [x] KimiK2
+- [x] Amp
+- [x] Docs and auth/key UX updates for all P0 providers
 
 ### Milestone B (P1)
 

--- a/README.md
+++ b/README.md
@@ -2,12 +2,12 @@
 
 Track usage across agentic LLM providers from your terminal.
 
-A unified CLI tool that aggregates usage statistics from Claude, OpenAI Codex, GitHub Copilot, Cursor, Gemini, Antigravity, Kimi, Z.ai, and Minimax with consistent formatting, progress indicators, and offline support.
+A unified CLI tool that aggregates usage statistics from Claude, OpenAI Codex, GitHub Copilot, Cursor, Gemini, Antigravity, Kimi, Kimi K2, OpenRouter, Warp, Amp, Z.ai, and Minimax with consistent formatting, progress indicators, and offline support.
 
 ## Features
 
 - **Unified Interface**: Single command to check usage across all configured providers
-- **Multiple Providers**: Claude, Codex, Copilot, Cursor, Gemini, Antigravity, Kimi, Z.ai, Minimax
+- **Multiple Providers**: Claude, Codex, Copilot, Cursor, Gemini, Antigravity, Kimi, Kimi K2, OpenRouter, Warp, Amp, Z.ai, Minimax
 - **Concurrent Fetching**: Check all providers in parallel
 - **Offline Support**: Displays cached data when network is unavailable
 - **JSON Output**: Scriptable with `--json` flag
@@ -63,6 +63,10 @@ vibeusage cursor
 vibeusage gemini
 vibeusage antigravity
 vibeusage kimi
+vibeusage kimik2
+vibeusage openrouter
+vibeusage warp
+vibeusage amp
 vibeusage zai
 vibeusage minimax
 ```
@@ -150,6 +154,46 @@ vibeusage gemini
 # Option 2: Use OAuth (recommended for full features)
 vibeusage auth gemini
 ```
+
+### OpenRouter
+
+**Required**: OpenRouter API key
+
+```bash
+vibeusage auth openrouter
+```
+
+Set `OPENROUTER_API_KEY` as an alternative.
+
+### Warp
+
+**Required**: Warp API token (`wk-...`)
+
+```bash
+vibeusage auth warp
+```
+
+Set `WARP_API_KEY` or `WARP_TOKEN` as alternatives.
+
+### Kimi K2
+
+**Required**: Kimi K2 API key
+
+```bash
+vibeusage auth kimik2
+```
+
+Set `KIMI_K2_API_KEY` (or `KIMI_API_KEY` / `KIMI_KEY`) as alternatives.
+
+### Amp
+
+**Required**: Amp API key or local Amp secrets
+
+```bash
+vibeusage auth amp
+```
+
+If Amp CLI is installed, vibeusage auto-detects `~/.local/share/amp/secrets.json`.
 
 ### Antigravity (Google)
 
@@ -247,6 +291,10 @@ vibeusage auth codex
 vibeusage auth copilot
 vibeusage auth cursor
 vibeusage auth gemini
+vibeusage auth openrouter
+vibeusage auth warp
+vibeusage auth kimik2
+vibeusage auth amp
 vibeusage auth kimi
 vibeusage auth minimax
 vibeusage auth zai
@@ -344,6 +392,13 @@ reuse_provider_credentials = true      # Auto-detect CLI credentials
 | `OPENAI_API_KEY` | OpenAI API key |
 | `GEMINI_API_KEY` | Gemini API key |
 | `GITHUB_TOKEN` | GitHub token for Copilot |
+| `OPENROUTER_API_KEY` | OpenRouter API key |
+| `WARP_API_KEY` | Warp API key |
+| `WARP_TOKEN` | Warp token fallback |
+| `KIMI_K2_API_KEY` | Kimi K2 API key |
+| `KIMI_API_KEY` | Kimi/Kimi K2 API key fallback |
+| `KIMI_KEY` | Kimi K2 API key fallback |
+| `AMP_API_KEY` | Amp API key |
 | `KIMI_CODE_API_KEY` | Kimi API key |
 | `ZAI_API_KEY` | Z.ai API key |
 | `MINIMAX_API_KEY` | Minimax Coding Plan API key |

--- a/internal/cli/init.go
+++ b/internal/cli/init.go
@@ -12,11 +12,15 @@ import (
 )
 
 var providerDescriptions = map[string]string{
-	"claude":  "Anthropic's Claude AI assistant (claude.ai)",
-	"codex":   "OpenAI's Codex/ChatGPT (platform.openai.com)",
-	"copilot": "GitHub Copilot (github.com)",
-	"cursor":  "Cursor AI code editor (cursor.com)",
-	"gemini":  "Google's Gemini AI (gemini.google.com)",
+	"amp":        "Amp coding assistant (ampcode.com)",
+	"claude":     "Anthropic's Claude AI assistant (claude.ai)",
+	"codex":      "OpenAI's Codex/ChatGPT (platform.openai.com)",
+	"copilot":    "GitHub Copilot (github.com)",
+	"cursor":     "Cursor AI code editor (cursor.com)",
+	"gemini":     "Google's Gemini AI (gemini.google.com)",
+	"kimik2":     "Kimi K2 API usage (kimi-k2.ai)",
+	"openrouter": "OpenRouter unified model gateway (openrouter.ai)",
+	"warp":       "Warp terminal AI (warp.dev)",
 }
 
 var initCmd = &cobra.Command{

--- a/internal/cli/key.go
+++ b/internal/cli/key.go
@@ -23,7 +23,7 @@ var keyCmd = &cobra.Command{
 }
 
 func init() {
-	for _, id := range []string{"antigravity", "claude", "codex", "copilot", "cursor", "gemini", "kimi", "minimax", "zai"} {
+	for _, id := range []string{"amp", "antigravity", "claude", "codex", "copilot", "cursor", "gemini", "kimik2", "kimi", "minimax", "openrouter", "warp", "zai"} {
 		keyCmd.AddCommand(makeKeyProviderCmd(id))
 	}
 }
@@ -88,14 +88,18 @@ func displayAllCredentialStatus() error {
 // credentialKey returns the JSON field name used when storing a credential
 // for a provider. This must match what the provider's loadCredentials reads.
 var credentialKeyMap = map[string]string{
+	"amp":         "api_key",
 	"antigravity": "access_token",
 	"claude":      "session_key",
 	"codex":       "access_token",
 	"copilot":     "access_token",
 	"cursor":      "session_token",
 	"gemini":      "access_token",
+	"kimik2":      "api_key",
 	"kimi":        "api_key",
 	"minimax":     "api_key",
+	"openrouter":  "api_key",
+	"warp":        "api_key",
 	"zai":         "api_key",
 }
 
@@ -104,7 +108,7 @@ func makeKeyProviderCmd(providerID string) *cobra.Command {
 	switch providerID {
 	case "antigravity", "codex", "copilot", "gemini":
 		credType = "oauth"
-	case "kimi", "minimax", "zai":
+	case "amp", "kimik2", "kimi", "minimax", "openrouter", "warp", "zai":
 		credType = "apikey"
 	}
 

--- a/internal/cli/key_test.go
+++ b/internal/cli/key_test.go
@@ -260,6 +260,14 @@ func TestKeyStatusJSON_UsesTypedStruct(t *testing.T) {
 	}
 }
 
+func TestKeyCommand_HasP0ProviderSubcommands(t *testing.T) {
+	for _, providerID := range []string{"openrouter", "warp", "kimik2", "amp"} {
+		if cmd := findSubcommand(keyCmd, providerID); cmd == nil {
+			t.Errorf("key command missing provider subcommand %q", providerID)
+		}
+	}
+}
+
 // findSubcommand finds a subcommand by name.
 func findSubcommand(parent *cobra.Command, name string) *cobra.Command {
 	for _, c := range parent.Commands() {

--- a/internal/cli/root.go
+++ b/internal/cli/root.go
@@ -18,6 +18,7 @@ import (
 	"github.com/joshuadavidthomas/vibeusage/internal/models"
 	"github.com/joshuadavidthomas/vibeusage/internal/provider"
 	// Register all providers
+	_ "github.com/joshuadavidthomas/vibeusage/internal/provider/amp"
 	_ "github.com/joshuadavidthomas/vibeusage/internal/provider/antigravity"
 	_ "github.com/joshuadavidthomas/vibeusage/internal/provider/claude"
 	_ "github.com/joshuadavidthomas/vibeusage/internal/provider/codex"
@@ -25,7 +26,10 @@ import (
 	_ "github.com/joshuadavidthomas/vibeusage/internal/provider/cursor"
 	_ "github.com/joshuadavidthomas/vibeusage/internal/provider/gemini"
 	_ "github.com/joshuadavidthomas/vibeusage/internal/provider/kimi"
+	_ "github.com/joshuadavidthomas/vibeusage/internal/provider/kimik2"
 	_ "github.com/joshuadavidthomas/vibeusage/internal/provider/minimax"
+	_ "github.com/joshuadavidthomas/vibeusage/internal/provider/openrouter"
+	_ "github.com/joshuadavidthomas/vibeusage/internal/provider/warp"
 	_ "github.com/joshuadavidthomas/vibeusage/internal/provider/zai"
 )
 
@@ -42,7 +46,7 @@ var (
 var rootCmd = &cobra.Command{
 	Use:          "vibeusage",
 	Short:        "Track usage across agentic LLM providers",
-	Long:         "A unified CLI tool that aggregates usage statistics from Antigravity, Claude, Codex, Copilot, Cursor, Gemini, Kimi, Minimax, and Z.ai.",
+	Long:         "A unified CLI tool that aggregates usage statistics from Amp, Antigravity, Claude, Codex, Copilot, Cursor, Gemini, Kimi, Kimi K2, Minimax, OpenRouter, Warp, and Z.ai.",
 	SilenceUsage: true,
 	PersistentPreRun: func(cmd *cobra.Command, args []string) {
 		if verbose && quiet {

--- a/internal/cli/root_test.go
+++ b/internal/cli/root_test.go
@@ -44,7 +44,7 @@ func TestRootCmd_HasExpectedSubcommands(t *testing.T) {
 }
 
 func TestRootCmd_HasProviderSubcommands(t *testing.T) {
-	providers := []string{"claude", "codex", "copilot", "cursor", "gemini"}
+	providers := []string{"claude", "codex", "copilot", "cursor", "gemini", "openrouter", "warp", "kimik2", "amp"}
 	for _, name := range providers {
 		found := false
 		for _, cmd := range rootCmd.Commands() {

--- a/internal/httpclient/client.go
+++ b/internal/httpclient/client.go
@@ -22,6 +22,7 @@ type Client struct {
 type Response struct {
 	StatusCode int
 	Body       []byte
+	Header     http.Header
 	JSONErr    error
 }
 
@@ -73,7 +74,7 @@ func (c *Client) DoCtx(ctx context.Context, method, rawURL string, body io.Reade
 		return nil, err
 	}
 
-	return &Response{StatusCode: resp.StatusCode, Body: respBody}, nil
+	return &Response{StatusCode: resp.StatusCode, Body: respBody, Header: resp.Header.Clone()}, nil
 }
 
 // Do sends an HTTP request with the given method and URL, applies options, reads

--- a/internal/provider/amp/amp.go
+++ b/internal/provider/amp/amp.go
@@ -1,0 +1,323 @@
+package amp
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"os"
+	"path/filepath"
+	"regexp"
+	"strconv"
+	"strings"
+	"time"
+
+	"github.com/joshuadavidthomas/vibeusage/internal/config"
+	"github.com/joshuadavidthomas/vibeusage/internal/fetch"
+	"github.com/joshuadavidthomas/vibeusage/internal/httpclient"
+	"github.com/joshuadavidthomas/vibeusage/internal/models"
+	"github.com/joshuadavidthomas/vibeusage/internal/provider"
+)
+
+type Amp struct{}
+
+func (a Amp) Meta() provider.Metadata {
+	return provider.Metadata{
+		ID:          "amp",
+		Name:        "Amp",
+		Description: "Amp coding assistant",
+		Homepage:    "https://ampcode.com",
+	}
+}
+
+func (a Amp) CredentialSources() provider.CredentialInfo {
+	return provider.CredentialInfo{
+		CLIPaths: []string{"~/.local/share/amp/secrets.json"},
+		EnvVars:  []string{"AMP_API_KEY"},
+	}
+}
+
+func (a Amp) FetchStrategies() []fetch.Strategy {
+	timeout := config.Get().Fetch.Timeout
+	return []fetch.Strategy{
+		&CLISecretsStrategy{HTTPTimeout: timeout},
+		&APIKeyStrategy{HTTPTimeout: timeout},
+	}
+}
+
+func (a Amp) FetchStatus(_ context.Context) models.ProviderStatus {
+	return models.ProviderStatus{Level: models.StatusUnknown}
+}
+
+func (a Amp) Auth() provider.AuthFlow {
+	return provider.ManualKeyAuthFlow{
+		Instructions: "Paste your Amp API key. If Amp CLI is installed, vibeusage can also auto-detect ~/.local/share/amp/secrets.json.",
+		Placeholder:  "amp-...",
+		Validate:     provider.ValidateNotEmpty,
+		CredPath:     config.CredentialPath("amp", "apikey"),
+		JSONKey:      "api_key",
+	}
+}
+
+func init() {
+	provider.Register(Amp{})
+}
+
+var internalRPCURL = "https://ampcode.com/api/internal"
+
+// CLISecretsStrategy loads Amp credentials from the local secrets file.
+type CLISecretsStrategy struct {
+	HTTPTimeout float64
+}
+
+func (s *CLISecretsStrategy) Name() string { return "provider_cli" }
+
+func (s *CLISecretsStrategy) IsAvailable() bool {
+	_, ok := loadCLISecretsToken()
+	return ok
+}
+
+func (s *CLISecretsStrategy) Fetch(ctx context.Context) (fetch.FetchResult, error) {
+	token, ok := loadCLISecretsToken()
+	if !ok {
+		return fetch.ResultFail("No Amp CLI credentials found in ~/.local/share/amp/secrets.json"), nil
+	}
+	return fetchBalance(ctx, token, s.Name(), s.HTTPTimeout)
+}
+
+// APIKeyStrategy supports manual key entry or AMP_API_KEY.
+type APIKeyStrategy struct {
+	HTTPTimeout float64
+}
+
+func (s *APIKeyStrategy) Name() string { return "api_key" }
+
+func (s *APIKeyStrategy) IsAvailable() bool {
+	return s.loadToken() != ""
+}
+
+func (s *APIKeyStrategy) Fetch(ctx context.Context) (fetch.FetchResult, error) {
+	token := s.loadToken()
+	if token == "" {
+		return fetch.ResultFail("No API key found. Set AMP_API_KEY or use 'vibeusage key amp set'"), nil
+	}
+	return fetchBalance(ctx, token, s.Name(), s.HTTPTimeout)
+}
+
+func (s *APIKeyStrategy) loadToken() string {
+	if token := strings.TrimSpace(os.Getenv("AMP_API_KEY")); token != "" {
+		return token
+	}
+	data, err := config.ReadCredential(config.CredentialPath("amp", "apikey"))
+	if err != nil || data == nil {
+		return ""
+	}
+	var creds struct {
+		APIKey string `json:"api_key"`
+	}
+	if err := json.Unmarshal(data, &creds); err != nil {
+		return ""
+	}
+	return strings.TrimSpace(creds.APIKey)
+}
+
+func loadCLISecretsToken() (string, bool) {
+	home, err := os.UserHomeDir()
+	if err != nil {
+		return "", false
+	}
+	path := filepath.Join(home, ".local", "share", "amp", "secrets.json")
+	data, err := os.ReadFile(path)
+	if err != nil {
+		return "", false
+	}
+
+	var secrets map[string]string
+	if err := json.Unmarshal(data, &secrets); err != nil {
+		return "", false
+	}
+	token := strings.TrimSpace(secrets["apiKey@https://ampcode.com/"])
+	if token == "" {
+		return "", false
+	}
+	return token, true
+}
+
+func fetchBalance(ctx context.Context, token string, source string, httpTimeout float64) (fetch.FetchResult, error) {
+	client := httpclient.NewFromConfig(httpTimeout)
+	body := jsonRPCRequest{
+		JSONRPC: "2.0",
+		ID:      "vibeusage",
+		Method:  "userDisplayBalanceInfo",
+		Params:  []string{},
+	}
+
+	var rpcResp rpcResponse
+	resp, err := client.PostJSONCtx(ctx, internalRPCURL, body, &rpcResp,
+		httpclient.WithBearer(token),
+		httpclient.WithHeader("Accept", "application/json"),
+	)
+	if err != nil {
+		return fetch.ResultFail("Request failed: " + err.Error()), nil
+	}
+
+	if resp.StatusCode == 401 || resp.StatusCode == 403 {
+		return fetch.ResultFatal("Token invalid or expired. Run `vibeusage auth amp` to re-authenticate."), nil
+	}
+	if resp.StatusCode != 200 {
+		return fetch.ResultFail(fmt.Sprintf("Amp usage request failed: HTTP %d (%s)", resp.StatusCode, summarizeBody(resp.Body))), nil
+	}
+	if resp.JSONErr != nil {
+		return fetch.ResultFail(fmt.Sprintf("Invalid response from Amp API: %v", resp.JSONErr)), nil
+	}
+	if rpcResp.Error != nil {
+		msg := strings.TrimSpace(rpcResp.Error.Message)
+		if msg == "" {
+			msg = fmt.Sprintf("rpc error code %d", rpcResp.Error.Code)
+		}
+		if strings.Contains(strings.ToLower(msg), "unauthor") {
+			return fetch.ResultFatal("Token invalid or expired. Run `vibeusage auth amp` to re-authenticate."), nil
+		}
+		return fetch.ResultFail(msg), nil
+	}
+	if rpcResp.Result == nil {
+		return fetch.ResultFail("Amp response missing result payload"), nil
+	}
+
+	snapshot, err := parseDisplayBalance(*rpcResp.Result, source)
+	if err != nil {
+		return fetch.ResultFail("Failed to parse Amp balance text: " + err.Error()), nil
+	}
+	return fetch.ResultOK(*snapshot), nil
+}
+
+type jsonRPCRequest struct {
+	JSONRPC string   `json:"jsonrpc"`
+	ID      string   `json:"id"`
+	Method  string   `json:"method"`
+	Params  []string `json:"params"`
+}
+
+type rpcResponse struct {
+	Result *balanceResult `json:"result"`
+	Error  *rpcError      `json:"error"`
+}
+
+type rpcError struct {
+	Code    int    `json:"code"`
+	Message string `json:"message"`
+}
+
+type balanceResult struct {
+	DisplayText string `json:"displayText"`
+}
+
+var (
+	quotaPattern   = regexp.MustCompile(`(?i)\$([0-9]+(?:\.[0-9]+)?)\s*/\s*\$([0-9]+(?:\.[0-9]+)?)`)
+	hourlyPattern  = regexp.MustCompile(`(?i)\$([0-9]+(?:\.[0-9]+)?)\s*/\s*hour`)
+	creditsPattern = regexp.MustCompile(`(?i)(?:bonus\s+)?credits?:\s*\$([0-9]+(?:\.[0-9]+)?)`)
+)
+
+func parseDisplayBalance(result balanceResult, source string) (*models.UsageSnapshot, error) {
+	text := strings.TrimSpace(result.DisplayText)
+	if text == "" {
+		return nil, fmt.Errorf("empty displayText")
+	}
+
+	periods := make([]models.UsagePeriod, 0, 1)
+
+	quotaMatch := quotaPattern.FindStringSubmatch(text)
+	if len(quotaMatch) == 3 {
+		remaining, err := strconv.ParseFloat(quotaMatch[1], 64)
+		if err != nil {
+			return nil, fmt.Errorf("parse remaining quota: %w", err)
+		}
+		total, err := strconv.ParseFloat(quotaMatch[2], 64)
+		if err != nil {
+			return nil, fmt.Errorf("parse total quota: %w", err)
+		}
+
+		utilization := 0
+		if total > 0 {
+			used := total - remaining
+			if used < 0 {
+				used = 0
+			}
+			utilization = int((used / total) * 100)
+			if utilization < 0 {
+				utilization = 0
+			}
+			if utilization > 100 {
+				utilization = 100
+			}
+		}
+
+		period := models.UsagePeriod{
+			Name:        "Daily Free Quota",
+			Utilization: utilization,
+			PeriodType:  models.PeriodDaily,
+		}
+
+		rateMatch := hourlyPattern.FindStringSubmatch(text)
+		if len(rateMatch) == 2 {
+			rate, err := strconv.ParseFloat(rateMatch[1], 64)
+			if err == nil && rate > 0 && total > remaining {
+				hoursUntilFull := (total - remaining) / rate
+				if hoursUntilFull > 0 {
+					reset := time.Now().UTC().Add(time.Duration(hoursUntilFull * float64(time.Hour)))
+					period.ResetsAt = &reset
+				}
+			}
+		}
+
+		periods = append(periods, period)
+	}
+
+	var overage *models.OverageUsage
+	creditMatch := creditsPattern.FindStringSubmatch(text)
+	if len(creditMatch) == 2 {
+		credits, err := strconv.ParseFloat(creditMatch[1], 64)
+		if err != nil {
+			return nil, fmt.Errorf("parse credits amount: %w", err)
+		}
+		overage = &models.OverageUsage{
+			Used:      0,
+			Limit:     credits,
+			Currency:  "USD",
+			IsEnabled: true,
+		}
+	}
+
+	if len(periods) == 0 {
+		if overage == nil {
+			return nil, fmt.Errorf("unrecognized displayText format: %q", text)
+		}
+		periods = append(periods, models.UsagePeriod{
+			Name:        "Credits Balance",
+			Utilization: 0,
+			PeriodType:  models.PeriodMonthly,
+		})
+	}
+
+	snapshot := &models.UsageSnapshot{
+		Provider:  "amp",
+		FetchedAt: time.Now().UTC(),
+		Periods:   periods,
+		Overage:   overage,
+		Source:    source,
+	}
+	if overage != nil {
+		snapshot.Identity = &models.ProviderIdentity{Organization: fmt.Sprintf("Credits: $%.2f", overage.Limit)}
+	}
+	return snapshot, nil
+}
+
+func summarizeBody(body []byte) string {
+	s := strings.TrimSpace(string(body))
+	if s == "" {
+		return "empty body"
+	}
+	if len(s) > 120 {
+		return s[:120] + "..."
+	}
+	return s
+}

--- a/internal/provider/amp/amp_test.go
+++ b/internal/provider/amp/amp_test.go
@@ -1,0 +1,84 @@
+package amp
+
+import (
+	"context"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+)
+
+func TestParseDisplayBalance_FreeTier(t *testing.T) {
+	result := balanceResult{DisplayText: "Free quota: $6.00 / $10.00 daily. Replenishes at $1.00/hour."}
+
+	snapshot, err := parseDisplayBalance(result, "provider_cli")
+	if err != nil {
+		t.Fatalf("parseDisplayBalance() error = %v", err)
+	}
+	if len(snapshot.Periods) != 1 {
+		t.Fatalf("period count = %d, want 1", len(snapshot.Periods))
+	}
+	if snapshot.Periods[0].Utilization != 40 {
+		t.Errorf("utilization = %d, want 40", snapshot.Periods[0].Utilization)
+	}
+	if snapshot.Periods[0].ResetsAt == nil {
+		t.Error("expected resetsAt estimate from replenish rate")
+	}
+}
+
+func TestParseDisplayBalance_CreditsOnly(t *testing.T) {
+	result := balanceResult{DisplayText: "Credits: $12.34"}
+
+	snapshot, err := parseDisplayBalance(result, "api_key")
+	if err != nil {
+		t.Fatalf("parseDisplayBalance() error = %v", err)
+	}
+	if snapshot.Overage == nil {
+		t.Fatal("expected overage info for credits")
+	}
+	if snapshot.Overage.Limit != 12.34 {
+		t.Errorf("credit limit = %.2f, want 12.34", snapshot.Overage.Limit)
+	}
+}
+
+func TestParseDisplayBalance_BonusText(t *testing.T) {
+	result := balanceResult{DisplayText: "Free quota: $2.50 / $10.00 daily. Bonus credits: $8.00"}
+
+	snapshot, err := parseDisplayBalance(result, "provider_cli")
+	if err != nil {
+		t.Fatalf("parseDisplayBalance() error = %v", err)
+	}
+	if snapshot.Periods[0].Utilization != 75 {
+		t.Errorf("utilization = %d, want 75", snapshot.Periods[0].Utilization)
+	}
+}
+
+func TestParseDisplayBalance_MalformedText(t *testing.T) {
+	_, err := parseDisplayBalance(balanceResult{DisplayText: "nonsense"}, "provider_cli")
+	if err == nil {
+		t.Fatal("expected parse error")
+	}
+}
+
+func TestFetchBalance_AuthError(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusUnauthorized)
+		_, _ = w.Write([]byte(`{"error":{"message":"unauthorized"}}`))
+	}))
+	defer srv.Close()
+
+	oldURL := internalRPCURL
+	internalRPCURL = srv.URL
+	defer func() { internalRPCURL = oldURL }()
+
+	result, err := fetchBalance(context.Background(), "amp-token", "provider_cli", 5)
+	if err != nil {
+		t.Fatalf("fetchBalance() err = %v", err)
+	}
+	if result.ShouldFallback {
+		t.Fatal("auth failure should be fatal")
+	}
+	if !strings.Contains(strings.ToLower(result.Error), "amp") {
+		t.Errorf("error = %q, want amp auth hint", result.Error)
+	}
+}

--- a/internal/provider/kimik2/kimik2.go
+++ b/internal/provider/kimik2/kimik2.go
@@ -1,0 +1,268 @@
+package kimik2
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"os"
+	"strconv"
+	"strings"
+	"time"
+
+	"github.com/joshuadavidthomas/vibeusage/internal/config"
+	"github.com/joshuadavidthomas/vibeusage/internal/fetch"
+	"github.com/joshuadavidthomas/vibeusage/internal/httpclient"
+	"github.com/joshuadavidthomas/vibeusage/internal/models"
+	"github.com/joshuadavidthomas/vibeusage/internal/provider"
+)
+
+type KimiK2 struct{}
+
+func (k KimiK2) Meta() provider.Metadata {
+	return provider.Metadata{
+		ID:          "kimik2",
+		Name:        "Kimi K2",
+		Description: "Kimi K2 API usage",
+		Homepage:    "https://kimi-k2.ai",
+	}
+}
+
+func (k KimiK2) CredentialSources() provider.CredentialInfo {
+	return provider.CredentialInfo{EnvVars: []string{"KIMI_K2_API_KEY", "KIMI_API_KEY", "KIMI_KEY"}}
+}
+
+func (k KimiK2) FetchStrategies() []fetch.Strategy {
+	timeout := config.Get().Fetch.Timeout
+	return []fetch.Strategy{&APIKeyStrategy{HTTPTimeout: timeout}}
+}
+
+func (k KimiK2) FetchStatus(_ context.Context) models.ProviderStatus {
+	return models.ProviderStatus{Level: models.StatusUnknown}
+}
+
+func (k KimiK2) Auth() provider.AuthFlow {
+	return provider.ManualKeyAuthFlow{
+		Instructions: "Get your Kimi K2 API key from your Kimi account settings.",
+		Placeholder:  "k2-...",
+		Validate:     provider.ValidateNotEmpty,
+		CredPath:     config.CredentialPath("kimik2", "apikey"),
+		JSONKey:      "api_key",
+	}
+}
+
+func init() {
+	provider.Register(KimiK2{})
+}
+
+var creditsURL = "https://kimi-k2.ai/api/user/credits"
+
+// APIKeyStrategy fetches Kimi K2 credits using an API key.
+type APIKeyStrategy struct {
+	HTTPTimeout float64
+}
+
+func (s *APIKeyStrategy) Name() string { return "api_key" }
+
+func (s *APIKeyStrategy) IsAvailable() bool {
+	return s.loadToken() != ""
+}
+
+func (s *APIKeyStrategy) Fetch(ctx context.Context) (fetch.FetchResult, error) {
+	token := s.loadToken()
+	if token == "" {
+		return fetch.ResultFail("No API key found. Set KIMI_K2_API_KEY or use 'vibeusage key kimik2 set'"), nil
+	}
+	return fetchCredits(ctx, token, s.HTTPTimeout)
+}
+
+func (s *APIKeyStrategy) loadToken() string {
+	for _, envVar := range []string{"KIMI_K2_API_KEY", "KIMI_API_KEY", "KIMI_KEY"} {
+		if token := strings.TrimSpace(os.Getenv(envVar)); token != "" {
+			return token
+		}
+	}
+	data, err := config.ReadCredential(config.CredentialPath("kimik2", "apikey"))
+	if err != nil || data == nil {
+		return ""
+	}
+	var creds struct {
+		APIKey string `json:"api_key"`
+	}
+	if err := json.Unmarshal(data, &creds); err != nil {
+		return ""
+	}
+	return strings.TrimSpace(creds.APIKey)
+}
+
+func fetchCredits(ctx context.Context, token string, httpTimeout float64) (fetch.FetchResult, error) {
+	client := httpclient.NewFromConfig(httpTimeout)
+	var parsed CreditsResponse
+	resp, err := client.GetJSONCtx(ctx, creditsURL, &parsed, httpclient.WithBearer(token))
+	if err != nil {
+		return fetch.ResultFail("Request failed: " + err.Error()), nil
+	}
+
+	if resp.StatusCode == 401 || resp.StatusCode == 403 {
+		return fetch.ResultFatal("API key is invalid or expired. Run `vibeusage auth kimik2` to re-authenticate."), nil
+	}
+	if resp.StatusCode != 200 {
+		return fetch.ResultFail(fmt.Sprintf("Kimi K2 credits request failed: HTTP %d (%s)", resp.StatusCode, summarizeBody(resp.Body))), nil
+	}
+	if resp.JSONErr != nil {
+		return fetch.ResultFail(fmt.Sprintf("Invalid response from Kimi K2 API: %v", resp.JSONErr)), nil
+	}
+
+	snapshot, err := parseCreditsSnapshot(parsed, resp.Header)
+	if err != nil {
+		return fetch.ResultFail("Failed to parse Kimi K2 credits: " + err.Error()), nil
+	}
+	return fetch.ResultOK(*snapshot), nil
+}
+
+type CreditsResponse struct {
+	Consumed  any          `json:"consumed,omitempty"`
+	Remaining any          `json:"remaining,omitempty"`
+	Used      any          `json:"used,omitempty"`
+	Balance   any          `json:"balance,omitempty"`
+	Data      *CreditsData `json:"data,omitempty"`
+}
+
+type CreditsData struct {
+	Consumed  any `json:"consumed,omitempty"`
+	Remaining any `json:"remaining,omitempty"`
+	Used      any `json:"used,omitempty"`
+	Balance   any `json:"balance,omitempty"`
+	Left      any `json:"left,omitempty"`
+}
+
+func parseCreditsSnapshot(resp CreditsResponse, headers http.Header) (*models.UsageSnapshot, error) {
+	consumed, okConsumed := firstNumber(
+		resp.Consumed,
+		resp.Used,
+		resp.DataField(func(d *CreditsData) any { return d.Consumed }),
+		resp.DataField(func(d *CreditsData) any { return d.Used }),
+	)
+	remaining, okRemaining := firstNumber(
+		resp.Remaining,
+		resp.Balance,
+		resp.DataField(func(d *CreditsData) any { return d.Remaining }),
+		resp.DataField(func(d *CreditsData) any { return d.Balance }),
+		resp.DataField(func(d *CreditsData) any { return d.Left }),
+	)
+	if !okRemaining {
+		if h, ok := remainingFromHeaders(headers); ok {
+			remaining = h
+			okRemaining = true
+		}
+	}
+	if !okConsumed {
+		consumed = 0
+	}
+	if !okRemaining {
+		return nil, fmt.Errorf("missing remaining credits in response")
+	}
+
+	if consumed < 0 {
+		consumed = 0
+	}
+	if remaining < 0 {
+		remaining = 0
+	}
+
+	total := consumed + remaining
+	utilization := 0
+	if total > 0 {
+		utilization = int((consumed / total) * 100)
+		if utilization < 0 {
+			utilization = 0
+		}
+		if utilization > 100 {
+			utilization = 100
+		}
+	}
+
+	return &models.UsageSnapshot{
+		Provider:  "kimik2",
+		FetchedAt: time.Now().UTC(),
+		Periods: []models.UsagePeriod{
+			{
+				Name:        "Credits",
+				Utilization: utilization,
+				PeriodType:  models.PeriodMonthly,
+			},
+		},
+		Source: "api_key",
+	}, nil
+}
+
+func (r CreditsResponse) DataField(fn func(*CreditsData) any) any {
+	if r.Data == nil {
+		return nil
+	}
+	return fn(r.Data)
+}
+
+func firstNumber(values ...any) (float64, bool) {
+	for _, v := range values {
+		if n, ok := parseNumber(v); ok {
+			return n, true
+		}
+	}
+	return 0, false
+}
+
+func parseNumber(v any) (float64, bool) {
+	switch x := v.(type) {
+	case nil:
+		return 0, false
+	case float64:
+		return x, true
+	case float32:
+		return float64(x), true
+	case int:
+		return float64(x), true
+	case int64:
+		return float64(x), true
+	case json.Number:
+		n, err := x.Float64()
+		return n, err == nil
+	case string:
+		s := strings.TrimSpace(x)
+		if s == "" {
+			return 0, false
+		}
+		n, err := strconv.ParseFloat(s, 64)
+		return n, err == nil
+	default:
+		return 0, false
+	}
+}
+
+func remainingFromHeaders(h http.Header) (float64, bool) {
+	if h == nil {
+		return 0, false
+	}
+	for _, key := range []string{"X-Remaining-Credits", "X-Credits-Remaining", "x-remaining-credits", "x-credits-remaining"} {
+		raw := strings.TrimSpace(h.Get(key))
+		if raw == "" {
+			continue
+		}
+		n, err := strconv.ParseFloat(raw, 64)
+		if err == nil {
+			return n, true
+		}
+	}
+	return 0, false
+}
+
+func summarizeBody(body []byte) string {
+	s := strings.TrimSpace(string(body))
+	if s == "" {
+		return "empty body"
+	}
+	if len(s) > 120 {
+		return s[:120] + "..."
+	}
+	return s
+}

--- a/internal/provider/kimik2/kimik2_test.go
+++ b/internal/provider/kimik2/kimik2_test.go
@@ -1,0 +1,69 @@
+package kimik2
+
+import (
+	"context"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+)
+
+func TestParseCreditsSnapshot_VariantTopLevel(t *testing.T) {
+	resp := CreditsResponse{Consumed: 40, Remaining: 60}
+
+	snapshot, err := parseCreditsSnapshot(resp, nil)
+	if err != nil {
+		t.Fatalf("parseCreditsSnapshot() error = %v", err)
+	}
+	if snapshot.Periods[0].Utilization != 40 {
+		t.Errorf("utilization = %d, want 40", snapshot.Periods[0].Utilization)
+	}
+}
+
+func TestParseCreditsSnapshot_VariantNestedStringFields(t *testing.T) {
+	resp := CreditsResponse{Data: &CreditsData{Used: "25", Balance: "75"}}
+
+	snapshot, err := parseCreditsSnapshot(resp, nil)
+	if err != nil {
+		t.Fatalf("parseCreditsSnapshot() error = %v", err)
+	}
+	if snapshot.Periods[0].Utilization != 25 {
+		t.Errorf("utilization = %d, want 25", snapshot.Periods[0].Utilization)
+	}
+}
+
+func TestParseCreditsSnapshot_HeaderFallbackForRemaining(t *testing.T) {
+	resp := CreditsResponse{Consumed: 30}
+	headers := http.Header{"X-Remaining-Credits": []string{"70"}}
+
+	snapshot, err := parseCreditsSnapshot(resp, headers)
+	if err != nil {
+		t.Fatalf("parseCreditsSnapshot() error = %v", err)
+	}
+	if snapshot.Periods[0].Utilization != 30 {
+		t.Errorf("utilization = %d, want 30", snapshot.Periods[0].Utilization)
+	}
+}
+
+func TestFetchCredits_AuthFailure(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusUnauthorized)
+		_, _ = w.Write([]byte(`{"error":"unauthorized"}`))
+	}))
+	defer srv.Close()
+
+	oldURL := creditsURL
+	creditsURL = srv.URL
+	defer func() { creditsURL = oldURL }()
+
+	result, err := fetchCredits(context.Background(), "k2-test", 5)
+	if err != nil {
+		t.Fatalf("fetchCredits() err = %v", err)
+	}
+	if result.ShouldFallback {
+		t.Fatal("auth failure should be fatal")
+	}
+	if !strings.Contains(strings.ToLower(result.Error), "kimik2") {
+		t.Errorf("error = %q, want kimik2 auth hint", result.Error)
+	}
+}

--- a/internal/provider/openrouter/openrouter.go
+++ b/internal/provider/openrouter/openrouter.go
@@ -1,0 +1,182 @@
+package openrouter
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"os"
+	"strings"
+	"time"
+
+	"github.com/joshuadavidthomas/vibeusage/internal/config"
+	"github.com/joshuadavidthomas/vibeusage/internal/fetch"
+	"github.com/joshuadavidthomas/vibeusage/internal/httpclient"
+	"github.com/joshuadavidthomas/vibeusage/internal/models"
+	"github.com/joshuadavidthomas/vibeusage/internal/provider"
+)
+
+type OpenRouter struct{}
+
+func (o OpenRouter) Meta() provider.Metadata {
+	return provider.Metadata{
+		ID:          "openrouter",
+		Name:        "OpenRouter",
+		Description: "OpenRouter unified model gateway",
+		Homepage:    "https://openrouter.ai",
+	}
+}
+
+func (o OpenRouter) CredentialSources() provider.CredentialInfo {
+	return provider.CredentialInfo{EnvVars: []string{"OPENROUTER_API_KEY"}}
+}
+
+func (o OpenRouter) FetchStrategies() []fetch.Strategy {
+	timeout := config.Get().Fetch.Timeout
+	return []fetch.Strategy{&APIKeyStrategy{HTTPTimeout: timeout}}
+}
+
+func (o OpenRouter) FetchStatus(_ context.Context) models.ProviderStatus {
+	return models.ProviderStatus{Level: models.StatusUnknown}
+}
+
+func (o OpenRouter) Auth() provider.AuthFlow {
+	return provider.ManualKeyAuthFlow{
+		Instructions: "Get your OpenRouter API key:\n" +
+			"  1. Open https://openrouter.ai/settings/keys\n" +
+			"  2. Create or copy an API key",
+		Placeholder: "sk-or-...",
+		Validate:    provider.ValidateNotEmpty,
+		CredPath:    config.CredentialPath("openrouter", "apikey"),
+		JSONKey:     "api_key",
+	}
+}
+
+func init() {
+	provider.Register(OpenRouter{})
+}
+
+var creditsURL = "https://openrouter.ai/api/v1/credits"
+
+// APIKeyStrategy fetches OpenRouter usage from the credits endpoint.
+type APIKeyStrategy struct {
+	HTTPTimeout float64
+}
+
+func (s *APIKeyStrategy) Name() string { return "api_key" }
+
+func (s *APIKeyStrategy) IsAvailable() bool {
+	return s.loadToken() != ""
+}
+
+func (s *APIKeyStrategy) Fetch(ctx context.Context) (fetch.FetchResult, error) {
+	token := s.loadToken()
+	if token == "" {
+		return fetch.ResultFail("No API key found. Set OPENROUTER_API_KEY or use 'vibeusage key openrouter set'"), nil
+	}
+	return fetchCredits(ctx, token, s.HTTPTimeout)
+}
+
+func (s *APIKeyStrategy) loadToken() string {
+	if key := strings.TrimSpace(os.Getenv("OPENROUTER_API_KEY")); key != "" {
+		return key
+	}
+	data, err := config.ReadCredential(config.CredentialPath("openrouter", "apikey"))
+	if err != nil || data == nil {
+		return ""
+	}
+	var creds struct {
+		APIKey string `json:"api_key"`
+	}
+	if err := json.Unmarshal(data, &creds); err != nil {
+		return ""
+	}
+	return strings.TrimSpace(creds.APIKey)
+}
+
+func fetchCredits(ctx context.Context, token string, httpTimeout float64) (fetch.FetchResult, error) {
+	client := httpclient.NewFromConfig(httpTimeout)
+	var parsed CreditsResponse
+	resp, err := client.GetJSONCtx(ctx, creditsURL, &parsed, httpclient.WithBearer(token))
+	if err != nil {
+		return fetch.ResultFail("Request failed: " + err.Error()), nil
+	}
+
+	if resp.StatusCode == 401 || resp.StatusCode == 403 {
+		return fetch.ResultFatal("API key is invalid or expired. Run `vibeusage auth openrouter` to re-authenticate."), nil
+	}
+	if resp.StatusCode != 200 {
+		return fetch.ResultFail(fmt.Sprintf("OpenRouter credits request failed: HTTP %d (%s)", resp.StatusCode, summarizeBody(resp.Body))), nil
+	}
+	if resp.JSONErr != nil {
+		return fetch.ResultFail(fmt.Sprintf("Invalid response from OpenRouter API: %v", resp.JSONErr)), nil
+	}
+
+	snapshot, err := parseCreditsSnapshot(parsed)
+	if err != nil {
+		return fetch.ResultFail("Failed to parse OpenRouter credits response: " + err.Error()), nil
+	}
+	return fetch.ResultOK(*snapshot), nil
+}
+
+type CreditsResponse struct {
+	Data CreditsData `json:"data"`
+}
+
+type CreditsData struct {
+	TotalCredits float64 `json:"total_credits"`
+	TotalUsage   float64 `json:"total_usage"`
+}
+
+func parseCreditsSnapshot(resp CreditsResponse) (*models.UsageSnapshot, error) {
+	total := resp.Data.TotalCredits
+	used := resp.Data.TotalUsage
+	if total < 0 {
+		total = 0
+	}
+	if used < 0 {
+		used = 0
+	}
+
+	utilization := 0
+	if total > 0 {
+		utilization = int((used / total) * 100)
+		if utilization < 0 {
+			utilization = 0
+		}
+		if utilization > 100 {
+			utilization = 100
+		}
+	}
+
+	now := time.Now().UTC()
+	snapshot := &models.UsageSnapshot{
+		Provider:  "openrouter",
+		FetchedAt: now,
+		Periods: []models.UsagePeriod{
+			{
+				Name:        "Credits",
+				Utilization: utilization,
+				PeriodType:  models.PeriodMonthly,
+			},
+		},
+		Overage: &models.OverageUsage{
+			Used:      used,
+			Limit:     total,
+			Currency:  "USD",
+			IsEnabled: true,
+		},
+		Source: "api_key",
+	}
+	return snapshot, nil
+}
+
+func summarizeBody(body []byte) string {
+	s := strings.TrimSpace(string(body))
+	if s == "" {
+		return "empty body"
+	}
+	if len(s) > 120 {
+		return s[:120] + "..."
+	}
+	return s
+}

--- a/internal/provider/openrouter/openrouter_test.go
+++ b/internal/provider/openrouter/openrouter_test.go
@@ -1,0 +1,93 @@
+package openrouter
+
+import (
+	"context"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+)
+
+func TestParseCreditsSnapshot_Success(t *testing.T) {
+	resp := CreditsResponse{
+		Data: CreditsData{TotalCredits: 100, TotalUsage: 25},
+	}
+
+	snapshot, err := parseCreditsSnapshot(resp)
+	if err != nil {
+		t.Fatalf("parseCreditsSnapshot() error = %v", err)
+	}
+	if snapshot.Provider != "openrouter" {
+		t.Errorf("provider = %q, want %q", snapshot.Provider, "openrouter")
+	}
+	if len(snapshot.Periods) != 1 {
+		t.Fatalf("period count = %d, want 1", len(snapshot.Periods))
+	}
+	if snapshot.Periods[0].Utilization != 25 {
+		t.Errorf("utilization = %d, want 25", snapshot.Periods[0].Utilization)
+	}
+	if snapshot.Overage == nil {
+		t.Fatal("expected overage")
+	}
+	if snapshot.Overage.Used != 25 || snapshot.Overage.Limit != 100 {
+		t.Errorf("overage = %+v, want used=25 limit=100", snapshot.Overage)
+	}
+}
+
+func TestParseCreditsSnapshot_ZeroCredits(t *testing.T) {
+	resp := CreditsResponse{Data: CreditsData{TotalCredits: 0, TotalUsage: 10}}
+
+	snapshot, err := parseCreditsSnapshot(resp)
+	if err != nil {
+		t.Fatalf("parseCreditsSnapshot() error = %v", err)
+	}
+	if snapshot.Periods[0].Utilization != 0 {
+		t.Errorf("utilization = %d, want 0", snapshot.Periods[0].Utilization)
+	}
+}
+
+func TestFetchCredits_AuthFailure(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusUnauthorized)
+		_, _ = w.Write([]byte(`{"error":"unauthorized"}`))
+	}))
+	defer srv.Close()
+
+	oldURL := creditsURL
+	creditsURL = srv.URL
+	defer func() { creditsURL = oldURL }()
+
+	result, err := fetchCredits(context.Background(), "or-test", 5)
+	if err != nil {
+		t.Fatalf("fetchCredits() err = %v", err)
+	}
+	if result.ShouldFallback {
+		t.Fatal("auth failure should be fatal")
+	}
+	if !strings.Contains(strings.ToLower(result.Error), "openrouter") {
+		t.Errorf("error = %q, want auth hint mentioning openrouter", result.Error)
+	}
+}
+
+func TestFetchCredits_InvalidJSONIncludesUnderlyingError(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusOK)
+		_, _ = w.Write([]byte(`{"data":`))
+	}))
+	defer srv.Close()
+
+	oldURL := creditsURL
+	creditsURL = srv.URL
+	defer func() { creditsURL = oldURL }()
+
+	result, err := fetchCredits(context.Background(), "or-test", 5)
+	if err != nil {
+		t.Fatalf("fetchCredits() err = %v", err)
+	}
+	if result.Success {
+		t.Fatal("expected parse failure")
+	}
+	if !strings.Contains(strings.ToLower(result.Error), "invalid") {
+		t.Errorf("error = %q, want invalid response message", result.Error)
+	}
+}

--- a/internal/provider/warp/warp.go
+++ b/internal/provider/warp/warp.go
@@ -1,0 +1,252 @@
+package warp
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"os"
+	"strings"
+	"time"
+
+	"github.com/joshuadavidthomas/vibeusage/internal/config"
+	"github.com/joshuadavidthomas/vibeusage/internal/fetch"
+	"github.com/joshuadavidthomas/vibeusage/internal/httpclient"
+	"github.com/joshuadavidthomas/vibeusage/internal/models"
+	"github.com/joshuadavidthomas/vibeusage/internal/provider"
+)
+
+type Warp struct{}
+
+func (w Warp) Meta() provider.Metadata {
+	return provider.Metadata{
+		ID:          "warp",
+		Name:        "Warp",
+		Description: "Warp terminal AI",
+		Homepage:    "https://warp.dev",
+	}
+}
+
+func (w Warp) CredentialSources() provider.CredentialInfo {
+	return provider.CredentialInfo{EnvVars: []string{"WARP_API_KEY", "WARP_TOKEN"}}
+}
+
+func (w Warp) FetchStrategies() []fetch.Strategy {
+	timeout := config.Get().Fetch.Timeout
+	return []fetch.Strategy{&APIKeyStrategy{HTTPTimeout: timeout}}
+}
+
+func (w Warp) FetchStatus(_ context.Context) models.ProviderStatus {
+	return models.ProviderStatus{Level: models.StatusUnknown}
+}
+
+func (w Warp) Auth() provider.AuthFlow {
+	return provider.ManualKeyAuthFlow{
+		Instructions: "Get your Warp API token:\n" +
+			"  1. Open Warp settings\n" +
+			"  2. Copy your token (starts with wk-)",
+		Placeholder: "wk-...",
+		Validate:    provider.ValidatePrefix("wk-"),
+		CredPath:    config.CredentialPath("warp", "apikey"),
+		JSONKey:     "api_key",
+	}
+}
+
+func init() {
+	provider.Register(Warp{})
+}
+
+var requestLimitURL = "https://app.warp.dev/graphql/v2?op=GetRequestLimitInfo"
+
+// APIKeyStrategy fetches Warp usage via GraphQL.
+type APIKeyStrategy struct {
+	HTTPTimeout float64
+}
+
+func (s *APIKeyStrategy) Name() string { return "api_key" }
+
+func (s *APIKeyStrategy) IsAvailable() bool {
+	return s.loadToken() != ""
+}
+
+func (s *APIKeyStrategy) Fetch(ctx context.Context) (fetch.FetchResult, error) {
+	token := s.loadToken()
+	if token == "" {
+		return fetch.ResultFail("No API key found. Set WARP_API_KEY or use 'vibeusage key warp set'"), nil
+	}
+	return fetchUsage(ctx, token, s.HTTPTimeout)
+}
+
+func (s *APIKeyStrategy) loadToken() string {
+	for _, envVar := range []string{"WARP_API_KEY", "WARP_TOKEN"} {
+		if key := strings.TrimSpace(os.Getenv(envVar)); key != "" {
+			return key
+		}
+	}
+	data, err := config.ReadCredential(config.CredentialPath("warp", "apikey"))
+	if err != nil || data == nil {
+		return ""
+	}
+	var creds struct {
+		APIKey string `json:"api_key"`
+		Token  string `json:"token"`
+	}
+	if err := json.Unmarshal(data, &creds); err != nil {
+		return ""
+	}
+	if strings.TrimSpace(creds.APIKey) != "" {
+		return strings.TrimSpace(creds.APIKey)
+	}
+	return strings.TrimSpace(creds.Token)
+}
+
+func fetchUsage(ctx context.Context, token string, httpTimeout float64) (fetch.FetchResult, error) {
+	client := httpclient.NewFromConfig(httpTimeout)
+	payload := GraphQLRequest{
+		OperationName: "GetRequestLimitInfo",
+		Query:         warpUsageQuery,
+		Variables:     map[string]any{},
+	}
+
+	headers := []httpclient.RequestOption{
+		httpclient.WithBearer(token),
+		httpclient.WithHeader("x-warp-client-id", "vibeusage"),
+		httpclient.WithHeader("x-warp-os", "linux"),
+		httpclient.WithHeader("User-Agent", "warp/0 vibeusage/1"),
+	}
+
+	var gqlResp GraphQLResponse
+	resp, err := client.PostJSONCtx(ctx, requestLimitURL, payload, &gqlResp, headers...)
+	if err != nil {
+		return fetch.ResultFail("Request failed: " + err.Error()), nil
+	}
+
+	if resp.StatusCode == 401 || resp.StatusCode == 403 {
+		return fetch.ResultFatal("Token invalid or expired. Run `vibeusage auth warp` to re-authenticate."), nil
+	}
+	if resp.StatusCode != 200 {
+		return fetch.ResultFail(fmt.Sprintf("Warp usage request failed: HTTP %d (%s)", resp.StatusCode, summarizeBody(resp.Body))), nil
+	}
+	if resp.JSONErr != nil {
+		return fetch.ResultFail(fmt.Sprintf("Invalid response from Warp API: %v", resp.JSONErr)), nil
+	}
+
+	snapshot, err := parseUsageSnapshot(gqlResp)
+	if err != nil {
+		if isAuthGraphQLError(err) {
+			return fetch.ResultFatal("Token invalid or expired. Run `vibeusage auth warp` to re-authenticate."), nil
+		}
+		return fetch.ResultFail("Failed to parse Warp usage: " + err.Error()), nil
+	}
+	return fetch.ResultOK(*snapshot), nil
+}
+
+const warpUsageQuery = `query GetRequestLimitInfo { requestLimitInfo { requestLimit requestsUsed nextRefreshTime isUnlimited bonusCredits { used total nextRefreshTime } } }`
+
+type GraphQLRequest struct {
+	OperationName string         `json:"operationName"`
+	Query         string         `json:"query"`
+	Variables     map[string]any `json:"variables"`
+}
+
+type GraphQLResponse struct {
+	Data   *GraphQLData   `json:"data"`
+	Errors []GraphQLError `json:"errors"`
+}
+
+type GraphQLData struct {
+	RequestLimitInfo *RequestLimitInfo `json:"requestLimitInfo"`
+}
+
+type GraphQLError struct {
+	Message string `json:"message"`
+}
+
+type RequestLimitInfo struct {
+	RequestLimit    int           `json:"requestLimit"`
+	RequestsUsed    int           `json:"requestsUsed"`
+	NextRefreshTime string        `json:"nextRefreshTime"`
+	IsUnlimited     bool          `json:"isUnlimited"`
+	BonusCredits    *BonusCredits `json:"bonusCredits,omitempty"`
+}
+
+type BonusCredits struct {
+	Used            int    `json:"used"`
+	Total           int    `json:"total"`
+	NextRefreshTime string `json:"nextRefreshTime"`
+}
+
+func parseUsageSnapshot(resp GraphQLResponse) (*models.UsageSnapshot, error) {
+	if len(resp.Errors) > 0 {
+		return nil, fmt.Errorf("graphql error: %s", resp.Errors[0].Message)
+	}
+	if resp.Data == nil || resp.Data.RequestLimitInfo == nil {
+		return nil, fmt.Errorf("missing requestLimitInfo")
+	}
+	info := resp.Data.RequestLimitInfo
+
+	utilization := 0
+	if !info.IsUnlimited && info.RequestLimit > 0 {
+		utilization = clampPct((info.RequestsUsed * 100) / info.RequestLimit)
+	}
+	primary := models.UsagePeriod{
+		Name:        "Monthly Credits",
+		Utilization: utilization,
+		PeriodType:  models.PeriodMonthly,
+		ResetsAt:    parseRFC3339Ptr(info.NextRefreshTime),
+	}
+
+	periods := []models.UsagePeriod{primary}
+	if info.BonusCredits != nil && info.BonusCredits.Total > 0 {
+		bonusUtil := clampPct((info.BonusCredits.Used * 100) / info.BonusCredits.Total)
+		periods = append(periods, models.UsagePeriod{
+			Name:        "Bonus Credits",
+			Utilization: bonusUtil,
+			PeriodType:  models.PeriodMonthly,
+			ResetsAt:    parseRFC3339Ptr(info.BonusCredits.NextRefreshTime),
+		})
+	}
+
+	return &models.UsageSnapshot{
+		Provider:  "warp",
+		FetchedAt: time.Now().UTC(),
+		Periods:   periods,
+		Source:    "api_key",
+	}, nil
+}
+
+func isAuthGraphQLError(err error) bool {
+	s := strings.ToLower(err.Error())
+	return strings.Contains(s, "unauthorized") || strings.Contains(s, "forbidden") || strings.Contains(s, "auth")
+}
+
+func parseRFC3339Ptr(raw string) *time.Time {
+	if strings.TrimSpace(raw) == "" {
+		return nil
+	}
+	t, err := time.Parse(time.RFC3339, raw)
+	if err != nil {
+		return nil
+	}
+	return &t
+}
+
+func clampPct(v int) int {
+	if v < 0 {
+		return 0
+	}
+	if v > 100 {
+		return 100
+	}
+	return v
+}
+
+func summarizeBody(body []byte) string {
+	s := strings.TrimSpace(string(body))
+	if s == "" {
+		return "empty body"
+	}
+	if len(s) > 120 {
+		return s[:120] + "..."
+	}
+	return s
+}

--- a/internal/provider/warp/warp_test.go
+++ b/internal/provider/warp/warp_test.go
@@ -1,0 +1,91 @@
+package warp
+
+import (
+	"context"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+)
+
+func TestParseUsageSnapshot_HappyPath(t *testing.T) {
+	resp := GraphQLResponse{
+		Data: &GraphQLData{
+			RequestLimitInfo: &RequestLimitInfo{
+				RequestLimit:    1000,
+				RequestsUsed:    250,
+				NextRefreshTime: "2026-03-01T00:00:00Z",
+			},
+		},
+	}
+
+	snapshot, err := parseUsageSnapshot(resp)
+	if err != nil {
+		t.Fatalf("parseUsageSnapshot() error = %v", err)
+	}
+	if len(snapshot.Periods) != 1 {
+		t.Fatalf("period count = %d, want 1", len(snapshot.Periods))
+	}
+	if snapshot.Periods[0].Utilization != 25 {
+		t.Errorf("utilization = %d, want 25", snapshot.Periods[0].Utilization)
+	}
+}
+
+func TestParseUsageSnapshot_UnlimitedPlan(t *testing.T) {
+	resp := GraphQLResponse{
+		Data: &GraphQLData{
+			RequestLimitInfo: &RequestLimitInfo{
+				IsUnlimited:  true,
+				RequestsUsed: 700,
+			},
+		},
+	}
+
+	snapshot, err := parseUsageSnapshot(resp)
+	if err != nil {
+		t.Fatalf("parseUsageSnapshot() error = %v", err)
+	}
+	if snapshot.Periods[0].Utilization != 0 {
+		t.Errorf("utilization = %d, want 0 for unlimited", snapshot.Periods[0].Utilization)
+	}
+}
+
+func TestParseUsageSnapshot_MissingFields(t *testing.T) {
+	_, err := parseUsageSnapshot(GraphQLResponse{Data: &GraphQLData{}})
+	if err == nil {
+		t.Fatal("expected error for missing requestLimitInfo")
+	}
+}
+
+func TestGraphQLErrorArrayParsing(t *testing.T) {
+	_, err := parseUsageSnapshot(GraphQLResponse{Errors: []GraphQLError{{Message: "backend unavailable"}}})
+	if err == nil {
+		t.Fatal("expected graphql error")
+	}
+	if !strings.Contains(err.Error(), "backend unavailable") {
+		t.Errorf("error = %q, want graphql message", err)
+	}
+}
+
+func TestFetchUsage_AuthFailure(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusForbidden)
+		_, _ = w.Write([]byte(`{"errors":[{"message":"forbidden"}]}`))
+	}))
+	defer srv.Close()
+
+	oldURL := requestLimitURL
+	requestLimitURL = srv.URL
+	defer func() { requestLimitURL = oldURL }()
+
+	result, err := fetchUsage(context.Background(), "wk-test", 5)
+	if err != nil {
+		t.Fatalf("fetchUsage() err = %v", err)
+	}
+	if result.ShouldFallback {
+		t.Fatal("auth failure should be fatal")
+	}
+	if !strings.Contains(strings.ToLower(result.Error), "warp") {
+		t.Errorf("error = %q, want warp auth hint", result.Error)
+	}
+}


### PR DESCRIPTION
## Summary
- add new providers: OpenRouter, Warp, KimiK2, and Amp
- wire providers into CLI registration and key management flows
- add typed parsing + auth failure handling tests for each new provider
- update docs and mark Milestone A as complete in PARITY_PLAN.md

## Validation
- just fmt
- just lint
- just test