### PR TITLE
Rename provider ID from kimi to kimicode

### DIFF
--- a/PARITY_PLAN.md
+++ b/PARITY_PLAN.md
@@ -4,7 +4,7 @@
 
 vibeusage currently ships 9 providers:
 
-`claude`, `gemini`, `codex`, `copilot`, `cursor`, `antigravity`, `kimi`, `minimax`, `zai`
+`claude`, `gemini`, `codex`, `copilot`, `cursor`, `antigravity`, `kimicode`, `minimax`, `zai`
 
 Reference apps:
 

--- a/README.md
+++ b/README.md
@@ -2,12 +2,12 @@
 
 Track usage across agentic LLM providers from your terminal.
 
-A unified CLI tool that aggregates usage statistics from Claude, OpenAI Codex, GitHub Copilot, Cursor, Gemini, Antigravity, Kimi, Kimi K2, OpenRouter, Warp, Amp, Z.ai, and Minimax with consistent formatting, progress indicators, and offline support.
+A unified CLI tool that aggregates usage statistics from Claude, OpenAI Codex, GitHub Copilot, Cursor, Gemini, Antigravity, Kimi Code, Kimi K2, OpenRouter, Warp, Amp, Z.ai, and Minimax with consistent formatting, progress indicators, and offline support.
 
 ## Features
 
 - **Unified Interface**: Single command to check usage across all configured providers
-- **Multiple Providers**: Claude, Codex, Copilot, Cursor, Gemini, Antigravity, Kimi, Kimi K2, OpenRouter, Warp, Amp, Z.ai, Minimax
+- **Multiple Providers**: Claude, Codex, Copilot, Cursor, Gemini, Antigravity, Kimi Code, Kimi K2, OpenRouter, Warp, Amp, Z.ai, Minimax
 - **Concurrent Fetching**: Check all providers in parallel
 - **Offline Support**: Displays cached data when network is unavailable
 - **JSON Output**: Scriptable with `--json` flag
@@ -62,7 +62,7 @@ vibeusage copilot
 vibeusage cursor
 vibeusage gemini
 vibeusage antigravity
-vibeusage kimi
+vibeusage kimicode
 vibeusage kimik2
 vibeusage openrouter
 vibeusage warp
@@ -205,17 +205,17 @@ Antigravity credentials are automatically detected from the IDE's state database
 vibeusage antigravity
 ```
 
-### Kimi (Moonshot AI)
+### Kimi Code (Moonshot AI)
 
 **Required**: OAuth token via device flow or API key
 
 ```bash
 # Option 1: Device flow OAuth (recommended)
-vibeusage auth kimi
+vibeusage auth kimicode
 
 # Option 2: Use API key
 export KIMI_CODE_API_KEY=your_api_key_here
-vibeusage kimi
+vibeusage kimicode
 ```
 
 For device flow, you'll be prompted to authorize in your browser. If you have the [kimi-cli](https://github.com/MoonshotAI/kimi-cli) installed, vibeusage will automatically use its credentials from `~/.kimi/credentials/kimi-code.json`.
@@ -295,7 +295,7 @@ vibeusage auth openrouter
 vibeusage auth warp
 vibeusage auth kimik2
 vibeusage auth amp
-vibeusage auth kimi
+vibeusage auth kimicode
 vibeusage auth minimax
 vibeusage auth zai
 

--- a/internal/cli/init.go
+++ b/internal/cli/init.go
@@ -19,6 +19,7 @@ var providerDescriptions = map[string]string{
 	"cursor":     "Cursor AI code editor (cursor.com)",
 	"gemini":     "Google's Gemini AI (gemini.google.com)",
 	"kimik2":     "Kimi K2 API usage (kimi-k2.ai)",
+	"kimicode":   "Kimi Code coding assistant (kimi.com)",
 	"openrouter": "OpenRouter unified model gateway (openrouter.ai)",
 	"warp":       "Warp terminal AI (warp.dev)",
 }

--- a/internal/cli/key.go
+++ b/internal/cli/key.go
@@ -23,7 +23,7 @@ var keyCmd = &cobra.Command{
 }
 
 func init() {
-	for _, id := range []string{"amp", "antigravity", "claude", "codex", "copilot", "cursor", "gemini", "kimik2", "kimi", "minimax", "openrouter", "warp", "zai"} {
+	for _, id := range []string{"amp", "antigravity", "claude", "codex", "copilot", "cursor", "gemini", "kimik2", "kimicode", "minimax", "openrouter", "warp", "zai"} {
 		keyCmd.AddCommand(makeKeyProviderCmd(id))
 	}
 }
@@ -96,7 +96,7 @@ var credentialKeyMap = map[string]string{
 	"cursor":      "session_token",
 	"gemini":      "access_token",
 	"kimik2":      "api_key",
-	"kimi":        "api_key",
+	"kimicode":    "api_key",
 	"minimax":     "api_key",
 	"openrouter":  "api_key",
 	"warp":        "api_key",
@@ -108,7 +108,7 @@ func makeKeyProviderCmd(providerID string) *cobra.Command {
 	switch providerID {
 	case "antigravity", "codex", "copilot", "gemini":
 		credType = "oauth"
-	case "amp", "kimik2", "kimi", "minimax", "openrouter", "warp", "zai":
+	case "amp", "kimik2", "kimicode", "minimax", "openrouter", "warp", "zai":
 		credType = "apikey"
 	}
 

--- a/internal/cli/key_test.go
+++ b/internal/cli/key_test.go
@@ -261,10 +261,14 @@ func TestKeyStatusJSON_UsesTypedStruct(t *testing.T) {
 }
 
 func TestKeyCommand_HasP0ProviderSubcommands(t *testing.T) {
-	for _, providerID := range []string{"openrouter", "warp", "kimik2", "amp"} {
+	for _, providerID := range []string{"openrouter", "warp", "kimik2", "kimicode", "amp"} {
 		if cmd := findSubcommand(keyCmd, providerID); cmd == nil {
 			t.Errorf("key command missing provider subcommand %q", providerID)
 		}
+	}
+
+	if cmd := findSubcommand(keyCmd, "kimi"); cmd != nil {
+		t.Error("key command should not expose legacy provider subcommand \"kimi\"")
 	}
 }
 

--- a/internal/cli/root.go
+++ b/internal/cli/root.go
@@ -25,7 +25,7 @@ import (
 	_ "github.com/joshuadavidthomas/vibeusage/internal/provider/copilot"
 	_ "github.com/joshuadavidthomas/vibeusage/internal/provider/cursor"
 	_ "github.com/joshuadavidthomas/vibeusage/internal/provider/gemini"
-	_ "github.com/joshuadavidthomas/vibeusage/internal/provider/kimi"
+	_ "github.com/joshuadavidthomas/vibeusage/internal/provider/kimicode"
 	_ "github.com/joshuadavidthomas/vibeusage/internal/provider/kimik2"
 	_ "github.com/joshuadavidthomas/vibeusage/internal/provider/minimax"
 	_ "github.com/joshuadavidthomas/vibeusage/internal/provider/openrouter"
@@ -46,7 +46,7 @@ var (
 var rootCmd = &cobra.Command{
 	Use:          "vibeusage",
 	Short:        "Track usage across agentic LLM providers",
-	Long:         "A unified CLI tool that aggregates usage statistics from Amp, Antigravity, Claude, Codex, Copilot, Cursor, Gemini, Kimi, Kimi K2, Minimax, OpenRouter, Warp, and Z.ai.",
+	Long:         "A unified CLI tool that aggregates usage statistics from Amp, Antigravity, Claude, Codex, Copilot, Cursor, Gemini, Kimi Code, Kimi K2, Minimax, OpenRouter, Warp, and Z.ai.",
 	SilenceUsage: true,
 	PersistentPreRun: func(cmd *cobra.Command, args []string) {
 		if verbose && quiet {

--- a/internal/cli/root_test.go
+++ b/internal/cli/root_test.go
@@ -44,7 +44,7 @@ func TestRootCmd_HasExpectedSubcommands(t *testing.T) {
 }
 
 func TestRootCmd_HasProviderSubcommands(t *testing.T) {
-	providers := []string{"claude", "codex", "copilot", "cursor", "gemini", "openrouter", "warp", "kimik2", "amp"}
+	providers := []string{"claude", "codex", "copilot", "cursor", "gemini", "openrouter", "warp", "kimik2", "kimicode", "amp"}
 	for _, name := range providers {
 		found := false
 		for _, cmd := range rootCmd.Commands() {
@@ -55,6 +55,12 @@ func TestRootCmd_HasProviderSubcommands(t *testing.T) {
 		}
 		if !found {
 			t.Errorf("rootCmd missing provider subcommand %q", name)
+		}
+	}
+
+	for _, cmd := range rootCmd.Commands() {
+		if cmd.Name() == "kimi" {
+			t.Error("rootCmd should not expose legacy provider subcommand \"kimi\"")
 		}
 	}
 }

--- a/internal/modelmap/registry.go
+++ b/internal/modelmap/registry.go
@@ -4,13 +4,13 @@ import "strings"
 
 // providerSources maps vibeusage provider IDs to models.dev provider IDs.
 var providerSources = map[string]string{
-	"claude":  "anthropic",
-	"copilot": "github-copilot",
-	"codex":   "openai",
-	"gemini":  "google",
-	"kimi":    "moonshotai",
-	"minimax": "minimax",
-	"zai":     "zai",
+	"claude":   "anthropic",
+	"copilot":  "github-copilot",
+	"codex":    "openai",
+	"gemini":   "google",
+	"kimicode": "moonshotai",
+	"minimax":  "minimax",
+	"zai":      "zai",
 }
 
 // inferredProviders maps vibeusage providers that aren't in models.dev to the

--- a/internal/provider/auth.go
+++ b/internal/provider/auth.go
@@ -11,7 +11,7 @@ type AuthFlow interface {
 }
 
 // DeviceAuthFlow wraps an OAuth/device-code flow provided by the
-// provider package (e.g. copilot.RunDeviceFlow, kimi.RunDeviceFlow).
+// provider package (e.g. copilot.RunDeviceFlow, kimicode.RunDeviceFlow).
 type DeviceAuthFlow struct {
 	RunFlow func(w io.Writer, quiet bool) (bool, error)
 }

--- a/internal/provider/kimicode/kimicode.go
+++ b/internal/provider/kimicode/kimicode.go
@@ -1,4 +1,4 @@
-package kimi
+package kimicode
 
 import (
 	"context"
@@ -18,25 +18,25 @@ import (
 	"github.com/joshuadavidthomas/vibeusage/internal/provider"
 )
 
-type Kimi struct{}
+type KimiCode struct{}
 
-func (k Kimi) Meta() provider.Metadata {
+func (k KimiCode) Meta() provider.Metadata {
 	return provider.Metadata{
-		ID:          "kimi",
-		Name:        "Kimi",
+		ID:          "kimicode",
+		Name:        "Kimi Code",
 		Description: "Moonshot AI coding assistant",
 		Homepage:    "https://www.kimi.com",
 	}
 }
 
-func (k Kimi) CredentialSources() provider.CredentialInfo {
+func (k KimiCode) CredentialSources() provider.CredentialInfo {
 	return provider.CredentialInfo{
 		CLIPaths: []string{"~/.kimi/credentials/kimi-code.json"},
 		EnvVars:  []string{"KIMI_CODE_API_KEY"},
 	}
 }
 
-func (k Kimi) FetchStrategies() []fetch.Strategy {
+func (k KimiCode) FetchStrategies() []fetch.Strategy {
 	timeout := config.Get().Fetch.Timeout
 	return []fetch.Strategy{
 		&DeviceFlowStrategy{HTTPTimeout: timeout},
@@ -44,17 +44,17 @@ func (k Kimi) FetchStrategies() []fetch.Strategy {
 	}
 }
 
-func (k Kimi) FetchStatus(_ context.Context) models.ProviderStatus {
+func (k KimiCode) FetchStatus(_ context.Context) models.ProviderStatus {
 	return models.ProviderStatus{Level: models.StatusUnknown}
 }
 
-// Auth returns the Kimi device flow.
-func (k Kimi) Auth() provider.AuthFlow {
+// Auth returns the Kimi Code device flow.
+func (k KimiCode) Auth() provider.AuthFlow {
 	return provider.DeviceAuthFlow{RunFlow: RunDeviceFlow}
 }
 
 func init() {
-	provider.Register(Kimi{})
+	provider.Register(KimiCode{})
 }
 
 const (
@@ -110,7 +110,7 @@ func (s *DeviceFlowStrategy) IsAvailable() bool {
 }
 
 func (s *DeviceFlowStrategy) credentialPaths() []string {
-	paths := []string{config.CredentialPath("kimi", "oauth")}
+	paths := []string{config.CredentialPath("kimicode", "oauth")}
 	// kimi-cli stores credentials at ~/.kimi/credentials/kimi-code.json
 	home, err := os.UserHomeDir()
 	if err == nil {
@@ -122,7 +122,7 @@ func (s *DeviceFlowStrategy) credentialPaths() []string {
 func (s *DeviceFlowStrategy) Fetch(ctx context.Context) (fetch.FetchResult, error) {
 	creds := s.loadCredentials()
 	if creds == nil {
-		return fetch.ResultFail("No OAuth credentials found. Run `vibeusage auth kimi` to authenticate."), nil
+		return fetch.ResultFail("No OAuth credentials found. Run `vibeusage auth kimicode` to authenticate."), nil
 	}
 
 	if creds.AccessToken == "" {
@@ -132,7 +132,7 @@ func (s *DeviceFlowStrategy) Fetch(ctx context.Context) (fetch.FetchResult, erro
 	if creds.NeedsRefresh() {
 		refreshed := s.refreshToken(ctx, creds)
 		if refreshed == nil {
-			return fetch.ResultFail("Failed to refresh token. Run `vibeusage auth kimi` to re-authenticate."), nil
+			return fetch.ResultFail("Failed to refresh token. Run `vibeusage auth kimicode` to re-authenticate."), nil
 		}
 		creds = refreshed
 	}
@@ -197,7 +197,7 @@ func (s *DeviceFlowStrategy) refreshToken(ctx context.Context, creds *OAuthCrede
 	}
 
 	content, _ := json.Marshal(updated)
-	_ = config.WriteCredential(config.CredentialPath("kimi", "oauth"), content)
+	_ = config.WriteCredential(config.CredentialPath("kimicode", "oauth"), content)
 
 	return updated
 }
@@ -216,7 +216,7 @@ func (s *APIKeyStrategy) IsAvailable() bool {
 func (s *APIKeyStrategy) Fetch(ctx context.Context) (fetch.FetchResult, error) {
 	apiKey := s.loadAPIKey()
 	if apiKey == "" {
-		return fetch.ResultFail("No API key found. Set KIMI_CODE_API_KEY or use 'vibeusage key kimi set'"), nil
+		return fetch.ResultFail("No API key found. Set KIMI_CODE_API_KEY or use 'vibeusage key kimicode set'"), nil
 	}
 
 	return fetchUsage(ctx, apiKey, "api_key", s.HTTPTimeout)
@@ -226,7 +226,7 @@ func (s *APIKeyStrategy) loadAPIKey() string {
 	if key := os.Getenv("KIMI_CODE_API_KEY"); key != "" {
 		return key
 	}
-	path := config.CredentialPath("kimi", "apikey")
+	path := config.CredentialPath("kimicode", "apikey")
 	data, err := config.ReadCredential(path)
 	if err != nil || data == nil {
 		return ""
@@ -252,7 +252,7 @@ func fetchUsage(ctx context.Context, token, source string, httpTimeout float64) 
 	}
 
 	if resp.StatusCode == 401 {
-		return fetch.ResultFatal("Token expired or invalid. Run `vibeusage auth kimi` to re-authenticate."), nil
+		return fetch.ResultFatal("Token expired or invalid. Run `vibeusage auth kimicode` to re-authenticate."), nil
 	}
 	if resp.StatusCode != 200 {
 		return fetch.ResultFail(fmt.Sprintf("Usage request failed: %d", resp.StatusCode)), nil
@@ -325,7 +325,7 @@ func parseUsageResponse(resp UsageResponse, source string) *models.UsageSnapshot
 
 	now := time.Now().UTC()
 	return &models.UsageSnapshot{
-		Provider:  "kimi",
+		Provider:  "kimicode",
 		FetchedAt: now,
 		Periods:   periods,
 		Identity:  identity,
@@ -414,7 +414,7 @@ func RunDeviceFlow(w io.Writer, quiet bool) (bool, error) {
 				creds.ExpiresAt = float64(time.Now().UTC().Unix() + int64(tokenResp.ExpiresIn))
 			}
 			content, _ := json.Marshal(creds)
-			_ = config.WriteCredential(config.CredentialPath("kimi", "oauth"), content)
+			_ = config.WriteCredential(config.CredentialPath("kimicode", "oauth"), content)
 			if !quiet {
 				_, _ = fmt.Fprintln(w, "\n  ✓ Authentication successful!")
 			}

--- a/internal/provider/kimicode/kimicode_test.go
+++ b/internal/provider/kimicode/kimicode_test.go
@@ -1,4 +1,4 @@
-package kimi
+package kimicode
 
 import (
 	"context"
@@ -95,8 +95,8 @@ func TestParseUsageResponse_FullResponse(t *testing.T) {
 	if snapshot == nil {
 		t.Fatal("expected non-nil snapshot")
 	}
-	if snapshot.Provider != "kimi" {
-		t.Errorf("Provider = %q, want %q", snapshot.Provider, "kimi")
+	if snapshot.Provider != "kimicode" {
+		t.Errorf("Provider = %q, want %q", snapshot.Provider, "kimicode")
 	}
 	if snapshot.Source != "device_flow" {
 		t.Errorf("Source = %q, want %q", snapshot.Source, "device_flow")
@@ -184,13 +184,13 @@ func TestParseUsageResponse_NoIdentity(t *testing.T) {
 	}
 }
 
-func TestKimi_Meta(t *testing.T) {
-	k := Kimi{}
+func TestKimiCode_Meta(t *testing.T) {
+	k := KimiCode{}
 	meta := k.Meta()
-	if meta.ID != "kimi" {
-		t.Errorf("ID = %q, want %q", meta.ID, "kimi")
+	if meta.ID != "kimicode" {
+		t.Errorf("ID = %q, want %q", meta.ID, "kimicode")
 	}
-	if meta.Name != "Kimi" {
-		t.Errorf("Name = %q, want %q", meta.Name, "Kimi")
+	if meta.Name != "Kimi Code" {
+		t.Errorf("Name = %q, want %q", meta.Name, "Kimi Code")
 	}
 }

--- a/internal/provider/kimicode/response.go
+++ b/internal/provider/kimicode/response.go
@@ -1,4 +1,4 @@
-package kimi
+package kimicode
 
 import (
 	"strconv"

--- a/internal/provider/kimicode/response_test.go
+++ b/internal/provider/kimicode/response_test.go
@@ -1,4 +1,4 @@
-package kimi
+package kimicode
 
 import (
 	"encoding/json"


### PR DESCRIPTION
## Summary
- rename provider ID and CLI command from `kimi` to `kimicode`
- rename provider package directory to `internal/provider/kimicode`
- update credential paths, auth/key hints, and provider registration wiring
- update modelmap provider source mapping to use `kimicode`
- update README and parity plan references
- add tests asserting `kimicode` exists and legacy `kimi` command is absent

## Validation
- just fmt
- just lint
- just test