### PR TITLE
Improve Claude CLI OAuth refresh latency

### DIFF
--- a/internal/provider/claude/claude.go
+++ b/internal/provider/claude/claude.go
@@ -222,32 +222,72 @@ func (s *OAuthStrategy) refreshToken(ctx context.Context, creds *OAuthCredential
 	return updated
 }
 
-// tryRefreshViaCLI attempts to refresh the OAuth token by running the
-// Claude CLI, which refreshes its stored credentials as a side effect of
-// startup. This handles the case where our own refresh call fails (e.g.
-// because the CLI uses a different client_id or PKCE parameters) but the
-// Claude CLI itself can still refresh successfully.
+// tryRefreshViaCLI attempts to refresh the OAuth token by running Claude CLI
+// print mode, which has been observed to refresh credentials as a side effect.
+// We prefer haiku to minimize refresh cost.
 func (s *OAuthStrategy) tryRefreshViaCLI(ctx context.Context) *OAuthCredentials {
 	claudePath, err := exec.LookPath("claude")
 	if err != nil {
 		return nil
 	}
 
-	tctx, cancel := context.WithTimeout(ctx, 10*time.Second)
+	tctx, cancel := context.WithTimeout(ctx, 2*time.Second)
 	defer cancel()
 
-	cmd := exec.CommandContext(tctx, claudePath, "--version")
+	cmd := exec.CommandContext(tctx, claudePath,
+		"-p", "ok",
+		"--model", "haiku",
+		"--output-format", "json",
+		"--no-session-persistence",
+		"--permission-mode", "plan",
+		"--allowed-tools", "",
+		"--max-budget-usd", "0.001",
+	)
 	cmd.Stdin = nil
 	cmd.Stdout = io.Discard
 	cmd.Stderr = io.Discard
-	_ = cmd.Run()
 
-	// Re-read credentials - return them only if they're now fresh.
-	creds := s.loadCredentials()
-	if creds == nil || creds.NeedsRefresh() {
+	if err := cmd.Start(); err != nil {
 		return nil
 	}
-	return creds
+
+	done := make(chan error, 1)
+	go func() {
+		done <- cmd.Wait()
+	}()
+
+	ticker := time.NewTicker(25 * time.Millisecond)
+	defer ticker.Stop()
+
+	for {
+		if creds := s.loadCredentials(); creds != nil && !creds.NeedsRefresh() {
+			stopCommand(cmd)
+			return creds
+		}
+
+		select {
+		case <-done:
+			creds := s.loadCredentials()
+			if creds == nil || creds.NeedsRefresh() {
+				return nil
+			}
+			return creds
+		case <-tctx.Done():
+			stopCommand(cmd)
+			creds := s.loadCredentials()
+			if creds == nil || creds.NeedsRefresh() {
+				return nil
+			}
+			return creds
+		case <-ticker.C:
+		}
+	}
+}
+
+func stopCommand(cmd *exec.Cmd) {
+	if cmd != nil && cmd.Process != nil {
+		_ = cmd.Process.Kill()
+	}
 }
 
 // inferClaudePlan guesses the plan tier from usage response features.

--- a/internal/provider/claude/refresh_cli_test.go
+++ b/internal/provider/claude/refresh_cli_test.go
@@ -1,0 +1,134 @@
+package claude
+
+import (
+	"context"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/joshuadavidthomas/vibeusage/internal/config"
+)
+
+func TestTryRefreshViaCLI_UsesSingleHaikuAttempt(t *testing.T) {
+	dir := t.TempDir()
+	t.Setenv("VIBEUSAGE_CONFIG_DIR", filepath.Join(dir, "config"))
+
+	expired := time.Now().UTC().Add(-1 * time.Hour).Format(time.RFC3339)
+	writeOAuthCred(t, "expired", "refresh", expired)
+
+	binDir := filepath.Join(dir, "bin")
+	logPath := filepath.Join(dir, "calls.log")
+	createFakeClaude(t, binDir, "#!/usr/bin/env sh\nset -eu\necho \"$@\" >> \"$CLAUDE_CALL_LOG\"\ncred=\"$VIBEUSAGE_CONFIG_DIR/credentials/claude/oauth.json\"\nif [ \"${1:-}\" = \"-p\" ]; then\n  mkdir -p \"$(dirname \"$cred\")\"\n  cat > \"$cred\" <<'JSON'\n{\"access_token\":\"fresh-print\",\"refresh_token\":\"refresh\",\"expires_at\":\"2099-01-01T00:00:00Z\"}\nJSON\nfi\n")
+	t.Setenv("CLAUDE_CALL_LOG", logPath)
+	t.Setenv("PATH", binDir+string(os.PathListSeparator)+os.Getenv("PATH"))
+
+	s := OAuthStrategy{}
+	got := s.tryRefreshViaCLI(context.Background())
+	if got == nil {
+		t.Fatal("tryRefreshViaCLI() = nil, want refreshed credentials")
+	}
+	if got.AccessToken != "fresh-print" {
+		t.Errorf("access_token = %q, want %q", got.AccessToken, "fresh-print")
+	}
+
+	calls := readTrimmed(t, logPath)
+	if len(calls) != 1 {
+		t.Fatalf("expected 1 CLI call, got %d (%v)", len(calls), calls)
+	}
+	if !strings.Contains(calls[0], "--model haiku") {
+		t.Errorf("call = %q, want haiku model", calls[0])
+	}
+}
+
+func TestTryRefreshViaCLI_ReturnsQuicklyAfterRefreshEvenIfCLIHangs(t *testing.T) {
+	dir := t.TempDir()
+	t.Setenv("VIBEUSAGE_CONFIG_DIR", filepath.Join(dir, "config"))
+
+	expired := time.Now().UTC().Add(-1 * time.Hour).Format(time.RFC3339)
+	writeOAuthCred(t, "expired", "refresh", expired)
+
+	binDir := filepath.Join(dir, "bin")
+	logPath := filepath.Join(dir, "calls.log")
+	createFakeClaude(t, binDir, "#!/usr/bin/env sh\nset -eu\necho \"$@\" >> \"$CLAUDE_CALL_LOG\"\ncred=\"$VIBEUSAGE_CONFIG_DIR/credentials/claude/oauth.json\"\nif [ \"${1:-}\" = \"-p\" ]; then\n  mkdir -p \"$(dirname \"$cred\")\"\n  cat > \"$cred\" <<'JSON'\n{\"access_token\":\"fresh-print\",\"refresh_token\":\"refresh\",\"expires_at\":\"2099-01-01T00:00:00Z\"}\nJSON\n  sleep 10\nfi\n")
+	t.Setenv("CLAUDE_CALL_LOG", logPath)
+	t.Setenv("PATH", binDir+string(os.PathListSeparator)+os.Getenv("PATH"))
+
+	s := OAuthStrategy{}
+	start := time.Now()
+	got := s.tryRefreshViaCLI(context.Background())
+	elapsed := time.Since(start)
+	if got == nil {
+		t.Fatal("tryRefreshViaCLI() = nil, want refreshed credentials")
+	}
+	if elapsed >= 2*time.Second {
+		t.Fatalf("tryRefreshViaCLI() took %v, want < 2s", elapsed)
+	}
+
+	calls := readTrimmed(t, logPath)
+	if len(calls) != 1 {
+		t.Fatalf("expected 1 CLI call, got %d (%v)", len(calls), calls)
+	}
+}
+
+func TestTryRefreshViaCLI_ReturnsNilWhenStillExpired(t *testing.T) {
+	dir := t.TempDir()
+	t.Setenv("VIBEUSAGE_CONFIG_DIR", filepath.Join(dir, "config"))
+
+	expired := time.Now().UTC().Add(-1 * time.Hour).Format(time.RFC3339)
+	writeOAuthCred(t, "expired", "refresh", expired)
+
+	binDir := filepath.Join(dir, "bin")
+	logPath := filepath.Join(dir, "calls.log")
+	createFakeClaude(t, binDir, "#!/usr/bin/env sh\nset -eu\necho \"$@\" >> \"$CLAUDE_CALL_LOG\"\nexit 0\n")
+	t.Setenv("CLAUDE_CALL_LOG", logPath)
+	t.Setenv("PATH", binDir+string(os.PathListSeparator)+os.Getenv("PATH"))
+
+	s := OAuthStrategy{}
+	got := s.tryRefreshViaCLI(context.Background())
+	if got != nil {
+		t.Fatalf("tryRefreshViaCLI() = %+v, want nil", got)
+	}
+
+	calls := readTrimmed(t, logPath)
+	if len(calls) != 1 {
+		t.Fatalf("expected 1 CLI call, got %d (%v)", len(calls), calls)
+	}
+	if !strings.Contains(calls[0], "--model haiku") {
+		t.Errorf("call = %q, want haiku model", calls[0])
+	}
+}
+
+func writeOAuthCred(t *testing.T, accessToken, refreshToken, expiresAt string) {
+	t.Helper()
+	path := config.CredentialPath("claude", "oauth")
+	content := []byte("{\"access_token\":\"" + accessToken + "\",\"refresh_token\":\"" + refreshToken + "\",\"expires_at\":\"" + expiresAt + "\"}")
+	if err := config.WriteCredential(path, content); err != nil {
+		t.Fatalf("WriteCredential(%s) error: %v", path, err)
+	}
+}
+
+func createFakeClaude(t *testing.T, binDir, script string) {
+	t.Helper()
+	if err := os.MkdirAll(binDir, 0o755); err != nil {
+		t.Fatalf("MkdirAll(%s) error: %v", binDir, err)
+	}
+	path := filepath.Join(binDir, "claude")
+	if err := os.WriteFile(path, []byte(script), 0o755); err != nil {
+		t.Fatalf("WriteFile(%s) error: %v", path, err)
+	}
+}
+
+func readTrimmed(t *testing.T, path string) []string {
+	t.Helper()
+	data, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatalf("ReadFile(%s) error: %v", path, err)
+	}
+	out := strings.TrimSpace(string(data))
+	if out == "" {
+		return nil
+	}
+	return strings.Split(out, "\n")
+}


### PR DESCRIPTION
## Summary
- replace the old `claude --version` refresh fallback with a single constrained print-mode refresh call
- use `--model haiku` and strict budget/tool flags for a low-cost refresh attempt
- run Claude CLI refresh in the background and poll credential freshness so we return as soon as credentials are refreshed
- keep a short safety timeout (2s) to avoid hangs

## Tests
- add focused unit tests for Claude CLI refresh behavior in `internal/provider/claude/refresh_cli_test.go`
- verify single-attempt haiku invocation
- verify quick return when credentials refresh even if the CLI process hangs
- verify nil result when credentials remain expired

## Validation
- `just fmt`
- `just lint`
- `just test`
