### PR TITLE
feat: add release workflow, install scripts, and self-update command

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,30 @@
+name: release
+
+on:
+  push:
+    tags:
+      - "v*"
+
+permissions:
+  contents: write
+
+jobs:
+  goreleaser:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v6
+        with:
+          fetch-depth: 0
+
+      - uses: actions/setup-go@v6
+        with:
+          go-version-file: go.mod
+
+      - name: Run GoReleaser
+        uses: goreleaser/goreleaser-action@v6
+        with:
+          distribution: goreleaser
+          version: "~> v2"
+          args: release --clean
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -1,0 +1,43 @@
+version: 2
+
+project_name: vibeusage
+
+before:
+  hooks:
+    - go mod tidy
+    - go test ./...
+
+builds:
+  - id: vibeusage
+    main: ./cmd/vibeusage
+    binary: vibeusage
+    env:
+      - CGO_ENABLED=0
+    goos:
+      - linux
+      - darwin
+      - windows
+    goarch:
+      - amd64
+      - arm64
+    ldflags:
+      - -s -w -X github.com/joshuadavidthomas/vibeusage/internal/cli.version={{ .Tag }}
+
+archives:
+  - id: default
+    ids:
+      - vibeusage
+    name_template: "{{ .ProjectName }}_{{ .Os }}_{{ .Arch }}"
+    format_overrides:
+      - goos: windows
+        format: zip
+
+checksum:
+  name_template: checksums.txt
+
+changelog:
+  sort: asc
+  filters:
+    exclude:
+      - '^docs:'
+      - '^test:'

--- a/README.md
+++ b/README.md
@@ -17,9 +17,17 @@ A unified CLI tool that aggregates usage statistics from Claude, OpenAI Codex, G
 
 ## Installation
 
-### Prerequisites
+### Install via GitHub Releases script (macOS/Linux)
 
-- Go 1.25.6 or later
+```bash
+curl -fsSL https://raw.githubusercontent.com/joshuadavidthomas/vibeusage/main/scripts/install.sh | sh
+```
+
+### Install via GitHub Releases script (Windows PowerShell)
+
+```powershell
+iwr https://raw.githubusercontent.com/joshuadavidthomas/vibeusage/main/scripts/install.ps1 -useb | iex
+```
 
 ### Install with go install
 
@@ -32,8 +40,39 @@ go install github.com/joshuadavidthomas/vibeusage@latest
 ```bash
 git clone https://github.com/joshuadavidthomas/vibeusage.git
 cd vibeusage
-go build -o vibeusage .
+go build -o vibeusage ./cmd/vibeusage
 ```
+
+### Install a specific version with scripts
+
+```bash
+curl -fsSL https://raw.githubusercontent.com/joshuadavidthomas/vibeusage/main/scripts/install.sh | VIBEUSAGE_VERSION=v0.1.0 sh
+```
+
+```powershell
+$env:VIBEUSAGE_VERSION = "v0.1.0"
+iwr https://raw.githubusercontent.com/joshuadavidthomas/vibeusage/main/scripts/install.ps1 -useb | iex
+```
+
+## Updating
+
+```bash
+# Check for updates
+vibeusage update --check
+
+# Update to latest release
+vibeusage update
+
+# Non-interactive update
+vibeusage update --yes
+
+# Install a specific version
+vibeusage update --version v0.1.0 --yes
+```
+
+You can also re-run the install scripts to upgrade in place.
+
+Install scripts place the binary in `~/.local/bin` by default (override with `VIBEUSAGE_INSTALL_DIR`). Ensure that directory is on your `PATH`.
 
 ## Quick Start
 
@@ -353,6 +392,25 @@ vibeusage status
 vibeusage status --json
 ```
 
+### Update Commands
+
+```bash
+# Check for updates only
+vibeusage update --check
+
+# Install the latest release
+vibeusage update
+
+# Install without interactive prompt
+vibeusage update --yes
+
+# Install a specific version
+vibeusage update --version v0.1.0 --yes
+
+# JSON output (requires --check or --yes)
+vibeusage update --check --json
+```
+
 ## Configuration
 
 ### Config File Location
@@ -480,6 +538,10 @@ go build -o vibeusage .
 ```bash
 golangci-lint run
 ```
+
+### Release
+
+See `docs/releasing.md` for the tag-and-publish workflow.
 
 ## License
 

--- a/docs/releasing.md
+++ b/docs/releasing.md
@@ -1,0 +1,40 @@
+# Releasing vibeusage
+
+This project publishes release binaries with GoReleaser via GitHub Actions.
+
+## What gets published
+
+Each release creates archives for:
+
+- linux/amd64
+- linux/arm64
+- darwin/amd64
+- darwin/arm64
+- windows/amd64
+- windows/arm64
+
+Assets include:
+
+- `vibeusage_<os>_<arch>.tar.gz` (linux/darwin)
+- `vibeusage_windows_<arch>.zip` (windows)
+- `checksums.txt`
+
+## How to cut a release
+
+1. Ensure CI is green on `main`.
+2. Tag the commit:
+
+```bash
+git tag v0.1.0
+git push origin v0.1.0
+```
+
+3. The `release` workflow runs automatically and creates a GitHub Release.
+
+## Version injection
+
+The runtime `vibeusage --version` value is injected from the tag by GoReleaser:
+
+- `internal/cli.version` is set via `-ldflags`.
+
+Local builds default to `dev`.

--- a/go.mod
+++ b/go.mod
@@ -13,6 +13,7 @@ require (
 	github.com/mattn/go-isatty v0.0.20
 	github.com/muesli/termenv v0.16.0
 	github.com/spf13/cobra v1.10.2
+	golang.org/x/mod v0.17.0
 	google.golang.org/protobuf v1.36.11
 	gopkg.in/yaml.v3 v3.0.1
 )

--- a/go.sum
+++ b/go.sum
@@ -86,6 +86,8 @@ github.com/xo/terminfo v0.0.0-20220910002029-abceb7e1c41e/go.mod h1:RbqR21r5mrJu
 go.yaml.in/yaml/v3 v3.0.4/go.mod h1:DhzuOOF2ATzADvBadXxruRBLzYTpT36CKvDb3+aBEFg=
 golang.org/x/exp v0.0.0-20231006140011-7918f672742d h1:jtJma62tbqLibJ5sFQz8bKtEM8rJBtfilJ2qTU199MI=
 golang.org/x/exp v0.0.0-20231006140011-7918f672742d/go.mod h1:ldy0pHrwJyGW56pPQzzkH36rKxoZW1tw7ZJpeKx+hdo=
+golang.org/x/mod v0.17.0 h1:zY54UmvipHiNd+pm+m0x9KhZ9hl1/7QNMyxXbc6ICqA=
+golang.org/x/mod v0.17.0/go.mod h1:hTbmBsO62+eylJbnUtE2MGJUyE7QWk4xUqPFrRgJ+7c=
 golang.org/x/sync v0.15.0 h1:KWH3jNZsfyT6xfAfKiz6MRNmd46ByHDYaZ7KSkCtdW8=
 golang.org/x/sync v0.15.0/go.mod h1:1dzgHSNfp02xaA81J2MS99Qcpr2w7fw1gpm99rleRqA=
 golang.org/x/sys v0.0.0-20210809222454-d867a43fc93e/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=

--- a/internal/cli/root.go
+++ b/internal/cli/root.go
@@ -33,7 +33,8 @@ import (
 	_ "github.com/joshuadavidthomas/vibeusage/internal/provider/zai"
 )
 
-const version = "0.1.0"
+// version is injected at build time via -ldflags.
+var version = "dev"
 
 var (
 	jsonOutput bool
@@ -79,6 +80,7 @@ func init() {
 	rootCmd.AddCommand(keyCmd)
 	rootCmd.AddCommand(initCmd)
 	rootCmd.AddCommand(routeCmd)
+	rootCmd.AddCommand(updateCmd)
 
 	ids := provider.ListIDs()
 	sort.Strings(ids)

--- a/internal/cli/root_test.go
+++ b/internal/cli/root_test.go
@@ -28,7 +28,7 @@ func resetPathFlags(t *testing.T) {
 // Root command tests
 
 func TestRootCmd_HasExpectedSubcommands(t *testing.T) {
-	expected := []string{"auth", "status", "config", "cache", "key", "init"}
+	expected := []string{"auth", "status", "config", "cache", "key", "init", "update"}
 	for _, name := range expected {
 		found := false
 		for _, cmd := range rootCmd.Commands() {

--- a/internal/cli/update.go
+++ b/internal/cli/update.go
@@ -1,0 +1,157 @@
+package cli
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/spf13/cobra"
+
+	"github.com/joshuadavidthomas/vibeusage/internal/display"
+	"github.com/joshuadavidthomas/vibeusage/internal/prompt"
+	"github.com/joshuadavidthomas/vibeusage/internal/updater"
+)
+
+var (
+	updateCheckOnly bool
+	updateYes       bool
+	updateVersion   string
+)
+
+var updaterFactory = func() updater.Service {
+	return updater.NewClient()
+}
+
+var updateCmd = &cobra.Command{
+	Use:   "update",
+	Short: "Check for updates and install newer releases",
+	RunE: func(cmd *cobra.Command, args []string) error {
+		return runUpdate(cmd.Context())
+	},
+}
+
+func init() {
+	updateCmd.Flags().BoolVar(&updateCheckOnly, "check", false, "Check for updates without installing")
+	updateCmd.Flags().BoolVarP(&updateYes, "yes", "y", false, "Install update without interactive confirmation")
+	updateCmd.Flags().StringVar(&updateVersion, "version", "", "Install a specific version (for example: v1.2.3)")
+}
+
+func runUpdate(ctx context.Context) error {
+	service := updaterFactory()
+	check, err := service.Check(ctx, updater.CheckRequest{
+		CurrentVersion: version,
+		TargetVersion:  updateVersion,
+	})
+	if err != nil {
+		return fmt.Errorf("failed to check for updates: %w", err)
+	}
+
+	if updateCheckOnly {
+		return outputUpdateCheck(check)
+	}
+
+	if !check.UpdateAvailable {
+		return outputUpdateCheck(check)
+	}
+
+	if jsonOutput && !updateYes {
+		return fmt.Errorf("--json update install requires --yes to avoid interactive prompts")
+	}
+
+	if !updateYes {
+		confirmed, err := confirmUpdate(check)
+		if err != nil {
+			return err
+		}
+		if !confirmed {
+			if jsonOutput {
+				return display.OutputJSON(outWriter, display.UpdateStatusJSON{
+					CurrentVersion:  check.CurrentVersion,
+					LatestVersion:   check.LatestVersion,
+					TargetVersion:   check.TargetVersion,
+					UpdateAvailable: check.UpdateAvailable,
+					IsDowngrade:     check.IsDowngrade,
+					Applied:         false,
+				})
+			}
+			outln("Update canceled")
+			return nil
+		}
+	}
+
+	apply, err := service.Apply(ctx, updater.ApplyRequest{
+		Check:          check,
+		AllowDowngrade: updateVersion != "",
+	})
+	if err != nil {
+		return fmt.Errorf("failed to apply update: %w", err)
+	}
+
+	if jsonOutput {
+		return display.OutputJSON(outWriter, display.UpdateStatusJSON{
+			CurrentVersion:  check.CurrentVersion,
+			LatestVersion:   check.LatestVersion,
+			TargetVersion:   check.TargetVersion,
+			UpdateAvailable: check.UpdateAvailable,
+			IsDowngrade:     check.IsDowngrade,
+			Asset:           check.AssetName,
+			Applied:         apply.Updated,
+			Pending:         apply.Pending,
+		})
+	}
+
+	if apply.Pending {
+		out("✓ Staged update to %s; restart your shell and rerun vibeusage\n", check.TargetVersion)
+		return nil
+	}
+
+	out("✓ Updated vibeusage %s → %s\n", check.CurrentVersion, check.TargetVersion)
+	return nil
+}
+
+func outputUpdateCheck(check updater.CheckResult) error {
+	if jsonOutput {
+		return display.OutputJSON(outWriter, display.UpdateStatusJSON{
+			CurrentVersion:  check.CurrentVersion,
+			LatestVersion:   check.LatestVersion,
+			TargetVersion:   check.TargetVersion,
+			UpdateAvailable: check.UpdateAvailable,
+			IsDowngrade:     check.IsDowngrade,
+			Asset:           check.AssetName,
+		})
+	}
+
+	if check.UpdateAvailable {
+		if check.IsDowngrade {
+			out("Version change available (downgrade): %s → %s\n", check.CurrentVersion, check.TargetVersion)
+		} else {
+			out("Update available: %s → %s\n", check.CurrentVersion, check.TargetVersion)
+		}
+		out("Run `vibeusage update --yes` to install.\n")
+		return nil
+	}
+
+	out("vibeusage is up to date (%s)\n", check.CurrentVersion)
+	return nil
+}
+
+func confirmUpdate(check updater.CheckResult) (bool, error) {
+	if !isTerminal() {
+		return false, fmt.Errorf("interactive confirmation required; rerun with --yes")
+	}
+
+	title := fmt.Sprintf("Install update %s → %s?", check.CurrentVersion, check.TargetVersion)
+	if check.IsDowngrade {
+		title = fmt.Sprintf("Install downgrade %s → %s?", check.CurrentVersion, check.TargetVersion)
+	}
+
+	confirmed, err := prompt.Default.Confirm(prompt.ConfirmConfig{
+		Title:       title,
+		Description: "The binary will be replaced in place.",
+		Affirmative: "Install",
+		Negative:    "Cancel",
+	})
+	if err != nil {
+		return false, err
+	}
+	return confirmed, nil
+}

--- a/internal/cli/update_test.go
+++ b/internal/cli/update_test.go
@@ -1,0 +1,192 @@
+package cli
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"errors"
+	"os"
+	"strings"
+	"testing"
+
+	"github.com/joshuadavidthomas/vibeusage/internal/display"
+	"github.com/joshuadavidthomas/vibeusage/internal/updater"
+)
+
+type fakeUpdaterService struct {
+	checkResult updater.CheckResult
+	checkErr    error
+	applyResult updater.ApplyResult
+	applyErr    error
+	applyCalls  int
+}
+
+func (f *fakeUpdaterService) Check(ctx context.Context, req updater.CheckRequest) (updater.CheckResult, error) {
+	if f.checkErr != nil {
+		return updater.CheckResult{}, f.checkErr
+	}
+	return f.checkResult, nil
+}
+
+func (f *fakeUpdaterService) Apply(ctx context.Context, req updater.ApplyRequest) (updater.ApplyResult, error) {
+	f.applyCalls++
+	if f.applyErr != nil {
+		return updater.ApplyResult{}, f.applyErr
+	}
+	return f.applyResult, nil
+}
+
+func TestRunUpdate_CheckJSON(t *testing.T) {
+	service := &fakeUpdaterService{
+		checkResult: updater.CheckResult{
+			CurrentVersion:  "v1.0.0",
+			LatestVersion:   "v1.1.0",
+			TargetVersion:   "v1.1.0",
+			UpdateAvailable: true,
+			AssetName:       "vibeusage_linux_amd64.tar.gz",
+		},
+	}
+
+	oldFactory := updaterFactory
+	updaterFactory = func() updater.Service { return service }
+	defer func() { updaterFactory = oldFactory }()
+
+	oldJSON := jsonOutput
+	jsonOutput = true
+	defer func() { jsonOutput = oldJSON }()
+
+	oldCheckOnly := updateCheckOnly
+	updateCheckOnly = true
+	defer func() { updateCheckOnly = oldCheckOnly }()
+
+	oldYes := updateYes
+	updateYes = false
+	defer func() { updateYes = oldYes }()
+
+	oldVersionFlag := updateVersion
+	updateVersion = ""
+	defer func() { updateVersion = oldVersionFlag }()
+
+	var buf bytes.Buffer
+	outWriter = &buf
+	defer func() { outWriter = os.Stdout }()
+
+	if err := runUpdate(context.Background()); err != nil {
+		t.Fatalf("runUpdate error: %v", err)
+	}
+
+	var got display.UpdateStatusJSON
+	if err := json.Unmarshal(buf.Bytes(), &got); err != nil {
+		t.Fatalf("invalid JSON output: %v\nOutput: %s", err, buf.String())
+	}
+	if !got.UpdateAvailable {
+		t.Fatal("expected update_available=true")
+	}
+	if got.TargetVersion != "v1.1.0" {
+		t.Fatalf("target_version = %q, want %q", got.TargetVersion, "v1.1.0")
+	}
+}
+
+func TestRunUpdate_ApplyRequiresYesNonInteractive(t *testing.T) {
+	service := &fakeUpdaterService{
+		checkResult: updater.CheckResult{
+			CurrentVersion:  "v1.0.0",
+			LatestVersion:   "v1.1.0",
+			TargetVersion:   "v1.1.0",
+			UpdateAvailable: true,
+		},
+	}
+
+	oldFactory := updaterFactory
+	updaterFactory = func() updater.Service { return service }
+	defer func() { updaterFactory = oldFactory }()
+
+	oldJSON := jsonOutput
+	jsonOutput = false
+	defer func() { jsonOutput = oldJSON }()
+
+	oldCheckOnly := updateCheckOnly
+	updateCheckOnly = false
+	defer func() { updateCheckOnly = oldCheckOnly }()
+
+	oldYes := updateYes
+	updateYes = false
+	defer func() { updateYes = oldYes }()
+
+	err := runUpdate(context.Background())
+	if err == nil {
+		t.Fatal("expected error without --yes in non-interactive mode")
+	}
+	if !strings.Contains(err.Error(), "rerun with --yes") {
+		t.Fatalf("error = %q, want rerun with --yes guidance", err.Error())
+	}
+	if service.applyCalls != 0 {
+		t.Fatalf("applyCalls = %d, want 0", service.applyCalls)
+	}
+}
+
+func TestRunUpdate_ApplyWithYes(t *testing.T) {
+	service := &fakeUpdaterService{
+		checkResult: updater.CheckResult{
+			CurrentVersion:  "v1.0.0",
+			LatestVersion:   "v1.1.0",
+			TargetVersion:   "v1.1.0",
+			UpdateAvailable: true,
+		},
+		applyResult: updater.ApplyResult{Updated: true, Pending: false},
+	}
+
+	oldFactory := updaterFactory
+	updaterFactory = func() updater.Service { return service }
+	defer func() { updaterFactory = oldFactory }()
+
+	oldJSON := jsonOutput
+	jsonOutput = false
+	defer func() { jsonOutput = oldJSON }()
+
+	oldCheckOnly := updateCheckOnly
+	updateCheckOnly = false
+	defer func() { updateCheckOnly = oldCheckOnly }()
+
+	oldYes := updateYes
+	updateYes = true
+	defer func() { updateYes = oldYes }()
+
+	oldVersionFlag := updateVersion
+	updateVersion = ""
+	defer func() { updateVersion = oldVersionFlag }()
+
+	var buf bytes.Buffer
+	outWriter = &buf
+	defer func() { outWriter = os.Stdout }()
+
+	if err := runUpdate(context.Background()); err != nil {
+		t.Fatalf("runUpdate error: %v", err)
+	}
+	if service.applyCalls != 1 {
+		t.Fatalf("applyCalls = %d, want 1", service.applyCalls)
+	}
+	if !strings.Contains(buf.String(), "Updated vibeusage") {
+		t.Fatalf("expected success output, got: %s", buf.String())
+	}
+}
+
+func TestRunUpdate_CheckError(t *testing.T) {
+	service := &fakeUpdaterService{checkErr: errors.New("boom")}
+
+	oldFactory := updaterFactory
+	updaterFactory = func() updater.Service { return service }
+	defer func() { updaterFactory = oldFactory }()
+
+	oldCheckOnly := updateCheckOnly
+	updateCheckOnly = true
+	defer func() { updateCheckOnly = oldCheckOnly }()
+
+	err := runUpdate(context.Background())
+	if err == nil {
+		t.Fatal("expected error")
+	}
+	if !strings.Contains(err.Error(), "failed to check for updates") {
+		t.Fatalf("error = %q, want wrapped check failure", err.Error())
+	}
+}

--- a/internal/display/json_types.go
+++ b/internal/display/json_types.go
@@ -125,3 +125,15 @@ type InitStatusJSON struct {
 	ConfiguredProviders int      `json:"configured_providers"`
 	AvailableProviders  []string `json:"available_providers"`
 }
+
+// UpdateStatusJSON represents update check/apply output.
+type UpdateStatusJSON struct {
+	CurrentVersion  string `json:"current_version"`
+	LatestVersion   string `json:"latest_version"`
+	TargetVersion   string `json:"target_version"`
+	UpdateAvailable bool   `json:"update_available"`
+	IsDowngrade     bool   `json:"is_downgrade"`
+	Asset           string `json:"asset,omitempty"`
+	Applied         bool   `json:"applied,omitempty"`
+	Pending         bool   `json:"pending,omitempty"`
+}

--- a/internal/updater/replace_unix.go
+++ b/internal/updater/replace_unix.go
@@ -1,0 +1,48 @@
+//go:build !windows
+
+package updater
+
+import (
+	"fmt"
+	"os"
+	"path/filepath"
+)
+
+func replaceBinary(targetPath string, binaryBody []byte) (bool, error) {
+	dir := filepath.Dir(targetPath)
+	tmpFile, err := os.CreateTemp(dir, ".vibeusage-update-*")
+	if err != nil {
+		return false, fmt.Errorf("failed to create temp file in %s: %w", dir, err)
+	}
+	tmpPath := tmpFile.Name()
+	defer func() {
+		_ = os.Remove(tmpPath)
+	}()
+
+	if _, err := tmpFile.Write(binaryBody); err != nil {
+		_ = tmpFile.Close()
+		return false, fmt.Errorf("failed to write update binary: %w", err)
+	}
+
+	mode := os.FileMode(0o755)
+	if info, err := os.Stat(targetPath); err == nil {
+		mode = info.Mode().Perm()
+	}
+	if err := tmpFile.Chmod(mode); err != nil {
+		_ = tmpFile.Close()
+		return false, fmt.Errorf("failed to set executable permissions on update binary: %w", err)
+	}
+
+	if err := tmpFile.Sync(); err != nil {
+		_ = tmpFile.Close()
+		return false, fmt.Errorf("failed to sync update binary: %w", err)
+	}
+	if err := tmpFile.Close(); err != nil {
+		return false, fmt.Errorf("failed to finalize update binary: %w", err)
+	}
+
+	if err := os.Rename(tmpPath, targetPath); err != nil {
+		return false, fmt.Errorf("failed to replace executable %s: %w", targetPath, err)
+	}
+	return false, nil
+}

--- a/internal/updater/replace_windows.go
+++ b/internal/updater/replace_windows.go
@@ -1,0 +1,44 @@
+//go:build windows
+
+package updater
+
+import (
+	"fmt"
+	"os"
+	"os/exec"
+	"path/filepath"
+)
+
+func replaceBinary(targetPath string, binaryBody []byte) (bool, error) {
+	stagedPath := targetPath + ".new"
+	if err := os.WriteFile(stagedPath, binaryBody, 0o755); err != nil {
+		return false, fmt.Errorf("failed to stage update binary: %w", err)
+	}
+
+	script, err := os.CreateTemp("", "vibeusage-update-*.cmd")
+	if err != nil {
+		return false, fmt.Errorf("failed to create update script: %w", err)
+	}
+	scriptPath := script.Name()
+
+	scriptContent := fmt.Sprintf("@echo off\r\nsetlocal\r\nset \"TARGET=%s\"\r\nset \"NEW=%s\"\r\nfor /L %%%%I in (1,1,45) do (\r\n  move /Y \"%%NEW%%\" \"%%TARGET%%\" >nul 2>&1\r\n  if not errorlevel 1 goto done\r\n  timeout /t 1 /nobreak >nul\r\n)\r\n:done\r\ndel \"%%~f0\" >nul 2>&1\r\n", targetPath, stagedPath)
+	if _, err := script.WriteString(scriptContent); err != nil {
+		_ = script.Close()
+		return false, fmt.Errorf("failed to write update script: %w", err)
+	}
+	if err := script.Close(); err != nil {
+		return false, fmt.Errorf("failed to finalize update script: %w", err)
+	}
+
+	if err := os.Chmod(scriptPath, 0o700); err != nil {
+		return false, fmt.Errorf("failed to chmod update script: %w", err)
+	}
+
+	cmd := exec.Command("cmd", "/C", scriptPath)
+	cmd.Dir = filepath.Dir(targetPath)
+	if err := cmd.Start(); err != nil {
+		return false, fmt.Errorf("failed to launch update script: %w", err)
+	}
+
+	return true, nil
+}

--- a/internal/updater/updater.go
+++ b/internal/updater/updater.go
@@ -1,0 +1,559 @@
+package updater
+
+import (
+	"archive/tar"
+	"archive/zip"
+	"bytes"
+	"compress/gzip"
+	"context"
+	"crypto/sha256"
+	"encoding/hex"
+	"encoding/json"
+	"fmt"
+	"io"
+	"net/http"
+	"net/url"
+	"os"
+	"path/filepath"
+	"runtime"
+	"strings"
+	"time"
+
+	"golang.org/x/mod/semver"
+)
+
+const (
+	defaultOwner       = "joshuadavidthomas"
+	defaultRepo        = "vibeusage"
+	defaultAPIBaseURL  = "https://api.github.com"
+	defaultUserAgent   = "vibeusage-updater"
+	projectName        = "vibeusage"
+	checksumsAssetName = "checksums.txt"
+)
+
+// Service is the interface used by the CLI update command.
+type Service interface {
+	Check(ctx context.Context, req CheckRequest) (CheckResult, error)
+	Apply(ctx context.Context, req ApplyRequest) (ApplyResult, error)
+}
+
+// Client checks GitHub releases and applies binary updates.
+type Client struct {
+	Owner      string
+	Repo       string
+	APIBaseURL string
+	Token      string
+	HTTP       *http.Client
+}
+
+// CheckRequest configures update-check behavior.
+type CheckRequest struct {
+	CurrentVersion string
+	TargetVersion  string
+	OS             string
+	Arch           string
+}
+
+// CheckResult describes update availability for this platform.
+type CheckResult struct {
+	CurrentVersion  string
+	LatestVersion   string
+	TargetVersion   string
+	UpdateAvailable bool
+	IsDowngrade     bool
+	ReleaseName     string
+	ReleaseNotes    string
+	ReleaseURL      string
+	AssetName       string
+	AssetURL        string
+	ChecksumsURL    string
+	OS              string
+	Arch            string
+}
+
+// ApplyRequest controls installation of a previously checked update.
+type ApplyRequest struct {
+	Check          CheckResult
+	BinaryPath     string
+	AllowDowngrade bool
+}
+
+// ApplyResult is the result of applying an update.
+type ApplyResult struct {
+	Updated    bool
+	Pending    bool
+	OldVersion string
+	NewVersion string
+	BinaryPath string
+}
+
+type githubRelease struct {
+	TagName     string               `json:"tag_name"`
+	Name        string               `json:"name"`
+	Body        string               `json:"body"`
+	HTMLURL     string               `json:"html_url"`
+	PublishedAt time.Time            `json:"published_at"`
+	Assets      []githubReleaseAsset `json:"assets"`
+}
+
+type githubReleaseAsset struct {
+	Name               string `json:"name"`
+	BrowserDownloadURL string `json:"browser_download_url"`
+	Size               int64  `json:"size"`
+}
+
+// NewClient creates a GitHub-backed updater client.
+func NewClient() *Client {
+	return &Client{
+		Owner:      defaultOwner,
+		Repo:       defaultRepo,
+		APIBaseURL: defaultAPIBaseURL,
+		Token:      strings.TrimSpace(os.Getenv("VIBEUSAGE_UPDATE_GITHUB_TOKEN")),
+		HTTP:       &http.Client{Timeout: 60 * time.Second},
+	}
+}
+
+// Check checks GitHub releases and returns whether an update is available.
+func (c *Client) Check(ctx context.Context, req CheckRequest) (CheckResult, error) {
+	osName := req.OS
+	if osName == "" {
+		osName = runtime.GOOS
+	}
+	arch := req.Arch
+	if arch == "" {
+		arch = runtime.GOARCH
+	}
+
+	release, err := c.fetchRelease(ctx, req.TargetVersion)
+	if err != nil {
+		return CheckResult{}, err
+	}
+
+	assetName, err := expectedAssetName(osName, arch)
+	if err != nil {
+		return CheckResult{}, err
+	}
+
+	asset, ok := findReleaseAsset(release.Assets, assetName, osName, arch)
+	if !ok {
+		return CheckResult{}, fmt.Errorf("release %s does not include an asset for %s/%s", release.TagName, osName, arch)
+	}
+
+	checksums, ok := findChecksumsAsset(release.Assets)
+	if !ok {
+		return CheckResult{}, fmt.Errorf("release %s does not include %s", release.TagName, checksumsAssetName)
+	}
+
+	targetVersion := normalizeVersion(release.TagName)
+	currentVersion := normalizeVersion(req.CurrentVersion)
+	updateAvailable := false
+	isDowngrade := false
+
+	if req.TargetVersion == "" {
+		if cmp, comparable := compareVersions(currentVersion, targetVersion); comparable {
+			updateAvailable = cmp < 0
+		} else {
+			updateAvailable = currentVersion == "" || currentVersion != targetVersion
+		}
+	} else {
+		if cmp, comparable := compareVersions(currentVersion, targetVersion); comparable {
+			updateAvailable = cmp != 0
+			isDowngrade = cmp > 0
+		} else {
+			updateAvailable = currentVersion == "" || currentVersion != targetVersion
+		}
+	}
+
+	return CheckResult{
+		CurrentVersion:  req.CurrentVersion,
+		LatestVersion:   release.TagName,
+		TargetVersion:   release.TagName,
+		UpdateAvailable: updateAvailable,
+		IsDowngrade:     isDowngrade,
+		ReleaseName:     release.Name,
+		ReleaseNotes:    release.Body,
+		ReleaseURL:      release.HTMLURL,
+		AssetName:       asset.Name,
+		AssetURL:        asset.BrowserDownloadURL,
+		ChecksumsURL:    checksums.BrowserDownloadURL,
+		OS:              osName,
+		Arch:            arch,
+	}, nil
+}
+
+// Apply downloads, verifies, and replaces the current binary.
+func (c *Client) Apply(ctx context.Context, req ApplyRequest) (ApplyResult, error) {
+	check := req.Check
+	if !check.UpdateAvailable {
+		return ApplyResult{
+			Updated:    false,
+			OldVersion: check.CurrentVersion,
+			NewVersion: check.TargetVersion,
+		}, nil
+	}
+	if check.IsDowngrade && !req.AllowDowngrade {
+		return ApplyResult{}, fmt.Errorf("refusing downgrade from %s to %s without explicit approval", check.CurrentVersion, check.TargetVersion)
+	}
+
+	checksumsBody, err := c.download(ctx, check.ChecksumsURL)
+	if err != nil {
+		return ApplyResult{}, fmt.Errorf("failed to download checksums: %w", err)
+	}
+
+	expectedChecksum, ok := checksumForAsset(string(checksumsBody), check.AssetName)
+	if !ok {
+		return ApplyResult{}, fmt.Errorf("checksums file does not contain %s", check.AssetName)
+	}
+
+	archiveBody, err := c.download(ctx, check.AssetURL)
+	if err != nil {
+		return ApplyResult{}, fmt.Errorf("failed to download release asset: %w", err)
+	}
+	if err := verifySHA256(archiveBody, expectedChecksum); err != nil {
+		return ApplyResult{}, err
+	}
+
+	binaryBody, err := extractBinaryFromArchive(check.AssetName, archiveBody, binaryNameForOS(check.OS))
+	if err != nil {
+		return ApplyResult{}, fmt.Errorf("failed to extract binary from archive: %w", err)
+	}
+
+	targetPath, err := resolveBinaryPath(req.BinaryPath)
+	if err != nil {
+		return ApplyResult{}, err
+	}
+
+	pending, err := replaceBinary(targetPath, binaryBody)
+	if err != nil {
+		return ApplyResult{}, err
+	}
+
+	return ApplyResult{
+		Updated:    true,
+		Pending:    pending,
+		OldVersion: check.CurrentVersion,
+		NewVersion: check.TargetVersion,
+		BinaryPath: targetPath,
+	}, nil
+}
+
+func (c *Client) fetchRelease(ctx context.Context, targetVersion string) (*githubRelease, error) {
+	apiBase := strings.TrimSuffix(strings.TrimSpace(c.APIBaseURL), "/")
+	if apiBase == "" {
+		apiBase = defaultAPIBaseURL
+	}
+	owner := strings.TrimSpace(c.Owner)
+	if owner == "" {
+		owner = defaultOwner
+	}
+	repo := strings.TrimSpace(c.Repo)
+	if repo == "" {
+		repo = defaultRepo
+	}
+
+	endpoint := fmt.Sprintf("%s/repos/%s/%s/releases/latest", apiBase, owner, repo)
+	if targetVersion != "" {
+		tag := targetVersion
+		if !strings.HasPrefix(tag, "v") {
+			tag = "v" + tag
+		}
+		endpoint = fmt.Sprintf("%s/repos/%s/%s/releases/tags/%s", apiBase, owner, repo, url.PathEscape(tag))
+	}
+
+	body, err := c.getJSON(ctx, endpoint)
+	if err != nil {
+		return nil, err
+	}
+
+	var rel githubRelease
+	if err := json.Unmarshal(body, &rel); err != nil {
+		return nil, fmt.Errorf("failed to parse release metadata: %w", err)
+	}
+	if rel.TagName == "" {
+		return nil, fmt.Errorf("release metadata missing tag_name")
+	}
+	return &rel, nil
+}
+
+func (c *Client) getJSON(ctx context.Context, rawURL string) ([]byte, error) {
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, rawURL, nil)
+	if err != nil {
+		return nil, err
+	}
+	req.Header.Set("Accept", "application/vnd.github+json")
+	req.Header.Set("User-Agent", defaultUserAgent)
+	if c.Token != "" {
+		req.Header.Set("Authorization", "Bearer "+c.Token)
+	}
+
+	httpClient := c.HTTP
+	if httpClient == nil {
+		httpClient = &http.Client{Timeout: 60 * time.Second}
+	}
+
+	resp, err := httpClient.Do(req)
+	if err != nil {
+		return nil, err
+	}
+	defer func() { _ = resp.Body.Close() }()
+
+	body, err := io.ReadAll(resp.Body)
+	if err != nil {
+		return nil, err
+	}
+
+	if resp.StatusCode < 200 || resp.StatusCode >= 300 {
+		msg := strings.TrimSpace(string(body))
+		if len(msg) > 300 {
+			msg = msg[:300]
+		}
+		if msg == "" {
+			msg = resp.Status
+		}
+		return nil, fmt.Errorf("GitHub API request failed (%d): %s", resp.StatusCode, msg)
+	}
+
+	return body, nil
+}
+
+func (c *Client) download(ctx context.Context, rawURL string) ([]byte, error) {
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, rawURL, nil)
+	if err != nil {
+		return nil, err
+	}
+	req.Header.Set("User-Agent", defaultUserAgent)
+	if c.Token != "" {
+		req.Header.Set("Authorization", "Bearer "+c.Token)
+	}
+
+	httpClient := c.HTTP
+	if httpClient == nil {
+		httpClient = &http.Client{Timeout: 60 * time.Second}
+	}
+
+	resp, err := httpClient.Do(req)
+	if err != nil {
+		return nil, err
+	}
+	defer func() { _ = resp.Body.Close() }()
+
+	body, err := io.ReadAll(resp.Body)
+	if err != nil {
+		return nil, err
+	}
+
+	if resp.StatusCode < 200 || resp.StatusCode >= 300 {
+		msg := strings.TrimSpace(string(body))
+		if len(msg) > 300 {
+			msg = msg[:300]
+		}
+		if msg == "" {
+			msg = resp.Status
+		}
+		return nil, fmt.Errorf("download failed (%d): %s", resp.StatusCode, msg)
+	}
+
+	return body, nil
+}
+
+func expectedAssetName(osName, arch string) (string, error) {
+	switch arch {
+	case "amd64", "arm64":
+	default:
+		return "", fmt.Errorf("unsupported architecture for self-update: %s", arch)
+	}
+
+	switch osName {
+	case "linux", "darwin":
+		return fmt.Sprintf("%s_%s_%s.tar.gz", projectName, osName, arch), nil
+	case "windows":
+		return fmt.Sprintf("%s_windows_%s.zip", projectName, arch), nil
+	default:
+		return "", fmt.Errorf("unsupported OS for self-update: %s", osName)
+	}
+}
+
+func findReleaseAsset(assets []githubReleaseAsset, expectedName, osName, arch string) (githubReleaseAsset, bool) {
+	for _, asset := range assets {
+		if asset.Name == expectedName {
+			return asset, true
+		}
+	}
+
+	marker := "_" + osName + "_" + arch
+	var fallback githubReleaseAsset
+	for _, asset := range assets {
+		if !strings.HasPrefix(asset.Name, projectName+"_") {
+			continue
+		}
+		if !strings.Contains(asset.Name, marker) {
+			continue
+		}
+		if strings.HasSuffix(asset.Name, ".tar.gz") || strings.HasSuffix(asset.Name, ".zip") {
+			if fallback.Name == "" {
+				fallback = asset
+			}
+		}
+	}
+	if fallback.Name != "" {
+		return fallback, true
+	}
+
+	return githubReleaseAsset{}, false
+}
+
+func findChecksumsAsset(assets []githubReleaseAsset) (githubReleaseAsset, bool) {
+	for _, asset := range assets {
+		if asset.Name == checksumsAssetName {
+			return asset, true
+		}
+	}
+	for _, asset := range assets {
+		if strings.HasSuffix(asset.Name, "_checksums.txt") {
+			return asset, true
+		}
+	}
+	return githubReleaseAsset{}, false
+}
+
+func checksumForAsset(checksumsContent, assetName string) (string, bool) {
+	for _, line := range strings.Split(checksumsContent, "\n") {
+		line = strings.TrimSpace(line)
+		if line == "" || strings.HasPrefix(line, "#") {
+			continue
+		}
+		fields := strings.Fields(line)
+		if len(fields) < 2 {
+			continue
+		}
+		hash := strings.TrimSpace(fields[0])
+		name := strings.TrimPrefix(strings.TrimSpace(fields[1]), "*")
+		if name == assetName {
+			return hash, true
+		}
+	}
+	return "", false
+}
+
+func verifySHA256(content []byte, expectedHex string) error {
+	expected := strings.ToLower(strings.TrimSpace(expectedHex))
+	sum := sha256.Sum256(content)
+	actual := hex.EncodeToString(sum[:])
+	if expected != actual {
+		return fmt.Errorf("checksum mismatch for release asset: expected %s, got %s", expected, actual)
+	}
+	return nil
+}
+
+func extractBinaryFromArchive(assetName string, archiveBody []byte, binaryName string) ([]byte, error) {
+	switch {
+	case strings.HasSuffix(assetName, ".tar.gz"):
+		return extractBinaryFromTarGz(archiveBody, binaryName)
+	case strings.HasSuffix(assetName, ".zip"):
+		return extractBinaryFromZip(archiveBody, binaryName)
+	default:
+		return nil, fmt.Errorf("unsupported archive format for asset %s", assetName)
+	}
+}
+
+func extractBinaryFromTarGz(archiveBody []byte, binaryName string) ([]byte, error) {
+	gzReader, err := gzip.NewReader(bytes.NewReader(archiveBody))
+	if err != nil {
+		return nil, err
+	}
+	defer func() { _ = gzReader.Close() }()
+
+	tarReader := tar.NewReader(gzReader)
+	for {
+		header, err := tarReader.Next()
+		if err == io.EOF {
+			break
+		}
+		if err != nil {
+			return nil, err
+		}
+		if header.Typeflag != tar.TypeReg {
+			continue
+		}
+		if filepath.Base(header.Name) != binaryName {
+			continue
+		}
+		binaryBody, err := io.ReadAll(tarReader)
+		if err != nil {
+			return nil, err
+		}
+		if len(binaryBody) == 0 {
+			return nil, fmt.Errorf("archive entry %s is empty", header.Name)
+		}
+		return binaryBody, nil
+	}
+	return nil, fmt.Errorf("binary %s not found in tar.gz archive", binaryName)
+}
+
+func extractBinaryFromZip(archiveBody []byte, binaryName string) ([]byte, error) {
+	readerAt := bytes.NewReader(archiveBody)
+	zipReader, err := zip.NewReader(readerAt, int64(len(archiveBody)))
+	if err != nil {
+		return nil, err
+	}
+	for _, file := range zipReader.File {
+		if filepath.Base(file.Name) != binaryName {
+			continue
+		}
+		rc, err := file.Open()
+		if err != nil {
+			return nil, err
+		}
+		binaryBody, readErr := io.ReadAll(rc)
+		_ = rc.Close()
+		if readErr != nil {
+			return nil, readErr
+		}
+		if len(binaryBody) == 0 {
+			return nil, fmt.Errorf("archive entry %s is empty", file.Name)
+		}
+		return binaryBody, nil
+	}
+	return nil, fmt.Errorf("binary %s not found in zip archive", binaryName)
+}
+
+func resolveBinaryPath(override string) (string, error) {
+	if strings.TrimSpace(override) != "" {
+		return override, nil
+	}
+	path, err := os.Executable()
+	if err != nil {
+		return "", fmt.Errorf("failed to locate current executable: %w", err)
+	}
+	if resolved, err := filepath.EvalSymlinks(path); err == nil {
+		path = resolved
+	}
+	return path, nil
+}
+
+func normalizeVersion(v string) string {
+	v = strings.TrimSpace(v)
+	v = strings.TrimPrefix(v, "v")
+	return v
+}
+
+func compareVersions(current, target string) (int, bool) {
+	current = normalizeVersion(current)
+	target = normalizeVersion(target)
+	if current == "" || target == "" {
+		return 0, false
+	}
+	currentSemver := "v" + current
+	targetSemver := "v" + target
+	if !semver.IsValid(currentSemver) || !semver.IsValid(targetSemver) {
+		return 0, false
+	}
+	return semver.Compare(currentSemver, targetSemver), true
+}
+
+func binaryNameForOS(osName string) string {
+	if osName == "windows" {
+		return projectName + ".exe"
+	}
+	return projectName
+}

--- a/internal/updater/updater_test.go
+++ b/internal/updater/updater_test.go
@@ -1,0 +1,210 @@
+package updater
+
+import (
+	"archive/tar"
+	"archive/zip"
+	"bytes"
+	"compress/gzip"
+	"context"
+	"crypto/sha256"
+	"encoding/hex"
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"net/http/httptest"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+func TestCompareVersions(t *testing.T) {
+	tests := []struct {
+		name     string
+		current  string
+		target   string
+		wantCmp  int
+		wantBool bool
+	}{
+		{name: "upgrade", current: "0.1.0", target: "0.2.0", wantCmp: -1, wantBool: true},
+		{name: "equal", current: "v1.2.3", target: "1.2.3", wantCmp: 0, wantBool: true},
+		{name: "downgrade", current: "2.0.0", target: "1.9.9", wantCmp: 1, wantBool: true},
+		{name: "invalid current", current: "dev", target: "1.0.0", wantCmp: 0, wantBool: false},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			cmp, ok := compareVersions(tt.current, tt.target)
+			if ok != tt.wantBool {
+				t.Fatalf("compareVersions ok = %v, want %v", ok, tt.wantBool)
+			}
+			if ok && cmp != tt.wantCmp {
+				t.Fatalf("compareVersions cmp = %d, want %d", cmp, tt.wantCmp)
+			}
+		})
+	}
+}
+
+func TestChecksumForAsset(t *testing.T) {
+	checksums := "" +
+		"aabbccdd  vibeusage_linux_amd64.tar.gz\n" +
+		"11223344 *vibeusage_windows_amd64.zip\n"
+
+	hash, ok := checksumForAsset(checksums, "vibeusage_windows_amd64.zip")
+	if !ok {
+		t.Fatal("checksumForAsset returned ok=false")
+	}
+	if hash != "11223344" {
+		t.Fatalf("checksumForAsset hash = %q, want %q", hash, "11223344")
+	}
+}
+
+func TestExtractBinaryFromTarGz(t *testing.T) {
+	archive := makeTarGzArchive(t, "vibeusage", []byte("binary-data"))
+	body, err := extractBinaryFromArchive("vibeusage_linux_amd64.tar.gz", archive, "vibeusage")
+	if err != nil {
+		t.Fatalf("extractBinaryFromArchive(tar.gz) error: %v", err)
+	}
+	if string(body) != "binary-data" {
+		t.Fatalf("extracted body = %q, want %q", string(body), "binary-data")
+	}
+}
+
+func TestExtractBinaryFromZip(t *testing.T) {
+	archive := makeZipArchive(t, "vibeusage.exe", []byte("windows-binary"))
+	body, err := extractBinaryFromArchive("vibeusage_windows_amd64.zip", archive, "vibeusage.exe")
+	if err != nil {
+		t.Fatalf("extractBinaryFromArchive(zip) error: %v", err)
+	}
+	if string(body) != "windows-binary" {
+		t.Fatalf("extracted body = %q, want %q", string(body), "windows-binary")
+	}
+}
+
+func TestClientCheckAndApply(t *testing.T) {
+	archive := makeTarGzArchive(t, "vibeusage", []byte("new-binary"))
+	sum := sha256.Sum256(archive)
+	checksum := hex.EncodeToString(sum[:])
+	checksums := fmt.Sprintf("%s  vibeusage_linux_amd64.tar.gz\n", checksum)
+
+	mux := http.NewServeMux()
+	server := httptest.NewServer(mux)
+	defer server.Close()
+
+	release := githubRelease{
+		TagName: "v1.2.3",
+		Name:    "v1.2.3",
+		Assets: []githubReleaseAsset{
+			{Name: "vibeusage_linux_amd64.tar.gz", BrowserDownloadURL: server.URL + "/asset"},
+			{Name: "checksums.txt", BrowserDownloadURL: server.URL + "/checksums"},
+		},
+	}
+
+	mux.HandleFunc("/repos/joshuadavidthomas/vibeusage/releases/latest", func(w http.ResponseWriter, r *http.Request) {
+		_ = json.NewEncoder(w).Encode(release)
+	})
+	mux.HandleFunc("/asset", func(w http.ResponseWriter, r *http.Request) {
+		_, _ = w.Write(archive)
+	})
+	mux.HandleFunc("/checksums", func(w http.ResponseWriter, r *http.Request) {
+		_, _ = w.Write([]byte(checksums))
+	})
+
+	client := NewClient()
+	client.APIBaseURL = server.URL
+	client.HTTP = server.Client()
+
+	check, err := client.Check(context.Background(), CheckRequest{
+		CurrentVersion: "v1.0.0",
+		OS:             "linux",
+		Arch:           "amd64",
+	})
+	if err != nil {
+		t.Fatalf("Check error: %v", err)
+	}
+	if !check.UpdateAvailable {
+		t.Fatal("expected update to be available")
+	}
+	if check.TargetVersion != "v1.2.3" {
+		t.Fatalf("target version = %q, want %q", check.TargetVersion, "v1.2.3")
+	}
+
+	targetPath := filepath.Join(t.TempDir(), "vibeusage")
+	if err := os.WriteFile(targetPath, []byte("old-binary"), 0o755); err != nil {
+		t.Fatalf("failed to seed target binary: %v", err)
+	}
+
+	apply, err := client.Apply(context.Background(), ApplyRequest{Check: check, BinaryPath: targetPath})
+	if err != nil {
+		t.Fatalf("Apply error: %v", err)
+	}
+	if !apply.Updated {
+		t.Fatal("expected Updated=true")
+	}
+	if apply.Pending {
+		t.Fatal("expected Pending=false on non-windows")
+	}
+
+	updatedBody, err := os.ReadFile(targetPath)
+	if err != nil {
+		t.Fatalf("failed to read updated binary: %v", err)
+	}
+	if string(updatedBody) != "new-binary" {
+		t.Fatalf("updated binary body = %q, want %q", string(updatedBody), "new-binary")
+	}
+}
+
+func TestClientApplyRefusesDowngrade(t *testing.T) {
+	client := NewClient()
+	_, err := client.Apply(context.Background(), ApplyRequest{Check: CheckResult{
+		CurrentVersion:  "v2.0.0",
+		TargetVersion:   "v1.0.0",
+		UpdateAvailable: true,
+		IsDowngrade:     true,
+	}})
+	if err == nil {
+		t.Fatal("expected downgrade refusal error")
+	}
+	if !strings.Contains(err.Error(), "refusing downgrade") {
+		t.Fatalf("error = %q, want downgrade refusal", err.Error())
+	}
+}
+
+func makeTarGzArchive(t *testing.T, filename string, body []byte) []byte {
+	t.Helper()
+	var buf bytes.Buffer
+	gz := gzip.NewWriter(&buf)
+	tarWriter := tar.NewWriter(gz)
+
+	header := &tar.Header{Name: filename, Mode: 0o755, Size: int64(len(body))}
+	if err := tarWriter.WriteHeader(header); err != nil {
+		t.Fatalf("WriteHeader error: %v", err)
+	}
+	if _, err := tarWriter.Write(body); err != nil {
+		t.Fatalf("Write error: %v", err)
+	}
+	if err := tarWriter.Close(); err != nil {
+		t.Fatalf("tar close error: %v", err)
+	}
+	if err := gz.Close(); err != nil {
+		t.Fatalf("gzip close error: %v", err)
+	}
+	return buf.Bytes()
+}
+
+func makeZipArchive(t *testing.T, filename string, body []byte) []byte {
+	t.Helper()
+	var buf bytes.Buffer
+	zipWriter := zip.NewWriter(&buf)
+	f, err := zipWriter.Create(filename)
+	if err != nil {
+		t.Fatalf("Create error: %v", err)
+	}
+	if _, err := f.Write(body); err != nil {
+		t.Fatalf("Write error: %v", err)
+	}
+	if err := zipWriter.Close(); err != nil {
+		t.Fatalf("zip close error: %v", err)
+	}
+	return buf.Bytes()
+}

--- a/scripts/install.ps1
+++ b/scripts/install.ps1
@@ -1,0 +1,72 @@
+$ErrorActionPreference = "Stop"
+
+$Repo = "joshuadavidthomas/vibeusage"
+$InstallDir = if ($env:VIBEUSAGE_INSTALL_DIR) { $env:VIBEUSAGE_INSTALL_DIR } else { Join-Path $HOME ".local\bin" }
+$Version = if ($env:VIBEUSAGE_VERSION) { $env:VIBEUSAGE_VERSION } else { "latest" }
+
+$archRaw = [System.Runtime.InteropServices.RuntimeInformation]::OSArchitecture.ToString().ToLowerInvariant()
+$arch = switch ($archRaw) {
+  "x64" { "amd64" }
+  "arm64" { "arm64" }
+  default { throw "Unsupported architecture: $archRaw" }
+}
+
+$asset = "vibeusage_windows_${arch}.zip"
+$checksums = "checksums.txt"
+
+if ($Version -eq "latest") {
+  $downloadUrl = "https://github.com/$Repo/releases/latest/download/$asset"
+  $checksumsUrl = "https://github.com/$Repo/releases/latest/download/$checksums"
+} else {
+  $tag = if ($Version.StartsWith("v")) { $Version } else { "v$Version" }
+  $downloadUrl = "https://github.com/$Repo/releases/download/$tag/$asset"
+  $checksumsUrl = "https://github.com/$Repo/releases/download/$tag/$checksums"
+}
+
+$tmpDir = Join-Path ([System.IO.Path]::GetTempPath()) ("vibeusage-install-" + [System.Guid]::NewGuid().ToString("N"))
+New-Item -ItemType Directory -Path $tmpDir | Out-Null
+
+$zipPath = Join-Path $tmpDir $asset
+$checksumsPath = Join-Path $tmpDir $checksums
+
+try {
+  Write-Host "Downloading $asset..."
+  Invoke-WebRequest -Uri $downloadUrl -OutFile $zipPath
+  Invoke-WebRequest -Uri $checksumsUrl -OutFile $checksumsPath
+
+  $expected = $null
+  foreach ($line in Get-Content $checksumsPath) {
+    if ([string]::IsNullOrWhiteSpace($line)) { continue }
+    $parts = $line -split "\s+"
+    if ($parts.Count -lt 2) { continue }
+    $name = $parts[1].TrimStart("*")
+    if ($name -eq $asset) {
+      $expected = $parts[0].ToLowerInvariant()
+      break
+    }
+  }
+
+  if (-not $expected) {
+    throw "Could not find checksum entry for $asset"
+  }
+
+  $actual = (Get-FileHash -Algorithm SHA256 -Path $zipPath).Hash.ToLowerInvariant()
+  if ($expected -ne $actual) {
+    throw "Checksum mismatch for $asset (expected $expected, got $actual)"
+  }
+
+  Expand-Archive -Path $zipPath -DestinationPath $tmpDir -Force
+  $binaryPath = Join-Path $tmpDir "vibeusage.exe"
+  if (-not (Test-Path $binaryPath)) {
+    throw "Release archive did not contain vibeusage.exe"
+  }
+
+  New-Item -ItemType Directory -Path $InstallDir -Force | Out-Null
+  Copy-Item -Path $binaryPath -Destination (Join-Path $InstallDir "vibeusage.exe") -Force
+
+  Write-Host "Installed vibeusage to $(Join-Path $InstallDir 'vibeusage.exe')"
+  Write-Host "Run: vibeusage --version"
+}
+finally {
+  Remove-Item -Path $tmpDir -Recurse -Force -ErrorAction SilentlyContinue
+}

--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -1,0 +1,128 @@
+#!/usr/bin/env sh
+set -eu
+
+REPO="joshuadavidthomas/vibeusage"
+INSTALL_DIR="${VIBEUSAGE_INSTALL_DIR:-$HOME/.local/bin}"
+VERSION="${VIBEUSAGE_VERSION:-latest}"
+
+need_cmd() {
+  if ! command -v "$1" >/dev/null 2>&1; then
+    echo "error: required command not found: $1" >&2
+    exit 1
+  fi
+}
+
+download() {
+  url="$1"
+  dest="$2"
+  if command -v curl >/dev/null 2>&1; then
+    curl -fsSL "$url" -o "$dest"
+    return
+  fi
+  if command -v wget >/dev/null 2>&1; then
+    wget -qO "$dest" "$url"
+    return
+  fi
+  echo "error: install requires curl or wget" >&2
+  exit 1
+}
+
+sha256_file() {
+  file="$1"
+  if command -v sha256sum >/dev/null 2>&1; then
+    sha256sum "$file" | awk '{print $1}'
+    return
+  fi
+  if command -v shasum >/dev/null 2>&1; then
+    shasum -a 256 "$file" | awk '{print $1}'
+    return
+  fi
+  echo "error: install requires sha256sum or shasum" >&2
+  exit 1
+}
+
+normalize_os() {
+  case "$(uname -s)" in
+    Linux) echo "linux" ;;
+    Darwin) echo "darwin" ;;
+    *)
+      echo "error: unsupported OS $(uname -s)" >&2
+      exit 1
+      ;;
+  esac
+}
+
+normalize_arch() {
+  case "$(uname -m)" in
+    x86_64|amd64) echo "amd64" ;;
+    arm64|aarch64) echo "arm64" ;;
+    *)
+      echo "error: unsupported architecture $(uname -m)" >&2
+      exit 1
+      ;;
+  esac
+}
+
+need_cmd tar
+need_cmd awk
+need_cmd mktemp
+
+OS="$(normalize_os)"
+ARCH="$(normalize_arch)"
+ASSET="vibeusage_${OS}_${ARCH}.tar.gz"
+CHECKSUMS="checksums.txt"
+
+if [ "$VERSION" = "latest" ]; then
+  DOWNLOAD_URL="https://github.com/${REPO}/releases/latest/download/${ASSET}"
+  CHECKSUMS_URL="https://github.com/${REPO}/releases/latest/download/${CHECKSUMS}"
+else
+  case "$VERSION" in
+    v*) TAG="$VERSION" ;;
+    *) TAG="v$VERSION" ;;
+  esac
+  DOWNLOAD_URL="https://github.com/${REPO}/releases/download/${TAG}/${ASSET}"
+  CHECKSUMS_URL="https://github.com/${REPO}/releases/download/${TAG}/${CHECKSUMS}"
+fi
+
+TMP_DIR="$(mktemp -d)"
+trap 'rm -rf "$TMP_DIR"' EXIT INT TERM
+
+ARCHIVE_PATH="$TMP_DIR/$ASSET"
+CHECKSUMS_PATH="$TMP_DIR/$CHECKSUMS"
+
+echo "Downloading ${ASSET}..."
+download "$DOWNLOAD_URL" "$ARCHIVE_PATH"
+download "$CHECKSUMS_URL" "$CHECKSUMS_PATH"
+
+EXPECTED_SUM="$(awk -v name="$ASSET" '$2 == name || $2 == "*"name { print $1; exit }' "$CHECKSUMS_PATH")"
+if [ -z "$EXPECTED_SUM" ]; then
+  echo "error: could not find checksum entry for ${ASSET}" >&2
+  exit 1
+fi
+
+ACTUAL_SUM="$(sha256_file "$ARCHIVE_PATH")"
+if [ "$EXPECTED_SUM" != "$ACTUAL_SUM" ]; then
+  echo "error: checksum mismatch for ${ASSET}" >&2
+  echo "expected: $EXPECTED_SUM" >&2
+  echo "actual:   $ACTUAL_SUM" >&2
+  exit 1
+fi
+
+mkdir -p "$INSTALL_DIR"
+tar -xzf "$ARCHIVE_PATH" -C "$TMP_DIR"
+
+BIN_PATH="$TMP_DIR/vibeusage"
+if [ ! -f "$BIN_PATH" ]; then
+  echo "error: release archive did not contain vibeusage binary" >&2
+  exit 1
+fi
+
+if command -v install >/dev/null 2>&1; then
+  install -m 0755 "$BIN_PATH" "$INSTALL_DIR/vibeusage"
+else
+  cp "$BIN_PATH" "$INSTALL_DIR/vibeusage"
+  chmod 0755 "$INSTALL_DIR/vibeusage"
+fi
+
+echo "Installed vibeusage to $INSTALL_DIR/vibeusage"
+echo "Run: vibeusage --version"


### PR DESCRIPTION
## Summary
- add GitHub release automation with GoReleaser and a tag-triggered release workflow
- add cross-platform install scripts (scripts/install.sh, scripts/install.ps1) with checksum verification
- add update command with --check, --yes, and --version flags
- add internal/updater package to check GitHub releases, verify checksums, and replace the binary in place
- switch CLI version to ldflags-injected internal/cli.version (default dev)
- document release process and update README install/update instructions

## Validation
- just test
- just lint
