### PR TITLE
Add Homebrew install support and restrict self-update to managed installs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,6 +24,10 @@ and this project attempts to adhere to [Semantic Versioning](https://semver.org/
 
 - Added Homebrew installation support.
 
+### Changed
+
+- Limited `vibeusage update` installs to script-managed installations.
+
 ## [0.1.1]
 
 ### Fixed

--- a/README.md
+++ b/README.md
@@ -316,7 +316,19 @@ vibeusage update
 vibeusage update --yes
 ```
 
-You can also re-run the [install scripts](#quick-install-recommended) to upgrade in place.
+`vibeusage update` only applies updates for installs managed by the official install scripts.
+
+If you installed with Homebrew, upgrade with:
+
+```bash
+brew upgrade vibeusage
+```
+
+If you installed with `go install`, rerun:
+
+```bash
+go install github.com/joshuadavidthomas/vibeusage@latest
+```
 
 ## Configuration
 

--- a/install.ps1
+++ b/install.ps1
@@ -63,6 +63,7 @@ try {
 
   New-Item -ItemType Directory -Path $InstallDir -Force | Out-Null
   Copy-Item -Path $binaryPath -Destination (Join-Path $InstallDir "vibeusage.exe") -Force
+  Set-Content -Path (Join-Path $InstallDir ".vibeusage-managed-by") -Value "install-script" -NoNewline
 
   Write-Host "Installed vibeusage to $(Join-Path $InstallDir 'vibeusage.exe')"
   Write-Host "Run: vibeusage --version"

--- a/install.sh
+++ b/install.sh
@@ -124,5 +124,7 @@ else
   chmod 0755 "$INSTALL_DIR/vibeusage"
 fi
 
+printf '%s\n' 'install-script' > "$INSTALL_DIR/.vibeusage-managed-by"
+
 echo "Installed vibeusage to $INSTALL_DIR/vibeusage"
 echo "Run: vibeusage --version"

--- a/internal/updater/install_control.go
+++ b/internal/updater/install_control.go
@@ -1,0 +1,75 @@
+package updater
+
+import (
+	"fmt"
+	"os"
+	"path/filepath"
+	"runtime"
+	"strings"
+)
+
+const (
+	// ManagedInstallMarkerFilename is written by the official install scripts.
+	// Self-update is only enabled when this marker is present (or when the
+	// install matches legacy ~/.local/bin behavior).
+	ManagedInstallMarkerFilename = ".vibeusage-managed-by"
+	managedInstallMarkerValue    = "install-script"
+)
+
+// AssertSelfUpdateSupported returns an error when self-update should be
+// disabled for the current installation method.
+func AssertSelfUpdateSupported(binaryPath string) error {
+	if strings.TrimSpace(os.Getenv("VIBEUSAGE_ALLOW_UNMANAGED_UPDATE")) == "1" {
+		return nil
+	}
+
+	targetPath, err := resolveBinaryPath(binaryPath)
+	if err != nil {
+		return err
+	}
+
+	if isManagedInstall(targetPath) || isLegacyManagedPath(targetPath) {
+		return nil
+	}
+
+	if isHomebrewInstallPath(targetPath) {
+		return fmt.Errorf("self-update is not supported for Homebrew installs; use `brew upgrade %s`", projectName)
+	}
+
+	return fmt.Errorf("self-update is only supported for installs managed by the official install scripts; rerun install.sh/install.ps1 or use your package manager to upgrade")
+}
+
+func isManagedInstall(binaryPath string) bool {
+	markerPath := filepath.Join(filepath.Dir(binaryPath), ManagedInstallMarkerFilename)
+	markerBody, err := os.ReadFile(markerPath)
+	if err != nil {
+		return false
+	}
+
+	markerValue := strings.TrimSpace(string(markerBody))
+	return markerValue == "" || markerValue == managedInstallMarkerValue
+}
+
+func isLegacyManagedPath(binaryPath string) bool {
+	home, err := os.UserHomeDir()
+	if err != nil || strings.TrimSpace(home) == "" {
+		return false
+	}
+
+	expected := filepath.Join(home, ".local", "bin", filepath.Base(binaryPath))
+	return samePath(expected, binaryPath)
+}
+
+func samePath(a, b string) bool {
+	a = filepath.Clean(a)
+	b = filepath.Clean(b)
+	if runtime.GOOS == "windows" {
+		return strings.EqualFold(a, b)
+	}
+	return a == b
+}
+
+func isHomebrewInstallPath(binaryPath string) bool {
+	path := filepath.ToSlash(filepath.Clean(binaryPath))
+	return strings.Contains(path, "/Cellar/"+projectName+"/")
+}

--- a/internal/updater/install_control_test.go
+++ b/internal/updater/install_control_test.go
@@ -1,0 +1,76 @@
+package updater
+
+import (
+	"os"
+	"path/filepath"
+	"runtime"
+	"strings"
+	"testing"
+)
+
+func TestAssertSelfUpdateSupported_AllowsManagedInstallMarker(t *testing.T) {
+	dir := t.TempDir()
+	binary := filepath.Join(dir, "vibeusage")
+	if runtime.GOOS == "windows" {
+		binary += ".exe"
+	}
+
+	markerPath := filepath.Join(dir, ManagedInstallMarkerFilename)
+	if err := os.WriteFile(markerPath, []byte("install-script\n"), 0o644); err != nil {
+		t.Fatalf("failed to write marker: %v", err)
+	}
+
+	if err := AssertSelfUpdateSupported(binary); err != nil {
+		t.Fatalf("AssertSelfUpdateSupported returned error: %v", err)
+	}
+}
+
+func TestAssertSelfUpdateSupported_AllowsLegacyLocalBinPath(t *testing.T) {
+	home := t.TempDir()
+	t.Setenv("HOME", home)
+	t.Setenv("USERPROFILE", home)
+
+	binaryName := "vibeusage"
+	if runtime.GOOS == "windows" {
+		binaryName += ".exe"
+	}
+	binary := filepath.Join(home, ".local", "bin", binaryName)
+
+	if err := AssertSelfUpdateSupported(binary); err != nil {
+		t.Fatalf("AssertSelfUpdateSupported returned error: %v", err)
+	}
+}
+
+func TestAssertSelfUpdateSupported_HomebrewInstall(t *testing.T) {
+	binary := "/opt/homebrew/Cellar/vibeusage/0.1.2/bin/vibeusage"
+	err := AssertSelfUpdateSupported(binary)
+	if err == nil {
+		t.Fatal("expected error for homebrew install")
+	}
+	if !strings.Contains(err.Error(), "brew upgrade vibeusage") {
+		t.Fatalf("error = %q, want brew guidance", err.Error())
+	}
+}
+
+func TestAssertSelfUpdateSupported_UnmanagedInstall(t *testing.T) {
+	home := t.TempDir()
+	t.Setenv("HOME", home)
+	t.Setenv("USERPROFILE", home)
+
+	binary := filepath.Join(t.TempDir(), "bin", "vibeusage")
+	err := AssertSelfUpdateSupported(binary)
+	if err == nil {
+		t.Fatal("expected error for unmanaged install")
+	}
+	if !strings.Contains(err.Error(), "official install scripts") {
+		t.Fatalf("error = %q, want unmanaged install guidance", err.Error())
+	}
+}
+
+func TestAssertSelfUpdateSupported_UnmanagedOverride(t *testing.T) {
+	t.Setenv("VIBEUSAGE_ALLOW_UNMANAGED_UPDATE", "1")
+	binary := filepath.Join(t.TempDir(), "bin", "vibeusage")
+	if err := AssertSelfUpdateSupported(binary); err != nil {
+		t.Fatalf("AssertSelfUpdateSupported returned error with override: %v", err)
+	}
+}


### PR DESCRIPTION
## Summary
- add Homebrew installation instructions to the README
- limit `vibeusage update` install mode to controlled/script-managed installs
- add install provenance markers to `install.sh` and `install.ps1`
- add updater install-control checks and tests
- update changelog entries under Unreleased

## Validation
- just fmt
- just lint
- just test
