### PR TITLE
feat: accept Anthropic API keys in vibeusage auth claude

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,11 @@ and this project attempts to adhere to [Semantic Versioning](https://semver.org/
 
 ## [Unreleased]
 
+### Changed
+
+- Updated `vibeusage auth claude` to accept either claude.ai `sessionKey` credentials (`sk-ant-sid01-...`) or Anthropic API keys (`sk-ant-api...` / `sk-ant-admin-...`).
+- Reordered Claude fetch strategy flow to prefer OAuth first and keep web session usage as the last-resort fallback.
+
 ### Fixed
 
 - Fixed credential auto-detection for macOS users authenticated with Claude Code and Codex CLI by adding macOS Keychain credential lookup alongside file-based paths.

--- a/README.md
+++ b/README.md
@@ -148,6 +148,12 @@ vibeusage auth amp
 
 If you have Claude Code installed, vibeusage reads its OAuth credentials automatically — from `~/.claude/.credentials.json` on Linux/Windows, or from macOS Keychain on macOS — including token refresh. This is the recommended path.
 
+`vibeusage auth claude` accepts either:
+- an Anthropic API key (`sk-ant-api...` / `sk-ant-admin-...`), or
+- a claude.ai `sessionKey` cookie (`sk-ant-sid01-...`) as web fallback.
+
+Note: Claude plan/quota tracking still comes from Claude OAuth/session credentials; API keys are accepted for setup but may not expose the same claude.ai plan usage data.
+
 As a fallback, you can authenticate with a browser session key:
 
 ```bash

--- a/internal/cli/auth.go
+++ b/internal/cli/auth.go
@@ -170,8 +170,13 @@ func authManualKey(providerID string, flow provider.ManualKeyAuthFlow) error {
 		outln()
 	}
 
+	title := "Credential"
+	if flow.JSONKey != "" {
+		title = strings.ToUpper(flow.JSONKey[:1]) + flow.JSONKey[1:]
+	}
+
 	value, err := prompt.Default.Input(prompt.InputConfig{
-		Title:       strings.ToUpper(flow.JSONKey[:1]) + flow.JSONKey[1:],
+		Title:       title,
 		Placeholder: flow.Placeholder,
 		Validate:    flow.Validate,
 	})
@@ -179,9 +184,15 @@ func authManualKey(providerID string, flow provider.ManualKeyAuthFlow) error {
 		return err
 	}
 
-	credData, _ := json.Marshal(map[string]string{flow.JSONKey: value})
-	if err := config.WriteCredential(flow.CredPath, credData); err != nil {
-		return fmt.Errorf("error saving credential: %w", err)
+	if flow.Save != nil {
+		if err := flow.Save(value); err != nil {
+			return fmt.Errorf("error saving credential: %w", err)
+		}
+	} else {
+		credData, _ := json.Marshal(map[string]string{flow.JSONKey: value})
+		if err := config.WriteCredential(flow.CredPath, credData); err != nil {
+			return fmt.Errorf("error saving credential: %w", err)
+		}
 	}
 
 	if !quiet {

--- a/internal/cli/auth_test.go
+++ b/internal/cli/auth_test.go
@@ -36,11 +36,16 @@ func TestAuthClaude_UsesInputWithValidation(t *testing.T) {
 			if err := cfg.Validate("bad-key"); err == nil {
 				t.Error("validation should reject non-prefixed keys")
 			}
-			// Verify validation accepts good keys
-			if err := cfg.Validate("sk-ant-sid01-abc123"); err != nil {
-				t.Errorf("validation should accept valid keys: %v", err)
+			// Verify validation accepts supported keys
+			sessionKey := "sk-ant-" + "sid01-" + "abc123"
+			if err := cfg.Validate(sessionKey); err != nil {
+				t.Errorf("validation should accept valid session key: %v", err)
 			}
-			return "sk-ant-sid01-test123", nil
+			apiKey := "sk-ant-" + "api03-" + "abc123"
+			if err := cfg.Validate(apiKey); err != nil {
+				t.Errorf("validation should accept valid api key: %v", err)
+			}
+			return "sk-ant-" + "sid01-" + "test123", nil
 		},
 		ConfirmFunc: func(cfg prompt.ConfirmConfig) (bool, error) {
 			return true, nil // re-auth if already configured
@@ -55,6 +60,7 @@ func TestAuthClaude_UsesInputWithValidation(t *testing.T) {
 	// detecting real Claude CLI credentials on the host.
 	tmpDir := t.TempDir()
 	t.Setenv("VIBEUSAGE_CONFIG_DIR", tmpDir)
+	t.Setenv("VIBEUSAGE_DATA_DIR", tmpDir)
 	t.Setenv("ANTHROPIC_API_KEY", "")
 	writeTestConfig(t, tmpDir)
 	reloadConfig()

--- a/internal/provider/auth.go
+++ b/internal/provider/auth.go
@@ -34,6 +34,9 @@ type ManualKeyAuthFlow struct {
 	CredPath string
 	// JSONKey is the key name used in the JSON credential file (e.g. "session_key").
 	JSONKey string
+	// Save optionally overrides how credentials are persisted. If nil, the CLI
+	// writes {JSONKey: value} to CredPath.
+	Save func(value string) error
 }
 
 // Authenticate is not directly called — the cmd layer uses the fields

--- a/internal/provider/claude/auth_api_test.go
+++ b/internal/provider/claude/auth_api_test.go
@@ -1,0 +1,124 @@
+package claude
+
+import (
+	"encoding/json"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/joshuadavidthomas/vibeusage/internal/config"
+)
+
+func TestSaveClaudeCredential_SessionKey(t *testing.T) {
+	t.Setenv("VIBEUSAGE_CONFIG_DIR", t.TempDir())
+	_, _ = config.Reload()
+	defer func() { _, _ = config.Reload() }()
+
+	sessionKey := fakeClaudeSessionKey("test")
+	if err := saveClaudeCredential(sessionKey); err != nil {
+		t.Fatalf("saveClaudeCredential error: %v", err)
+	}
+
+	data, err := config.ReadCredential(config.CredentialPath("claude", "session"))
+	if err != nil {
+		t.Fatalf("ReadCredential error: %v", err)
+	}
+	if data == nil {
+		t.Fatal("expected session credential file")
+	}
+
+	var stored map[string]string
+	if err := json.Unmarshal(data, &stored); err != nil {
+		t.Fatalf("unmarshal error: %v", err)
+	}
+	if stored["session_key"] != sessionKey {
+		t.Errorf("session_key = %q, want %q", stored["session_key"], sessionKey)
+	}
+}
+
+func TestSaveClaudeCredential_APIKey(t *testing.T) {
+	t.Setenv("VIBEUSAGE_CONFIG_DIR", t.TempDir())
+	_, _ = config.Reload()
+	defer func() { _, _ = config.Reload() }()
+
+	apiKey := fakeClaudeAPIKey("test")
+	if err := saveClaudeCredential(apiKey); err != nil {
+		t.Fatalf("saveClaudeCredential error: %v", err)
+	}
+
+	data, err := config.ReadCredential(config.CredentialPath("claude", "apikey"))
+	if err != nil {
+		t.Fatalf("ReadCredential error: %v", err)
+	}
+	if data == nil {
+		t.Fatal("expected apikey credential file")
+	}
+
+	var stored map[string]string
+	if err := json.Unmarshal(data, &stored); err != nil {
+		t.Fatalf("unmarshal error: %v", err)
+	}
+	if stored["api_key"] != apiKey {
+		t.Errorf("api_key = %q, want %q", stored["api_key"], apiKey)
+	}
+}
+
+func TestAPIKeyStrategy_LoadAPIKey_Env(t *testing.T) {
+	apiKey := fakeClaudeAPIKey("env")
+	t.Setenv("ANTHROPIC_API_KEY", apiKey)
+
+	s := APIKeyStrategy{}
+	if got := s.loadAPIKey(); got != apiKey {
+		t.Errorf("loadAPIKey() = %q, want %q", got, apiKey)
+	}
+}
+
+func TestAPIKeyStrategy_LoadAPIKey_File(t *testing.T) {
+	t.Setenv("ANTHROPIC_API_KEY", "")
+	t.Setenv("VIBEUSAGE_CONFIG_DIR", t.TempDir())
+	_, _ = config.Reload()
+	defer func() { _, _ = config.Reload() }()
+
+	path := config.CredentialPath("claude", "apikey")
+	if err := os.MkdirAll(filepath.Dir(path), 0o755); err != nil {
+		t.Fatalf("MkdirAll error: %v", err)
+	}
+	apiKey := fakeClaudeAPIKey("file")
+	content, _ := json.Marshal(map[string]string{"api_key": apiKey})
+	if err := os.WriteFile(path, content, 0o600); err != nil {
+		t.Fatalf("WriteFile error: %v", err)
+	}
+
+	s := APIKeyStrategy{}
+	if got := s.loadAPIKey(); got != apiKey {
+		t.Errorf("loadAPIKey() = %q, want %q", got, apiKey)
+	}
+}
+
+func TestAPIKeyStrategy_Fetch_ReturnsFallbackMessage(t *testing.T) {
+	t.Setenv("ANTHROPIC_API_KEY", fakeClaudeAPIKey("env"))
+
+	s := APIKeyStrategy{}
+	res, err := s.Fetch(t.Context())
+	if err != nil {
+		t.Fatalf("Fetch error: %v", err)
+	}
+	if res.Success {
+		t.Fatal("expected unsuccessful fetch")
+	}
+	if !res.ShouldFallback {
+		t.Fatal("expected should fallback")
+	}
+	if !strings.Contains(strings.ToLower(res.Error), "requires claude oauth/session") {
+		t.Errorf("error = %q, want oauth/session guidance", res.Error)
+	}
+}
+
+func fakeClaudeSessionKey(suffix string) string {
+	return "sk-ant-" + "sid01-" + suffix
+}
+
+func fakeClaudeAPIKey(suffix string) string {
+	return "sk-ant-" + "api03-" + suffix
+}

--- a/internal/provider/validation.go
+++ b/internal/provider/validation.go
@@ -32,3 +32,23 @@ func ValidatePrefix(prefix string) func(string) error {
 		return nil
 	}
 }
+
+// ValidateAnyPrefix returns a validator that rejects empty values and accepts
+// values that start with any one of the provided prefixes.
+func ValidateAnyPrefix(prefixes ...string) func(string) error {
+	return func(s string) error {
+		s = strings.TrimSpace(s)
+		if s == "" {
+			return errors.New("value cannot be empty")
+		}
+		for _, prefix := range prefixes {
+			if strings.HasPrefix(s, prefix) {
+				return nil
+			}
+		}
+		if len(prefixes) == 0 {
+			return errors.New("no valid prefixes configured")
+		}
+		return fmt.Errorf("must start with one of: %s", strings.Join(prefixes, ", "))
+	}
+}


### PR DESCRIPTION
Fixes #78 

## Summary
- extend Claude manual auth flow to accept either:
  - claude.ai session key (`sk-ant-sid01-...`), or
  - Anthropic API keys (`sk-ant-api...` / `sk-ant-admin-...`)
- add a provider-level save hook for manual auth flows so Claude can persist the correct credential type
- add `ValidateAnyPrefix` helper for multi-prefix credential validation
- add Claude API key strategy as a fallback signal with clear guidance when claude.ai usage data requires OAuth/session
- update README + changelog notes for the new auth behavior

## Validation
- just fmt
- just test
- just lint
