### PR TITLE
refactor: replace config singleton lazy-load with explicit Init and test Override

### DIFF
--- a/internal/cli/cache_test.go
+++ b/internal/cli/cache_test.go
@@ -7,6 +7,7 @@ import (
 	"strings"
 	"testing"
 
+	"github.com/joshuadavidthomas/vibeusage/internal/config"
 	"github.com/joshuadavidthomas/vibeusage/internal/display"
 	"github.com/joshuadavidthomas/vibeusage/internal/testenv"
 )
@@ -14,7 +15,7 @@ import (
 func TestCacheShowCmd_HasTableBorders(t *testing.T) {
 	tmp := t.TempDir()
 	testenv.ApplySameDir(t.Setenv, tmp)
-	reloadConfig()
+	config.Override(t, config.DefaultConfig())
 
 	var buf bytes.Buffer
 	outWriter = &buf
@@ -46,7 +47,7 @@ func TestCacheShowCmd_HasTableBorders(t *testing.T) {
 func TestCacheShowCmd_ContainsHeaders(t *testing.T) {
 	tmp := t.TempDir()
 	testenv.ApplySameDir(t.Setenv, tmp)
-	reloadConfig()
+	config.Override(t, config.DefaultConfig())
 
 	var buf bytes.Buffer
 	outWriter = &buf
@@ -79,7 +80,7 @@ func TestCacheShowCmd_ContainsHeaders(t *testing.T) {
 func TestCacheShowCmd_QuietMode(t *testing.T) {
 	tmp := t.TempDir()
 	testenv.ApplySameDir(t.Setenv, tmp)
-	reloadConfig()
+	config.Override(t, config.DefaultConfig())
 
 	var buf bytes.Buffer
 	outWriter = &buf
@@ -107,7 +108,7 @@ func TestCacheShowCmd_QuietMode(t *testing.T) {
 func TestCacheShowCmd_ShowsCacheDir(t *testing.T) {
 	tmp := t.TempDir()
 	testenv.ApplySameDir(t.Setenv, tmp)
-	reloadConfig()
+	config.Override(t, config.DefaultConfig())
 
 	var buf bytes.Buffer
 	outWriter = &buf
@@ -140,7 +141,7 @@ func TestCacheShowCmd_ShowsCacheDir(t *testing.T) {
 func TestCacheClearJSON_UsesTypedStruct(t *testing.T) {
 	tmp := t.TempDir()
 	testenv.ApplySameDir(t.Setenv, tmp)
-	reloadConfig()
+	config.Override(t, config.DefaultConfig())
 
 	var buf bytes.Buffer
 	outWriter = &buf

--- a/internal/cli/config_test.go
+++ b/internal/cli/config_test.go
@@ -7,6 +7,7 @@ import (
 	"path/filepath"
 	"testing"
 
+	"github.com/joshuadavidthomas/vibeusage/internal/config"
 	"github.com/joshuadavidthomas/vibeusage/internal/display"
 	"github.com/joshuadavidthomas/vibeusage/internal/prompt"
 	"github.com/joshuadavidthomas/vibeusage/internal/testenv"
@@ -35,7 +36,7 @@ func TestConfigReset_UsesConfirm(t *testing.T) {
 	outWriter = &buf
 	defer func() { outWriter = os.Stdout }()
 
-	reloadConfig()
+	config.Override(t, config.DefaultConfig())
 
 	err := configResetCmd.RunE(configResetCmd, nil)
 	if err != nil {
@@ -68,7 +69,7 @@ func TestConfigReset_UserDeclinesConfirm(t *testing.T) {
 	outWriter = &buf
 	defer func() { outWriter = os.Stdout }()
 
-	reloadConfig()
+	config.Override(t, config.DefaultConfig())
 
 	cmd := configResetCmd
 	err := cmd.RunE(cmd, nil)
@@ -92,7 +93,7 @@ func TestConfigReset_UserDeclinesConfirm(t *testing.T) {
 func TestConfigResetJSON_UsesTypedStruct(t *testing.T) {
 	tmp := t.TempDir()
 	testenv.ApplySameDir(t.Setenv, tmp)
-	reloadConfig()
+	config.Override(t, config.DefaultConfig())
 
 	var buf bytes.Buffer
 	outWriter = &buf

--- a/internal/cli/init_test.go
+++ b/internal/cli/init_test.go
@@ -6,6 +6,7 @@ import (
 	"os"
 	"testing"
 
+	"github.com/joshuadavidthomas/vibeusage/internal/config"
 	"github.com/joshuadavidthomas/vibeusage/internal/display"
 	"github.com/joshuadavidthomas/vibeusage/internal/prompt"
 	"github.com/joshuadavidthomas/vibeusage/internal/testenv"
@@ -156,7 +157,7 @@ func TestQuickSetup_QuietMode(t *testing.T) {
 func TestInitCommand_QuickFlag_DoesNotPanicWhenConfigMissing(t *testing.T) {
 	tmp := t.TempDir()
 	testenv.ApplySameDir(t.Setenv, tmp)
-	reloadConfig()
+	config.Override(t, config.DefaultConfig())
 
 	var buf bytes.Buffer
 	outWriter = &buf
@@ -179,7 +180,7 @@ func TestInitCommand_QuickFlag_DoesNotPanicWhenConfigMissing(t *testing.T) {
 func TestInitJSON_UsesTypedStruct(t *testing.T) {
 	tmp := t.TempDir()
 	testenv.ApplySameDir(t.Setenv, tmp)
-	reloadConfig()
+	config.Override(t, config.DefaultConfig())
 
 	var buf bytes.Buffer
 	outWriter = &buf

--- a/internal/cli/key_test.go
+++ b/internal/cli/key_test.go
@@ -10,6 +10,7 @@ import (
 
 	"github.com/spf13/cobra"
 
+	"github.com/joshuadavidthomas/vibeusage/internal/config"
 	"github.com/joshuadavidthomas/vibeusage/internal/display"
 	"github.com/joshuadavidthomas/vibeusage/internal/prompt"
 	"github.com/joshuadavidthomas/vibeusage/internal/testenv"
@@ -40,7 +41,7 @@ func TestKeySet_UsesInputPrompt(t *testing.T) {
 	outWriter = &buf
 	defer func() { outWriter = os.Stdout }()
 
-	reloadConfig()
+	config.Override(t, config.DefaultConfig())
 
 	// Get the claude subcommand, then its "set" subcommand
 	claudeCmd := findSubcommand(keyCmd, "claude")
@@ -92,7 +93,7 @@ func TestKeyDelete_UsesConfirmPrompt(t *testing.T) {
 	outWriter = &buf
 	defer func() { outWriter = os.Stdout }()
 
-	reloadConfig()
+	config.Override(t, config.DefaultConfig())
 
 	claudeCmd := findSubcommand(keyCmd, "claude")
 	if claudeCmd == nil {
@@ -136,7 +137,7 @@ func TestKeyDelete_UserDeclinesConfirm(t *testing.T) {
 	outWriter = &buf
 	defer func() { outWriter = os.Stdout }()
 
-	reloadConfig()
+	config.Override(t, config.DefaultConfig())
 
 	claudeCmd := findSubcommand(keyCmd, "claude")
 	deleteCmd := findSubcommand(claudeCmd, "delete")
@@ -155,7 +156,7 @@ func TestKeyDelete_UserDeclinesConfirm(t *testing.T) {
 func TestDisplayAllCredentialStatus_HasTableBorders(t *testing.T) {
 	tmp := t.TempDir()
 	testenv.ApplySameDir(t.Setenv, tmp)
-	reloadConfig()
+	config.Override(t, config.DefaultConfig())
 
 	var buf bytes.Buffer
 	outWriter = &buf
@@ -185,7 +186,7 @@ func TestDisplayAllCredentialStatus_HasTableBorders(t *testing.T) {
 func TestDisplayAllCredentialStatus_ContainsHeaders(t *testing.T) {
 	tmp := t.TempDir()
 	testenv.ApplySameDir(t.Setenv, tmp)
-	reloadConfig()
+	config.Override(t, config.DefaultConfig())
 
 	var buf bytes.Buffer
 	outWriter = &buf
@@ -216,7 +217,7 @@ func TestDisplayAllCredentialStatus_ContainsHeaders(t *testing.T) {
 func TestDisplayAllCredentialStatus_QuietMode(t *testing.T) {
 	tmp := t.TempDir()
 	testenv.ApplySameDir(t.Setenv, tmp)
-	reloadConfig()
+	config.Override(t, config.DefaultConfig())
 
 	var buf bytes.Buffer
 	outWriter = &buf
@@ -243,7 +244,7 @@ func TestDisplayAllCredentialStatus_QuietMode(t *testing.T) {
 func TestKeyStatusJSON_UsesTypedStruct(t *testing.T) {
 	tmp := t.TempDir()
 	testenv.ApplySameDir(t.Setenv, tmp)
-	reloadConfig()
+	config.Override(t, config.DefaultConfig())
 
 	var buf bytes.Buffer
 	outWriter = &buf

--- a/internal/cli/root.go
+++ b/internal/cli/root.go
@@ -56,8 +56,8 @@ var rootCmd = &cobra.Command{
 		ctx := logging.WithLogger(cmd.Context(), l)
 		cmd.SetContext(ctx)
 
-		// Eagerly load config so malformed files surface a warning.
-		if _, err := config.Reload(); err != nil {
+		// Load config from disk so malformed files surface a warning.
+		if _, err := config.Init(); err != nil {
 			l.Warn("config file is malformed, using defaults", "err", err)
 		}
 	},

--- a/internal/cli/root_test.go
+++ b/internal/cli/root_test.go
@@ -10,6 +10,7 @@ import (
 
 	"github.com/spf13/cobra"
 
+	"github.com/joshuadavidthomas/vibeusage/internal/config"
 	"github.com/joshuadavidthomas/vibeusage/internal/display"
 	"github.com/joshuadavidthomas/vibeusage/internal/fetch"
 	"github.com/joshuadavidthomas/vibeusage/internal/models"
@@ -131,7 +132,7 @@ func TestRootCmd_VersionFlag(t *testing.T) {
 	// Set up temp dir to avoid first-run check
 	tmpDir := t.TempDir()
 	testenv.ApplySameDir(t.Setenv, tmpDir)
-	reloadConfig()
+	config.Override(t, config.DefaultConfig())
 
 	rootCmd.SetArgs([]string{"--version"})
 	defer rootCmd.SetArgs(nil)
@@ -158,7 +159,7 @@ func TestConfigShow_DefaultOutput(t *testing.T) {
 
 	tmpDir := t.TempDir()
 	testenv.ApplySameDir(t.Setenv, tmpDir)
-	reloadConfig()
+	config.Override(t, config.DefaultConfig())
 
 	oldQuiet := quiet
 	quiet = false
@@ -189,7 +190,7 @@ func TestConfigShow_QuietMode(t *testing.T) {
 
 	tmpDir := t.TempDir()
 	testenv.ApplySameDir(t.Setenv, tmpDir)
-	reloadConfig()
+	config.Override(t, config.DefaultConfig())
 
 	oldQuiet := quiet
 	quiet = true
@@ -217,7 +218,7 @@ func TestConfigShow_JSONOutput(t *testing.T) {
 
 	tmpDir := t.TempDir()
 	testenv.ApplySameDir(t.Setenv, tmpDir)
-	reloadConfig()
+	config.Override(t, config.DefaultConfig())
 
 	oldJSON := jsonOutput
 	jsonOutput = true
@@ -246,7 +247,7 @@ func TestConfigPath_DefaultOutput(t *testing.T) {
 
 	tmpDir := t.TempDir()
 	testenv.ApplySameDir(t.Setenv, tmpDir)
-	reloadConfig()
+	config.Override(t, config.DefaultConfig())
 
 	oldQuiet := quiet
 	quiet = false
@@ -277,7 +278,7 @@ func TestConfigPath_QuietMode(t *testing.T) {
 
 	tmpDir := t.TempDir()
 	testenv.ApplySameDir(t.Setenv, tmpDir)
-	reloadConfig()
+	config.Override(t, config.DefaultConfig())
 
 	oldQuiet := quiet
 	quiet = true
@@ -306,7 +307,7 @@ func TestConfigPath_JSONOutput(t *testing.T) {
 
 	tmpDir := t.TempDir()
 	testenv.ApplySameDir(t.Setenv, tmpDir)
-	reloadConfig()
+	config.Override(t, config.DefaultConfig())
 
 	oldJSON := jsonOutput
 	jsonOutput = true
@@ -337,7 +338,7 @@ func TestConfigPath_CacheFlag(t *testing.T) {
 
 	tmpDir := t.TempDir()
 	testenv.ApplySameDir(t.Setenv, tmpDir)
-	reloadConfig()
+	config.Override(t, config.DefaultConfig())
 
 	oldQuiet := quiet
 	quiet = true

--- a/internal/cli/testutil_test.go
+++ b/internal/cli/testutil_test.go
@@ -4,15 +4,8 @@ import (
 	"bytes"
 	"context"
 
-	"github.com/joshuadavidthomas/vibeusage/internal/config"
 	"github.com/joshuadavidthomas/vibeusage/internal/logging"
 )
-
-// reloadConfig forces a config reload. Used by tests that modify
-// VIBEUSAGE_CONFIG_DIR via t.Setenv before exercising commands.
-func reloadConfig() {
-	_, _ = config.Reload()
-}
 
 func newVerboseContext(logBuf *bytes.Buffer) context.Context {
 	l := logging.NewLogger(logBuf)

--- a/internal/config/testing.go
+++ b/internal/config/testing.go
@@ -1,0 +1,20 @@
+package config
+
+import "testing"
+
+// Override sets the global config to cfg for the duration of the test,
+// restoring the previous value on cleanup. This avoids the need to write
+// config files to disk and call Init in tests.
+func Override(t testing.TB, cfg Config) {
+	t.Helper()
+	configMu.RLock()
+	prev := globalConfig
+	configMu.RUnlock()
+
+	set(cfg)
+	t.Cleanup(func() {
+		configMu.Lock()
+		defer configMu.Unlock()
+		globalConfig = prev
+	})
+}

--- a/internal/provider/amp/amp_test.go
+++ b/internal/provider/amp/amp_test.go
@@ -96,13 +96,7 @@ func TestCLISecretsStrategy_IsAvailable_RespectsReuseProviderCredentials(t *test
 
 	cfg := config.DefaultConfig()
 	cfg.Credentials.ReuseProviderCredentials = false
-	if err := config.Save(cfg, ""); err != nil {
-		t.Fatalf("config.Save: %v", err)
-	}
-	if _, err := config.Reload(); err != nil {
-		t.Fatalf("config.Reload: %v", err)
-	}
-	t.Cleanup(func() { _, _ = config.Reload() })
+	config.Override(t, cfg)
 
 	secretsPath := filepath.Join(dir, "home", ".local", "share", "amp", "secrets.json")
 	if err := os.MkdirAll(filepath.Dir(secretsPath), 0o755); err != nil {

--- a/internal/provider/antigravity/antigravity_test.go
+++ b/internal/provider/antigravity/antigravity_test.go
@@ -43,13 +43,7 @@ func TestOAuthStrategy_CredentialPaths_RespectsReuseProviderCredentials(t *testi
 
 	cfg := config.DefaultConfig()
 	cfg.Credentials.ReuseProviderCredentials = false
-	if err := config.Save(cfg, ""); err != nil {
-		t.Fatalf("config.Save: %v", err)
-	}
-	if _, err := config.Reload(); err != nil {
-		t.Fatalf("config.Reload: %v", err)
-	}
-	t.Cleanup(func() { _, _ = config.Reload() })
+	config.Override(t, cfg)
 
 	externalPath := filepath.Join(dir, "home", ".config", "Antigravity", "credentials.json")
 	if err := os.MkdirAll(filepath.Dir(externalPath), 0o755); err != nil {

--- a/internal/provider/claude/auth_api_test.go
+++ b/internal/provider/claude/auth_api_test.go
@@ -13,8 +13,7 @@ import (
 
 func TestSaveClaudeCredential_SessionKey(t *testing.T) {
 	testenv.ApplyVibeusage(t.Setenv, t.TempDir())
-	_, _ = config.Reload()
-	defer func() { _, _ = config.Reload() }()
+	config.Override(t, config.DefaultConfig())
 
 	sessionKey := fakeClaudeSessionKey("test")
 	if err := saveClaudeCredential(sessionKey); err != nil {
@@ -40,8 +39,7 @@ func TestSaveClaudeCredential_SessionKey(t *testing.T) {
 
 func TestSaveClaudeCredential_APIKey(t *testing.T) {
 	testenv.ApplyVibeusage(t.Setenv, t.TempDir())
-	_, _ = config.Reload()
-	defer func() { _, _ = config.Reload() }()
+	config.Override(t, config.DefaultConfig())
 
 	apiKey := fakeClaudeAPIKey("test")
 	if err := saveClaudeCredential(apiKey); err != nil {
@@ -78,8 +76,7 @@ func TestAPIKeyStrategy_LoadAPIKey_Env(t *testing.T) {
 func TestAPIKeyStrategy_LoadAPIKey_File(t *testing.T) {
 	t.Setenv("ANTHROPIC_API_KEY", "")
 	testenv.ApplyVibeusage(t.Setenv, t.TempDir())
-	_, _ = config.Reload()
-	defer func() { _, _ = config.Reload() }()
+	config.Override(t, config.DefaultConfig())
 
 	path := config.CredentialPath("claude", "apikey")
 	if err := os.MkdirAll(filepath.Dir(path), 0o755); err != nil {

--- a/internal/provider/claude/oauth_test.go
+++ b/internal/provider/claude/oauth_test.go
@@ -364,13 +364,7 @@ func TestOAuthStrategy_CredentialPaths_RespectsReuseProviderCredentials(t *testi
 
 	cfg := config.DefaultConfig()
 	cfg.Credentials.ReuseProviderCredentials = false
-	if err := config.Save(cfg, ""); err != nil {
-		t.Fatalf("config.Save: %v", err)
-	}
-	if _, err := config.Reload(); err != nil {
-		t.Fatalf("config.Reload: %v", err)
-	}
-	t.Cleanup(func() { _, _ = config.Reload() })
+	config.Override(t, cfg)
 
 	externalPath := filepath.Join(dir, "home", ".claude", ".credentials.json")
 	if err := os.MkdirAll(filepath.Dir(externalPath), 0o755); err != nil {

--- a/internal/provider/codex/codex_test.go
+++ b/internal/provider/codex/codex_test.go
@@ -236,13 +236,7 @@ func TestOAuthStrategy_CredentialPaths_RespectsReuseProviderCredentials(t *testi
 
 	cfg := config.DefaultConfig()
 	cfg.Credentials.ReuseProviderCredentials = false
-	if err := config.Save(cfg, ""); err != nil {
-		t.Fatalf("config.Save: %v", err)
-	}
-	if _, err := config.Reload(); err != nil {
-		t.Fatalf("config.Reload: %v", err)
-	}
-	t.Cleanup(func() { _, _ = config.Reload() })
+	config.Override(t, cfg)
 
 	externalPath := filepath.Join(dir, "home", ".codex", "auth.json")
 	if err := os.MkdirAll(filepath.Dir(externalPath), 0o755); err != nil {

--- a/internal/provider/credentials_test.go
+++ b/internal/provider/credentials_test.go
@@ -24,10 +24,7 @@ func withTempCredentialDir(t *testing.T) {
 	t.Helper()
 	dir := t.TempDir()
 	testenv.ApplyVibeusage(t.Setenv, dir)
-	// Force config reload so paths pick up the new env.
-	if _, err := config.Reload(); err != nil {
-		t.Fatalf("config.Reload: %v", err)
-	}
+	config.Override(t, config.DefaultConfig())
 }
 
 func TestFindCredential_VibeusageStorage(t *testing.T) {
@@ -128,14 +125,9 @@ func TestFindCredential_CLIPaths(t *testing.T) {
 	})
 
 	// Enable reuse of provider credentials
-	cfg := config.Get()
+	cfg := config.DefaultConfig()
 	cfg.Credentials.ReuseProviderCredentials = true
-	if err := config.Save(cfg, ""); err != nil {
-		t.Fatalf("config.Save: %v", err)
-	}
-	if _, err := config.Reload(); err != nil {
-		t.Fatalf("config.Reload: %v", err)
-	}
+	config.Override(t, cfg)
 
 	found, source, _ := FindCredential("testprov")
 	if !found {

--- a/internal/provider/gemini/gemini_test.go
+++ b/internal/provider/gemini/gemini_test.go
@@ -19,13 +19,7 @@ func TestOAuthStrategy_CredentialPaths_RespectsReuseProviderCredentials(t *testi
 
 	cfg := config.DefaultConfig()
 	cfg.Credentials.ReuseProviderCredentials = false
-	if err := config.Save(cfg, ""); err != nil {
-		t.Fatalf("config.Save: %v", err)
-	}
-	if _, err := config.Reload(); err != nil {
-		t.Fatalf("config.Reload: %v", err)
-	}
-	t.Cleanup(func() { _, _ = config.Reload() })
+	config.Override(t, cfg)
 
 	externalPath := filepath.Join(dir, "home", ".gemini", "oauth_creds.json")
 	if err := os.MkdirAll(filepath.Dir(externalPath), 0o755); err != nil {

--- a/internal/provider/kimicode/kimicode_test.go
+++ b/internal/provider/kimicode/kimicode_test.go
@@ -25,13 +25,7 @@ func TestDeviceFlowStrategy_CredentialPaths_RespectsReuseProviderCredentials(t *
 
 	cfg := config.DefaultConfig()
 	cfg.Credentials.ReuseProviderCredentials = false
-	if err := config.Save(cfg, ""); err != nil {
-		t.Fatalf("config.Save: %v", err)
-	}
-	if _, err := config.Reload(); err != nil {
-		t.Fatalf("config.Reload: %v", err)
-	}
-	t.Cleanup(func() { _, _ = config.Reload() })
+	config.Override(t, cfg)
 
 	externalPath := filepath.Join(dir, "home", ".kimi", "credentials", "kimi-code.json")
 	if err := os.MkdirAll(filepath.Dir(externalPath), 0o755); err != nil {

--- a/internal/provider/provider_test.go
+++ b/internal/provider/provider_test.go
@@ -275,8 +275,7 @@ func TestAvailableIDs_IsSorted(t *testing.T) {
 
 func TestCheckCredentials_FallsBackToAvailableStrategy(t *testing.T) {
 	testenv.ApplySameDir(t.Setenv, t.TempDir())
-	_, _ = config.Reload()
-	defer func() { _, _ = config.Reload() }()
+	config.Override(t, config.DefaultConfig())
 
 	orig := registry
 	registry = map[string]Provider{}
@@ -300,11 +299,7 @@ func TestCheckCredentials_NoStrategyFallbackWhenReuseDisabled(t *testing.T) {
 	testenv.ApplySameDir(t.Setenv, t.TempDir())
 	cfg := config.DefaultConfig()
 	cfg.Credentials.ReuseProviderCredentials = false
-	if err := config.Save(cfg, ""); err != nil {
-		t.Fatalf("Save config error: %v", err)
-	}
-	_, _ = config.Reload()
-	defer func() { _, _ = config.Reload() }()
+	config.Override(t, cfg)
 
 	orig := registry
 	registry = map[string]Provider{}


### PR DESCRIPTION
## Summary

Replace the `config.Get()` lazy-loading singleton with explicit initialization and a proper test helper.

## The problem

The config singleton had three issues:
1. **Lazy-loads from disk on first `Get()` call** — hidden I/O with no explicit initialization point
2. **`Reload()` mutates global state** — every test had to call it to pick up env var changes
3. **Test ceremony** — every test did the `config.Save() → config.Reload() → defer config.Reload()` dance, writing real files just to set config values

## The fix

`config.Get()` stays as the access pattern — callers don't change. The *implementation* changes:

- **`config.Init()`** — called once in CLI `PersistentPreRun`, loads from disk, sets the global. Explicit, not hidden.
- **`config.Get()`** — returns what `Init` loaded, or `DefaultConfig()` if not yet initialized. No more lazy disk I/O.
- **`config.Override(t, cfg)`** — test helper that sets config for the duration of a test and auto-restores on `t.Cleanup`. No filesystem, no reload.
- **`config.Reload()`** — removed entirely.

## Changes

### `internal/config/`
- `config.go`: Replace `Get()` lazy-load + `Reload()` with `Get()` (read-only) + `Init()` (explicit load) + `set()` (internal helper)
- `testing.go`: New file with `Override(t, cfg)` test helper
- `config_test.go`: Update tests for new semantics

### `internal/cli/`
- `root.go`: `PersistentPreRun` calls `config.Init()` instead of `config.Reload()`
- `testutil_test.go`: Remove `reloadConfig()` helper and `config` import — only context helpers remain
- All `*_test.go`: Replace `reloadConfig()` with `config.Override(t, config.DefaultConfig())`

### Provider tests (8 files)
- Replace `config.Save(cfg, "") + config.Reload() + t.Cleanup(config.Reload)` with `config.Override(t, cfg)`

## Before/After

```go
// Before: write file, reload global, cleanup global
cfg := config.DefaultConfig()
cfg.Credentials.ReuseProviderCredentials = false
config.Save(cfg, "")
config.Reload()
t.Cleanup(func() { config.Reload() })

// After: just set the value
cfg := config.DefaultConfig()
cfg.Credentials.ReuseProviderCredentials = false
config.Override(t, cfg)
```