### PR TITLE
Remove Name() from Strategy interface and drop FetchAttempt

### DIFF
--- a/internal/cli/root_test.go
+++ b/internal/cli/root_test.go
@@ -387,9 +387,6 @@ func TestOutcomeToCompletion_Success(t *testing.T) {
 		ProviderID: "claude",
 		Success:    true,
 		Source:     "oauth",
-		Attempts: []fetch.FetchAttempt{
-			{Strategy: "oauth", Success: true, DurationMs: 342},
-		},
 	}
 
 	got := outcomeToCompletion(o)
@@ -409,10 +406,6 @@ func TestOutcomeToCompletion_Failure(t *testing.T) {
 		ProviderID: "cursor",
 		Success:    false,
 		Error:      "auth failed",
-		Attempts: []fetch.FetchAttempt{
-			{Strategy: "api_key", Success: false, DurationMs: 50, Error: "not available"},
-			{Strategy: "web", Success: false, DurationMs: 100, Error: "auth failed"},
-		},
 	}
 
 	got := outcomeToCompletion(o)
@@ -433,10 +426,6 @@ func TestOutcomeToCompletion_Fallback(t *testing.T) {
 		ProviderID: "gemini",
 		Success:    true,
 		Source:     "code_assist",
-		Attempts: []fetch.FetchAttempt{
-			{Strategy: "oauth", Success: false, DurationMs: 200, Error: "token expired"},
-			{Strategy: "code_assist", Success: true, DurationMs: 800},
-		},
 	}
 
 	got := outcomeToCompletion(o)

--- a/internal/fetch/orchestrator_test.go
+++ b/internal/fetch/orchestrator_test.go
@@ -23,7 +23,6 @@ func TestFetchAllProviders_MultipleProviders(t *testing.T) {
 	providerMap := map[string][]Strategy{
 		"provider-a": {
 			&mockStrategy{
-				name:      "strategy-a",
 				available: true,
 				fetchFn: func(ctx context.Context) (FetchResult, error) {
 					return ResultOK(testSnapshot("provider-a", "strategy-a", 40)), nil
@@ -32,7 +31,6 @@ func TestFetchAllProviders_MultipleProviders(t *testing.T) {
 		},
 		"provider-b": {
 			&mockStrategy{
-				name:      "strategy-b",
 				available: true,
 				fetchFn: func(ctx context.Context) (FetchResult, error) {
 					return ResultOK(testSnapshot("provider-b", "strategy-b", 60)), nil
@@ -41,7 +39,6 @@ func TestFetchAllProviders_MultipleProviders(t *testing.T) {
 		},
 		"provider-c": {
 			&mockStrategy{
-				name:      "strategy-c",
 				available: true,
 				fetchFn: func(ctx context.Context) (FetchResult, error) {
 					return ResultOK(testSnapshot("provider-c", "strategy-c", 80)), nil
@@ -99,7 +96,6 @@ func TestFetchAllProviders_MixedResults(t *testing.T) {
 	providerMap := map[string][]Strategy{
 		"succeeder": {
 			&mockStrategy{
-				name:      "good",
 				available: true,
 				fetchFn: func(ctx context.Context) (FetchResult, error) {
 					return ResultOK(testSnapshot("succeeder", "good", 50)), nil
@@ -108,7 +104,6 @@ func TestFetchAllProviders_MixedResults(t *testing.T) {
 		},
 		"failer": {
 			&mockStrategy{
-				name:      "bad",
 				available: true,
 				fetchFn: func(ctx context.Context) (FetchResult, error) {
 					return ResultFatal("credentials revoked"), nil
@@ -141,7 +136,6 @@ func TestFetchAllProviders_OnCompleteCallback(t *testing.T) {
 	providerMap := map[string][]Strategy{
 		"alpha": {
 			&mockStrategy{
-				name:      "s",
 				available: true,
 				fetchFn: func(ctx context.Context) (FetchResult, error) {
 					return ResultOK(testSnapshot("alpha", "s", 10)), nil
@@ -150,7 +144,6 @@ func TestFetchAllProviders_OnCompleteCallback(t *testing.T) {
 		},
 		"beta": {
 			&mockStrategy{
-				name:      "s",
 				available: true,
 				fetchFn: func(ctx context.Context) (FetchResult, error) {
 					return ResultOK(testSnapshot("beta", "s", 20)), nil
@@ -194,7 +187,6 @@ func TestFetchAllProviders_ContextCancellation(t *testing.T) {
 	providerMap := map[string][]Strategy{
 		"blocking": {
 			&mockStrategy{
-				name:      "blocker",
 				available: true,
 				fetchFn: func(ctx context.Context) (FetchResult, error) {
 					<-ctx.Done()
@@ -233,7 +225,6 @@ func TestFetchAllProviders_ConcurrencyLimit(t *testing.T) {
 	makeStrategy := func(pid string) []Strategy {
 		return []Strategy{
 			&mockStrategy{
-				name:      "s",
 				available: true,
 				fetchFn: func(ctx context.Context) (FetchResult, error) {
 					cur := concurrentCount.Add(1)
@@ -287,7 +278,6 @@ func TestFetchEnabledProviders_FiltersDisabled(t *testing.T) {
 	providerMap := map[string][]Strategy{
 		"alpha": {
 			&mockStrategy{
-				name:      "s",
 				available: true,
 				fetchFn: func(ctx context.Context) (FetchResult, error) {
 					return ResultOK(testSnapshot("alpha", "s", 10)), nil
@@ -296,7 +286,6 @@ func TestFetchEnabledProviders_FiltersDisabled(t *testing.T) {
 		},
 		"beta": {
 			&mockStrategy{
-				name:      "s",
 				available: true,
 				fetchFn: func(ctx context.Context) (FetchResult, error) {
 					t.Error("beta should not be fetched — it's not enabled")
@@ -306,7 +295,6 @@ func TestFetchEnabledProviders_FiltersDisabled(t *testing.T) {
 		},
 		"gamma": {
 			&mockStrategy{
-				name:      "s",
 				available: true,
 				fetchFn: func(ctx context.Context) (FetchResult, error) {
 					return ResultOK(testSnapshot("gamma", "s", 30)), nil
@@ -339,7 +327,6 @@ func TestFetchEnabledProviders_AllEnabledByDefault(t *testing.T) {
 	providerMap := map[string][]Strategy{
 		"alpha": {
 			&mockStrategy{
-				name:      "s",
 				available: true,
 				fetchFn: func(ctx context.Context) (FetchResult, error) {
 					return ResultOK(testSnapshot("alpha", "s", 10)), nil
@@ -348,7 +335,6 @@ func TestFetchEnabledProviders_AllEnabledByDefault(t *testing.T) {
 		},
 		"beta": {
 			&mockStrategy{
-				name:      "s",
 				available: true,
 				fetchFn: func(ctx context.Context) (FetchResult, error) {
 					return ResultOK(testSnapshot("beta", "s", 20)), nil
@@ -372,7 +358,6 @@ func TestFetchEnabledProviders_WithProviderConfigDisabled(t *testing.T) {
 	providerMap := map[string][]Strategy{
 		"alpha": {
 			&mockStrategy{
-				name:      "s",
 				available: true,
 				fetchFn: func(ctx context.Context) (FetchResult, error) {
 					return ResultOK(testSnapshot("alpha", "s", 10)), nil
@@ -381,7 +366,6 @@ func TestFetchEnabledProviders_WithProviderConfigDisabled(t *testing.T) {
 		},
 		"beta": {
 			&mockStrategy{
-				name:      "s",
 				available: true,
 				fetchFn: func(ctx context.Context) (FetchResult, error) {
 					t.Error("beta should not be fetched — disabled in config")

--- a/internal/fetch/pipeline_test.go
+++ b/internal/fetch/pipeline_test.go
@@ -12,12 +12,10 @@ import (
 
 // mockStrategy implements Strategy for testing.
 type mockStrategy struct {
-	name      string
 	available bool
 	fetchFn   func(ctx context.Context) (FetchResult, error)
 }
 
-func (m *mockStrategy) Name() string                                   { return m.name }
 func (m *mockStrategy) IsAvailable() bool                              { return m.available }
 func (m *mockStrategy) Fetch(ctx context.Context) (FetchResult, error) { return m.fetchFn(ctx) }
 
@@ -67,9 +65,7 @@ func testSnapshot(provider, source string, utilization int) models.UsageSnapshot
 }
 
 func TestExecutePipeline_ContextCancellation(t *testing.T) {
-	// A strategy that blocks until context is cancelled
 	strategy := &mockStrategy{
-		name:      "blocking",
 		available: true,
 		fetchFn: func(ctx context.Context) (FetchResult, error) {
 			<-ctx.Done()
@@ -78,7 +74,6 @@ func TestExecutePipeline_ContextCancellation(t *testing.T) {
 	}
 
 	ctx, cancel := context.WithCancel(context.Background())
-	// Cancel after a short delay
 	go func() {
 		time.Sleep(50 * time.Millisecond)
 		cancel()
@@ -95,11 +90,9 @@ func TestExecutePipeline_ContextCancellation(t *testing.T) {
 }
 
 func TestExecutePipeline_ContextPassedToStrategy(t *testing.T) {
-	// Verify the context is actually passed to strategy.Fetch
 	var receivedCtx context.Context
 
 	strategy := &mockStrategy{
-		name:      "ctx-checker",
 		available: true,
 		fetchFn: func(ctx context.Context) (FetchResult, error) {
 			receivedCtx = ctx
@@ -123,12 +116,10 @@ func TestExecutePipeline_ContextPassedToStrategy(t *testing.T) {
 	if receivedCtx == nil {
 		t.Fatal("strategy did not receive a context")
 	}
-	// The strategy should receive the parent context (or a derived one)
-	// Verify it's not a bare background context by checking the cancel works
 	cancel()
 	select {
 	case <-receivedCtx.Done():
-		// Expected - context was properly derived from the parent
+		// Expected
 	default:
 		t.Error("strategy received a context that is not derived from the parent")
 	}
@@ -143,7 +134,6 @@ func TestExecutePipeline_SuccessfulFetch(t *testing.T) {
 	}
 
 	strategy := &mockStrategy{
-		name:      "mock",
 		available: true,
 		fetchFn: func(ctx context.Context) (FetchResult, error) {
 			return ResultOK(snap), nil
@@ -159,34 +149,30 @@ func TestExecutePipeline_SuccessfulFetch(t *testing.T) {
 	if outcome.Snapshot == nil {
 		t.Fatal("expected snapshot")
 	}
+	// Source is derived from type name: *fetch.mockStrategy → "mock"
 	if outcome.Source != "mock" {
 		t.Errorf("expected source 'mock', got '%s'", outcome.Source)
 	}
 }
 
 func TestExecutePipeline_FallbackToSecondStrategy(t *testing.T) {
-	snap := models.UsageSnapshot{
-		Provider:  "test",
-		FetchedAt: time.Now().UTC(),
-		Periods:   []models.UsagePeriod{{Name: "daily", Utilization: 10}},
-		Source:    "fallback",
-	}
+	type fallbackStrategy struct{ mockStrategy }
+
+	snap := testSnapshot("test", "fallback", 10)
 
 	strategies := []Strategy{
 		&mockStrategy{
-			name:      "primary",
 			available: true,
 			fetchFn: func(ctx context.Context) (FetchResult, error) {
 				return ResultFail("primary failed"), nil
 			},
 		},
-		&mockStrategy{
-			name:      "fallback",
+		&fallbackStrategy{mockStrategy{
 			available: true,
 			fetchFn: func(ctx context.Context) (FetchResult, error) {
 				return ResultOK(snap), nil
 			},
-		},
+		}},
 	}
 
 	ctx := context.Background()
@@ -198,23 +184,18 @@ func TestExecutePipeline_FallbackToSecondStrategy(t *testing.T) {
 	if outcome.Source != "fallback" {
 		t.Errorf("expected source 'fallback', got '%s'", outcome.Source)
 	}
-	if len(outcome.Attempts) < 1 {
-		t.Error("expected at least 1 attempt recorded")
-	}
 }
 
 func TestExecutePipeline_FatalStopsChain(t *testing.T) {
 	fallbackCalled := false
 	strategies := []Strategy{
 		&mockStrategy{
-			name:      "fatal",
 			available: true,
 			fetchFn: func(ctx context.Context) (FetchResult, error) {
 				return ResultFatal("token expired"), nil
 			},
 		},
 		&mockStrategy{
-			name:      "fallback",
 			available: true,
 			fetchFn: func(ctx context.Context) (FetchResult, error) {
 				fallbackCalled = true
@@ -239,7 +220,6 @@ func TestExecutePipeline_FatalStopsChain(t *testing.T) {
 
 func TestExecutePipeline_UnavailableStrategy(t *testing.T) {
 	strategy := &mockStrategy{
-		name:      "unavailable",
 		available: false,
 		fetchFn: func(ctx context.Context) (FetchResult, error) {
 			t.Fatal("should not call Fetch on unavailable strategy")
@@ -253,11 +233,8 @@ func TestExecutePipeline_UnavailableStrategy(t *testing.T) {
 	if outcome.Success {
 		t.Error("expected failure when only strategy is unavailable")
 	}
-	if len(outcome.Attempts) != 1 {
-		t.Errorf("expected 1 attempt, got %d", len(outcome.Attempts))
-	}
-	if outcome.Attempts[0].Error != "not configured" {
-		t.Errorf("expected 'not configured', got '%s'", outcome.Attempts[0].Error)
+	if outcome.Error != "No strategies available" {
+		t.Errorf("expected 'No strategies available', got '%s'", outcome.Error)
 	}
 }
 
@@ -273,8 +250,6 @@ func TestExecutePipeline_EmptyStrategies(t *testing.T) {
 	}
 }
 
-// Timeout tests
-
 func TestExecutePipeline_Timeout(t *testing.T) {
 	cfg := PipelineConfig{
 		Timeout:               50 * time.Millisecond,
@@ -283,7 +258,6 @@ func TestExecutePipeline_Timeout(t *testing.T) {
 	}
 
 	strategy := &mockStrategy{
-		name:      "slow",
 		available: true,
 		fetchFn: func(ctx context.Context) (FetchResult, error) {
 			time.Sleep(500 * time.Millisecond)
@@ -297,21 +271,14 @@ func TestExecutePipeline_Timeout(t *testing.T) {
 	if outcome.Success {
 		t.Error("expected failure due to timeout")
 	}
-	if len(outcome.Attempts) != 1 {
-		t.Fatalf("expected 1 attempt, got %d", len(outcome.Attempts))
-	}
-	if outcome.Attempts[0].Strategy != "slow" {
-		t.Errorf("attempt strategy = %q, want %q", outcome.Attempts[0].Strategy, "slow")
-	}
-	if outcome.Attempts[0].Error != "Fetch timed out" {
-		t.Errorf("attempt error = %q, want %q", outcome.Attempts[0].Error, "Fetch timed out")
-	}
-	if outcome.Attempts[0].Success {
-		t.Error("timed out attempt should not be marked as success")
+	if outcome.Error != "Fetch timed out" {
+		t.Errorf("error = %q, want 'Fetch timed out'", outcome.Error)
 	}
 }
 
 func TestExecutePipeline_TimeoutFallsBackToNextStrategy(t *testing.T) {
+	type fastStrategy struct{ mockStrategy }
+
 	cfg := PipelineConfig{
 		Timeout:               50 * time.Millisecond,
 		StaleThresholdMinutes: 60,
@@ -321,20 +288,18 @@ func TestExecutePipeline_TimeoutFallsBackToNextStrategy(t *testing.T) {
 	snap := testSnapshot("test", "fast", 42)
 	strategies := []Strategy{
 		&mockStrategy{
-			name:      "slow",
 			available: true,
 			fetchFn: func(ctx context.Context) (FetchResult, error) {
 				time.Sleep(500 * time.Millisecond)
 				return ResultOK(testSnapshot("test", "slow", 0)), nil
 			},
 		},
-		&mockStrategy{
-			name:      "fast",
+		&fastStrategy{mockStrategy{
 			available: true,
 			fetchFn: func(ctx context.Context) (FetchResult, error) {
 				return ResultOK(snap), nil
 			},
-		},
+		}},
 	}
 
 	ctx := context.Background()
@@ -346,19 +311,10 @@ func TestExecutePipeline_TimeoutFallsBackToNextStrategy(t *testing.T) {
 	if outcome.Source != "fast" {
 		t.Errorf("expected source %q, got %q", "fast", outcome.Source)
 	}
-	if len(outcome.Attempts) < 1 {
-		t.Fatal("expected at least 1 recorded attempt")
-	}
-	if outcome.Attempts[0].Error != "Fetch timed out" {
-		t.Errorf("first attempt error = %q, want %q", outcome.Attempts[0].Error, "Fetch timed out")
-	}
 }
-
-// Go error from Fetch()
 
 func TestExecutePipeline_FetchReturnsGoError(t *testing.T) {
 	strategy := &mockStrategy{
-		name:      "erroring",
 		available: true,
 		fetchFn: func(ctx context.Context) (FetchResult, error) {
 			return FetchResult{}, fmt.Errorf("connection refused")
@@ -372,34 +328,28 @@ func TestExecutePipeline_FetchReturnsGoError(t *testing.T) {
 	if outcome.Success {
 		t.Error("expected failure when strategy returns Go error")
 	}
-	if len(outcome.Attempts) != 1 {
-		t.Fatalf("expected 1 attempt, got %d", len(outcome.Attempts))
-	}
-	if outcome.Attempts[0].Error != "connection refused" {
-		t.Errorf("attempt error = %q, want %q", outcome.Attempts[0].Error, "connection refused")
-	}
 	if outcome.Error != "connection refused" {
 		t.Errorf("outcome error = %q, want %q", outcome.Error, "connection refused")
 	}
 }
 
 func TestExecutePipeline_GoErrorFallsBackToNextStrategy(t *testing.T) {
+	type backupStrategy struct{ mockStrategy }
+
 	snap := testSnapshot("test", "backup", 25)
 	strategies := []Strategy{
 		&mockStrategy{
-			name:      "broken",
 			available: true,
 			fetchFn: func(ctx context.Context) (FetchResult, error) {
 				return FetchResult{}, fmt.Errorf("DNS resolution failed")
 			},
 		},
-		&mockStrategy{
-			name:      "backup",
+		&backupStrategy{mockStrategy{
 			available: true,
 			fetchFn: func(ctx context.Context) (FetchResult, error) {
 				return ResultOK(snap), nil
 			},
-		},
+		}},
 	}
 
 	ctx := context.Background()
@@ -414,11 +364,8 @@ func TestExecutePipeline_GoErrorFallsBackToNextStrategy(t *testing.T) {
 	}
 }
 
-// Cache fallback tests
-
 func TestExecutePipeline_CacheFallback(t *testing.T) {
 	cache := newMemCache()
-	// Pre-populate cache with recent data (within default 60min threshold)
 	cache.data["test-provider"] = models.UsageSnapshot{
 		Provider:  "test-provider",
 		FetchedAt: time.Now().Add(-10 * time.Minute).UTC(),
@@ -433,7 +380,6 @@ func TestExecutePipeline_CacheFallback(t *testing.T) {
 	}
 
 	strategy := &mockStrategy{
-		name:      "failing",
 		available: true,
 		fetchFn: func(ctx context.Context) (FetchResult, error) {
 			return ResultFail("API error"), nil
@@ -462,7 +408,6 @@ func TestExecutePipeline_CacheFallback(t *testing.T) {
 
 func TestExecutePipeline_CacheFallbackServesStaleWhenFetchAttempted(t *testing.T) {
 	cache := newMemCache()
-	// Pre-populate cache with old data (beyond default 60min threshold)
 	cache.data["test-provider"] = models.UsageSnapshot{
 		Provider:  "test-provider",
 		FetchedAt: time.Now().Add(-2 * time.Hour).UTC(),
@@ -476,9 +421,7 @@ func TestExecutePipeline_CacheFallbackServesStaleWhenFetchAttempted(t *testing.T
 		Cache:                 cache,
 	}
 
-	// Strategy has credentials (available=true) but the fetch itself fails
 	strategy := &mockStrategy{
-		name:      "failing",
 		available: true,
 		fetchFn: func(ctx context.Context) (FetchResult, error) {
 			return ResultFail("API error"), nil
@@ -488,7 +431,6 @@ func TestExecutePipeline_CacheFallbackServesStaleWhenFetchAttempted(t *testing.T
 	ctx := context.Background()
 	outcome := ExecutePipeline(ctx, "test-provider", []Strategy{strategy}, true, cfg)
 
-	// Should still serve stale cache — credentials exist, API is just down
 	if !outcome.Success {
 		t.Fatalf("expected success from cache fallback when fetch was attempted, got error: %s", outcome.Error)
 	}
@@ -499,7 +441,6 @@ func TestExecutePipeline_CacheFallbackServesStaleWhenFetchAttempted(t *testing.T
 
 func TestExecutePipeline_CacheFallbackRejectsStaleWhenNotConfigured(t *testing.T) {
 	cache := newMemCache()
-	// Pre-populate cache with old data (beyond default 60min threshold)
 	cache.data["test-provider"] = models.UsageSnapshot{
 		Provider:  "test-provider",
 		FetchedAt: time.Now().Add(-2 * time.Hour).UTC(),
@@ -513,9 +454,7 @@ func TestExecutePipeline_CacheFallbackRejectsStaleWhenNotConfigured(t *testing.T
 		Cache:                 cache,
 	}
 
-	// No credentials — strategy is unavailable
 	strategy := &mockStrategy{
-		name:      "unavailable",
 		available: false,
 		fetchFn: func(ctx context.Context) (FetchResult, error) {
 			t.Fatal("should not call Fetch on unavailable strategy")
@@ -526,7 +465,6 @@ func TestExecutePipeline_CacheFallbackRejectsStaleWhenNotConfigured(t *testing.T
 	ctx := context.Background()
 	outcome := ExecutePipeline(ctx, "test-provider", []Strategy{strategy}, true, cfg)
 
-	// Should NOT serve stale cache when no credentials exist
 	if outcome.Success {
 		t.Error("expected failure when cached data is stale and no credentials configured")
 	}
@@ -539,11 +477,10 @@ func TestExecutePipeline_CacheFallbackNoData(t *testing.T) {
 	cfg := PipelineConfig{
 		Timeout:               30 * time.Second,
 		StaleThresholdMinutes: 60,
-		Cache:                 newMemCache(), // empty cache
+		Cache:                 newMemCache(),
 	}
 
 	strategy := &mockStrategy{
-		name:      "failing",
 		available: true,
 		fetchFn: func(ctx context.Context) (FetchResult, error) {
 			return ResultFail("API error"), nil
@@ -566,7 +503,6 @@ func TestExecutePipeline_CacheFallbackNoData(t *testing.T) {
 
 func TestExecutePipeline_CacheDisabled(t *testing.T) {
 	cache := newMemCache()
-	// Pre-populate cache (should NOT be used because useCache=false)
 	cache.data["test-provider"] = models.UsageSnapshot{
 		Provider:  "test-provider",
 		FetchedAt: time.Now().UTC(),
@@ -580,7 +516,6 @@ func TestExecutePipeline_CacheDisabled(t *testing.T) {
 	}
 
 	strategy := &mockStrategy{
-		name:      "failing",
 		available: true,
 		fetchFn: func(ctx context.Context) (FetchResult, error) {
 			return ResultFail("API error"), nil
@@ -598,32 +533,29 @@ func TestExecutePipeline_CacheDisabled(t *testing.T) {
 	}
 }
 
-// Multi-strategy chain
-
 func TestExecutePipeline_ThreeStrategyChain(t *testing.T) {
+	type thirdStrategy struct{ mockStrategy }
+
 	snap := testSnapshot("test", "third", 75)
 	strategies := []Strategy{
 		&mockStrategy{
-			name:      "first",
 			available: true,
 			fetchFn: func(ctx context.Context) (FetchResult, error) {
 				return ResultFail("first failed"), nil
 			},
 		},
 		&mockStrategy{
-			name:      "second",
 			available: true,
 			fetchFn: func(ctx context.Context) (FetchResult, error) {
 				return ResultFail("second failed"), nil
 			},
 		},
-		&mockStrategy{
-			name:      "third",
+		&thirdStrategy{mockStrategy{
 			available: true,
 			fetchFn: func(ctx context.Context) (FetchResult, error) {
 				return ResultOK(snap), nil
 			},
-		},
+		}},
 	}
 
 	ctx := context.Background()
@@ -636,36 +568,17 @@ func TestExecutePipeline_ThreeStrategyChain(t *testing.T) {
 	if outcome.Source != "third" {
 		t.Errorf("expected source %q, got %q", "third", outcome.Source)
 	}
-	// Two failed attempts should be recorded (third succeeded, not in Attempts)
-	if len(outcome.Attempts) != 2 {
-		t.Errorf("expected 2 recorded attempts, got %d", len(outcome.Attempts))
-	}
-	if len(outcome.Attempts) >= 1 && outcome.Attempts[0].Strategy != "first" {
-		t.Errorf("first attempt strategy = %q, want %q", outcome.Attempts[0].Strategy, "first")
-	}
-	if len(outcome.Attempts) >= 2 && outcome.Attempts[1].Strategy != "second" {
-		t.Errorf("second attempt strategy = %q, want %q", outcome.Attempts[1].Strategy, "second")
-	}
 }
 
-// Attempt tracking
-
-func TestExecutePipeline_AttemptsRecordErrors(t *testing.T) {
+func TestExecutePipeline_LastErrorPropagated(t *testing.T) {
 	strategies := []Strategy{
 		&mockStrategy{
-			name:      "unavail",
-			available: false,
-			fetchFn:   func(ctx context.Context) (FetchResult, error) { return FetchResult{}, nil },
-		},
-		&mockStrategy{
-			name:      "failing",
 			available: true,
 			fetchFn: func(ctx context.Context) (FetchResult, error) {
 				return ResultFail("auth expired"), nil
 			},
 		},
 		&mockStrategy{
-			name:      "erroring",
 			available: true,
 			fetchFn: func(ctx context.Context) (FetchResult, error) {
 				return FetchResult{}, fmt.Errorf("network timeout")
@@ -680,63 +593,10 @@ func TestExecutePipeline_AttemptsRecordErrors(t *testing.T) {
 	if outcome.Success {
 		t.Error("expected failure")
 	}
-	if len(outcome.Attempts) != 3 {
-		t.Fatalf("expected 3 attempts, got %d", len(outcome.Attempts))
-	}
-
-	// Attempt 0: unavailable
-	if outcome.Attempts[0].Strategy != "unavail" {
-		t.Errorf("attempt[0] strategy = %q, want %q", outcome.Attempts[0].Strategy, "unavail")
-	}
-	if outcome.Attempts[0].Error != "not configured" {
-		t.Errorf("attempt[0] error = %q, want %q", outcome.Attempts[0].Error, "not configured")
-	}
-
-	// Attempt 1: ResultFail
-	if outcome.Attempts[1].Strategy != "failing" {
-		t.Errorf("attempt[1] strategy = %q, want %q", outcome.Attempts[1].Strategy, "failing")
-	}
-	if outcome.Attempts[1].Error != "auth expired" {
-		t.Errorf("attempt[1] error = %q, want %q", outcome.Attempts[1].Error, "auth expired")
-	}
-
-	// Attempt 2: Go error
-	if outcome.Attempts[2].Strategy != "erroring" {
-		t.Errorf("attempt[2] strategy = %q, want %q", outcome.Attempts[2].Strategy, "erroring")
-	}
-	if outcome.Attempts[2].Error != "network timeout" {
-		t.Errorf("attempt[2] error = %q, want %q", outcome.Attempts[2].Error, "network timeout")
-	}
-
-	// Final error should be the last attempt's error
 	if outcome.Error != "network timeout" {
-		t.Errorf("outcome error = %q, want %q (last attempt)", outcome.Error, "network timeout")
+		t.Errorf("outcome error = %q, want %q (last error)", outcome.Error, "network timeout")
 	}
 }
-
-func TestExecutePipeline_AttemptsDurationTracked(t *testing.T) {
-	strategy := &mockStrategy{
-		name:      "sleeper",
-		available: true,
-		fetchFn: func(ctx context.Context) (FetchResult, error) {
-			time.Sleep(10 * time.Millisecond)
-			return ResultFail("intentional failure"), nil
-		},
-	}
-
-	ctx := context.Background()
-	cfg := defaultTestPipelineCfg()
-	outcome := ExecutePipeline(ctx, "test-provider", []Strategy{strategy}, false, cfg)
-
-	if len(outcome.Attempts) != 1 {
-		t.Fatalf("expected 1 attempt, got %d", len(outcome.Attempts))
-	}
-	if outcome.Attempts[0].DurationMs < 1 {
-		t.Errorf("DurationMs = %d, expected > 0 for a strategy that slept", outcome.Attempts[0].DurationMs)
-	}
-}
-
-// Success behavior
 
 func TestExecutePipeline_SuccessCachesResult(t *testing.T) {
 	cache := newMemCache()
@@ -748,7 +608,6 @@ func TestExecutePipeline_SuccessCachesResult(t *testing.T) {
 
 	snap := testSnapshot("cache-test-provider", "mock", 60)
 	strategy := &mockStrategy{
-		name:      "mock",
 		available: true,
 		fetchFn: func(ctx context.Context) (FetchResult, error) {
 			return ResultOK(snap), nil
@@ -762,7 +621,6 @@ func TestExecutePipeline_SuccessCachesResult(t *testing.T) {
 		t.Fatalf("expected success, got error: %s", outcome.Error)
 	}
 
-	// Verify the snapshot was cached via the injected cache
 	cached := cache.Load("cache-test-provider")
 	if cached == nil {
 		t.Fatal("expected snapshot to be cached after successful fetch")
@@ -776,18 +634,16 @@ func TestExecutePipeline_SuccessStopsChain(t *testing.T) {
 	secondCalled := false
 	strategies := []Strategy{
 		&mockStrategy{
-			name:      "fast-success",
 			available: true,
 			fetchFn: func(ctx context.Context) (FetchResult, error) {
-				return ResultOK(testSnapshot("test", "fast-success", 20)), nil
+				return ResultOK(testSnapshot("test", "first", 20)), nil
 			},
 		},
 		&mockStrategy{
-			name:      "never-reached",
 			available: true,
 			fetchFn: func(ctx context.Context) (FetchResult, error) {
 				secondCalled = true
-				return ResultOK(testSnapshot("test", "never-reached", 0)), nil
+				return ResultOK(testSnapshot("test", "second", 0)), nil
 			},
 		},
 	}
@@ -799,15 +655,10 @@ func TestExecutePipeline_SuccessStopsChain(t *testing.T) {
 	if !outcome.Success {
 		t.Fatalf("expected success, got error: %s", outcome.Error)
 	}
-	if outcome.Source != "fast-success" {
-		t.Errorf("expected source %q, got %q", "fast-success", outcome.Source)
-	}
 	if secondCalled {
 		t.Error("second strategy should not be called when first succeeds")
 	}
 }
-
-// ProviderID propagation
 
 func TestExecutePipeline_ProviderIDInOutcome(t *testing.T) {
 	tests := []struct {
@@ -824,7 +675,6 @@ func TestExecutePipeline_ProviderIDInOutcome(t *testing.T) {
 			var strategy *mockStrategy
 			if tt.success {
 				strategy = &mockStrategy{
-					name:      "mock",
 					available: true,
 					fetchFn: func(ctx context.Context) (FetchResult, error) {
 						return ResultOK(testSnapshot(tt.providerID, "mock", 50)), nil
@@ -832,7 +682,6 @@ func TestExecutePipeline_ProviderIDInOutcome(t *testing.T) {
 				}
 			} else {
 				strategy = &mockStrategy{
-					name:      "mock",
 					available: true,
 					fetchFn: func(ctx context.Context) (FetchResult, error) {
 						return ResultFail("error"), nil
@@ -851,13 +700,10 @@ func TestExecutePipeline_ProviderIDInOutcome(t *testing.T) {
 	}
 }
 
-// Mixed unavailable and available strategies
-
 func TestExecutePipeline_SkipsUnavailableTriesAvailable(t *testing.T) {
-	snap := testSnapshot("test", "available", 55)
+	snap := testSnapshot("test", "mock", 55)
 	strategies := []Strategy{
 		&mockStrategy{
-			name:      "unavailable-1",
 			available: false,
 			fetchFn: func(ctx context.Context) (FetchResult, error) {
 				t.Fatal("should not call Fetch on unavailable strategy")
@@ -865,7 +711,6 @@ func TestExecutePipeline_SkipsUnavailableTriesAvailable(t *testing.T) {
 			},
 		},
 		&mockStrategy{
-			name:      "unavailable-2",
 			available: false,
 			fetchFn: func(ctx context.Context) (FetchResult, error) {
 				t.Fatal("should not call Fetch on unavailable strategy")
@@ -873,7 +718,6 @@ func TestExecutePipeline_SkipsUnavailableTriesAvailable(t *testing.T) {
 			},
 		},
 		&mockStrategy{
-			name:      "available",
 			available: true,
 			fetchFn: func(ctx context.Context) (FetchResult, error) {
 				return ResultOK(snap), nil
@@ -888,18 +732,10 @@ func TestExecutePipeline_SkipsUnavailableTriesAvailable(t *testing.T) {
 	if !outcome.Success {
 		t.Fatalf("expected success, got error: %s", outcome.Error)
 	}
-	if outcome.Source != "available" {
-		t.Errorf("expected source %q, got %q", "available", outcome.Source)
-	}
-	// Two unavailable attempts should be recorded
-	if len(outcome.Attempts) != 2 {
-		t.Errorf("expected 2 attempts (for unavailable strategies), got %d", len(outcome.Attempts))
-	}
 }
 
 func TestExecutePipeline_CacheFallbackServesFreshWhenNotConfigured(t *testing.T) {
 	cache := newMemCache()
-	// Recent snapshot (10 minutes ago)
 	cache.data["test-provider"] = models.UsageSnapshot{
 		Provider:  "test-provider",
 		FetchedAt: time.Now().Add(-10 * time.Minute).UTC(),
@@ -912,16 +748,13 @@ func TestExecutePipeline_CacheFallbackServesFreshWhenNotConfigured(t *testing.T)
 		Cache:                 cache,
 	}
 
-	// Unconfigured provider — strategy not available
 	strategy := &mockStrategy{
-		name:      "unavailable",
 		available: false,
 	}
 
 	ctx := context.Background()
 	outcome := ExecutePipeline(ctx, "test-provider", []Strategy{strategy}, true, cfg)
 
-	// Should serve fresh cache even when unconfigured
 	if !outcome.Success {
 		t.Fatalf("expected success from fresh cache, got error: %s", outcome.Error)
 	}
@@ -938,7 +771,6 @@ func TestExecutePipeline_NilCacheNoFallback(t *testing.T) {
 	}
 
 	strategy := &mockStrategy{
-		name:      "failing",
 		available: true,
 		fetchFn: func(ctx context.Context) (FetchResult, error) {
 			return ResultFail("API error"), nil
@@ -948,7 +780,6 @@ func TestExecutePipeline_NilCacheNoFallback(t *testing.T) {
 	ctx := context.Background()
 	outcome := ExecutePipeline(ctx, "test-provider", []Strategy{strategy}, true, cfg)
 
-	// Should not panic with nil cache, just skip caching
 	if outcome.Success {
 		t.Error("expected failure — nil cache means no fallback")
 	}

--- a/internal/fetch/strategy_test.go
+++ b/internal/fetch/strategy_test.go
@@ -1,0 +1,50 @@
+package fetch
+
+import (
+	"context"
+	"testing"
+)
+
+type OAuthStrategy struct{}
+
+func (s *OAuthStrategy) IsAvailable() bool                              { return false }
+func (s *OAuthStrategy) Fetch(ctx context.Context) (FetchResult, error) { return FetchResult{}, nil }
+
+type APIKeyStrategy struct{}
+
+func (s *APIKeyStrategy) IsAvailable() bool                              { return false }
+func (s *APIKeyStrategy) Fetch(ctx context.Context) (FetchResult, error) { return FetchResult{}, nil }
+
+type DeviceFlowStrategy struct{}
+
+func (s *DeviceFlowStrategy) IsAvailable() bool { return false }
+func (s *DeviceFlowStrategy) Fetch(ctx context.Context) (FetchResult, error) {
+	return FetchResult{}, nil
+}
+
+type WebStrategy struct{}
+
+func (s *WebStrategy) IsAvailable() bool                              { return false }
+func (s *WebStrategy) Fetch(ctx context.Context) (FetchResult, error) { return FetchResult{}, nil }
+
+func TestStrategyName(t *testing.T) {
+	tests := []struct {
+		name     string
+		strategy Strategy
+		want     string
+	}{
+		{"OAuthStrategy", &OAuthStrategy{}, "oauth"},
+		{"APIKeyStrategy", &APIKeyStrategy{}, "apikey"},
+		{"DeviceFlowStrategy", &DeviceFlowStrategy{}, "deviceflow"},
+		{"WebStrategy", &WebStrategy{}, "web"},
+		{"mockStrategy", &mockStrategy{}, "mock"},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := StrategyName(tt.strategy)
+			if got != tt.want {
+				t.Errorf("StrategyName() = %q, want %q", got, tt.want)
+			}
+		})
+	}
+}

--- a/internal/provider/amp/amp.go
+++ b/internal/provider/amp/amp.go
@@ -69,8 +69,6 @@ type CLISecretsStrategy struct {
 	HTTPTimeout float64
 }
 
-func (s *CLISecretsStrategy) Name() string { return "provider_cli" }
-
 func (s *CLISecretsStrategy) IsAvailable() bool {
 	if !provider.ExternalCredentialReuseEnabled() {
 		return false
@@ -84,15 +82,13 @@ func (s *CLISecretsStrategy) Fetch(ctx context.Context) (fetch.FetchResult, erro
 	if !ok {
 		return fetch.ResultFail("No Amp CLI credentials found in ~/.local/share/amp/secrets.json"), nil
 	}
-	return fetchBalance(ctx, token, s.Name(), s.HTTPTimeout)
+	return fetchBalance(ctx, token, "provider_cli", s.HTTPTimeout)
 }
 
 // APIKeyStrategy supports manual key entry or AMP_API_KEY.
 type APIKeyStrategy struct {
 	HTTPTimeout float64
 }
-
-func (s *APIKeyStrategy) Name() string { return "api_key" }
 
 func (s *APIKeyStrategy) IsAvailable() bool {
 	return s.loadToken() != ""
@@ -103,7 +99,7 @@ func (s *APIKeyStrategy) Fetch(ctx context.Context) (fetch.FetchResult, error) {
 	if token == "" {
 		return fetch.ResultFail("No API key found. Set AMP_API_KEY or use 'vibeusage key amp set'"), nil
 	}
-	return fetchBalance(ctx, token, s.Name(), s.HTTPTimeout)
+	return fetchBalance(ctx, token, "api_key", s.HTTPTimeout)
 }
 
 func (s *APIKeyStrategy) loadToken() string {

--- a/internal/provider/antigravity/antigravity.go
+++ b/internal/provider/antigravity/antigravity.go
@@ -76,8 +76,6 @@ type OAuthStrategy struct {
 	vscdb       *vscdbResult // cached vscdb data (credentials + subscription)
 }
 
-func (s *OAuthStrategy) Name() string { return "oauth" }
-
 func (s *OAuthStrategy) IsAvailable() bool {
 	for _, p := range s.credentialPaths() {
 		if _, err := os.Stat(p); err == nil {

--- a/internal/provider/antigravity/antigravity_test.go
+++ b/internal/provider/antigravity/antigravity_test.go
@@ -29,9 +29,6 @@ func TestFetchStrategies(t *testing.T) {
 	if len(strategies) != 1 {
 		t.Fatalf("len(strategies) = %d, want 1", len(strategies))
 	}
-	if strategies[0].Name() != "oauth" {
-		t.Errorf("strategy name = %q, want %q", strategies[0].Name(), "oauth")
-	}
 }
 
 func TestOAuthStrategy_CredentialPaths_RespectsReuseProviderCredentials(t *testing.T) {

--- a/internal/provider/claude/claude.go
+++ b/internal/provider/claude/claude.go
@@ -112,8 +112,6 @@ type OAuthStrategy struct {
 	HTTPTimeout float64
 }
 
-func (s *OAuthStrategy) Name() string { return "oauth" }
-
 func (s *OAuthStrategy) IsAvailable() bool {
 	for _, p := range s.credentialPaths() {
 		if _, err := os.Stat(p); err == nil {
@@ -454,8 +452,6 @@ type APIKeyStrategy struct {
 	HTTPTimeout float64
 }
 
-func (s *APIKeyStrategy) Name() string { return "apikey" }
-
 func (s *APIKeyStrategy) IsAvailable() bool {
 	return s.loadAPIKey() != ""
 }
@@ -496,8 +492,6 @@ func (s *APIKeyStrategy) loadAPIKey() string {
 type WebStrategy struct {
 	HTTPTimeout float64
 }
-
-func (s *WebStrategy) Name() string { return "web" }
 
 func (s *WebStrategy) IsAvailable() bool {
 	return s.loadSessionKey() != ""

--- a/internal/provider/codex/codex.go
+++ b/internal/provider/codex/codex.go
@@ -89,8 +89,6 @@ type OAuthStrategy struct {
 	HTTPTimeout float64
 }
 
-func (s *OAuthStrategy) Name() string { return "oauth" }
-
 func (s *OAuthStrategy) IsAvailable() bool {
 	for _, p := range s.credentialPaths() {
 		if _, err := os.Stat(p); err == nil {

--- a/internal/provider/copilot/copilot.go
+++ b/internal/provider/copilot/copilot.go
@@ -64,8 +64,6 @@ type DeviceFlowStrategy struct {
 	HTTPTimeout float64
 }
 
-func (s *DeviceFlowStrategy) Name() string { return "device_flow" }
-
 func (s *DeviceFlowStrategy) IsAvailable() bool {
 	path := config.CredentialPath("copilot", "oauth")
 	_, err := os.Stat(path)

--- a/internal/provider/cursor/cursor.go
+++ b/internal/provider/cursor/cursor.go
@@ -72,8 +72,6 @@ type WebStrategy struct {
 	HTTPTimeout float64
 }
 
-func (s *WebStrategy) Name() string { return "web" }
-
 func (s *WebStrategy) IsAvailable() bool {
 	path := config.CredentialPath("cursor", "session")
 	_, err := os.Stat(path)

--- a/internal/provider/gemini/gemini.go
+++ b/internal/provider/gemini/gemini.go
@@ -90,8 +90,6 @@ type OAuthStrategy struct {
 	HTTPTimeout float64
 }
 
-func (s *OAuthStrategy) Name() string { return "oauth" }
-
 func (s *OAuthStrategy) IsAvailable() bool {
 	for _, p := range s.credentialPaths() {
 		if _, err := os.Stat(p); err == nil {
@@ -253,8 +251,6 @@ func (s *OAuthStrategy) parseTypedQuotaResponse(quotaResp QuotaResponse, codeAss
 type APIKeyStrategy struct {
 	HTTPTimeout float64
 }
-
-func (s *APIKeyStrategy) Name() string { return "api_key" }
 
 func (s *APIKeyStrategy) IsAvailable() bool {
 	if os.Getenv("GEMINI_API_KEY") != "" {

--- a/internal/provider/kimicode/kimicode.go
+++ b/internal/provider/kimicode/kimicode.go
@@ -98,8 +98,6 @@ type DeviceFlowStrategy struct {
 	HTTPTimeout float64
 }
 
-func (s *DeviceFlowStrategy) Name() string { return "device_flow" }
-
 func (s *DeviceFlowStrategy) IsAvailable() bool {
 	for _, p := range s.credentialPaths() {
 		if _, err := os.Stat(p); err == nil {
@@ -205,8 +203,6 @@ func (s *DeviceFlowStrategy) refreshToken(ctx context.Context, creds *OAuthCrede
 type APIKeyStrategy struct {
 	HTTPTimeout float64
 }
-
-func (s *APIKeyStrategy) Name() string { return "api_key" }
 
 func (s *APIKeyStrategy) IsAvailable() bool {
 	return s.loadAPIKey() != ""

--- a/internal/provider/kimicode/kimicode_test.go
+++ b/internal/provider/kimicode/kimicode_test.go
@@ -11,13 +11,6 @@ import (
 	"github.com/joshuadavidthomas/vibeusage/internal/testenv"
 )
 
-func TestDeviceFlowStrategy_Name(t *testing.T) {
-	s := &DeviceFlowStrategy{}
-	if s.Name() != "device_flow" {
-		t.Errorf("Name() = %q, want %q", s.Name(), "device_flow")
-	}
-}
-
 func TestDeviceFlowStrategy_CredentialPaths_RespectsReuseProviderCredentials(t *testing.T) {
 	dir := t.TempDir()
 	testenv.ApplyVibeusage(t.Setenv, dir)
@@ -45,13 +38,6 @@ func TestDeviceFlowStrategy_CredentialPaths_RespectsReuseProviderCredentials(t *
 	}
 	if s.IsAvailable() {
 		t.Fatal("IsAvailable() = true, want false when only provider CLI credentials exist")
-	}
-}
-
-func TestAPIKeyStrategy_Name(t *testing.T) {
-	s := &APIKeyStrategy{}
-	if s.Name() != "api_key" {
-		t.Errorf("Name() = %q, want %q", s.Name(), "api_key")
 	}
 }
 

--- a/internal/provider/minimax/minimax.go
+++ b/internal/provider/minimax/minimax.go
@@ -70,8 +70,6 @@ type APIKeyStrategy struct {
 	HTTPTimeout float64
 }
 
-func (s *APIKeyStrategy) Name() string { return "api_key" }
-
 func (s *APIKeyStrategy) IsAvailable() bool {
 	return s.loadToken() != ""
 }

--- a/internal/provider/minimax/minimax_test.go
+++ b/internal/provider/minimax/minimax_test.go
@@ -7,13 +7,6 @@ import (
 	"github.com/joshuadavidthomas/vibeusage/internal/models"
 )
 
-func TestAPIKeyStrategy_Name(t *testing.T) {
-	s := &APIKeyStrategy{}
-	if s.Name() != "api_key" {
-		t.Errorf("Name() = %q, want %q", s.Name(), "api_key")
-	}
-}
-
 func TestAPIKeyStrategy_IsAvailable_EnvVar(t *testing.T) {
 	t.Setenv("MINIMAX_API_KEY", "sk-cp-test")
 	s := &APIKeyStrategy{}

--- a/internal/provider/openrouter/openrouter.go
+++ b/internal/provider/openrouter/openrouter.go
@@ -62,8 +62,6 @@ type APIKeyStrategy struct {
 	HTTPTimeout float64
 }
 
-func (s *APIKeyStrategy) Name() string { return "api_key" }
-
 func (s *APIKeyStrategy) IsAvailable() bool {
 	return s.loadToken() != ""
 }

--- a/internal/provider/registry_test.go
+++ b/internal/provider/registry_test.go
@@ -43,7 +43,6 @@ type stubStrategy struct {
 	available bool
 }
 
-func (s *stubStrategy) Name() string      { return "stub" }
 func (s *stubStrategy) IsAvailable() bool { return s.available }
 func (s *stubStrategy) Fetch(_ context.Context) (fetch.FetchResult, error) {
 	return fetch.FetchResult{}, nil

--- a/internal/provider/warp/warp.go
+++ b/internal/provider/warp/warp.go
@@ -62,8 +62,6 @@ type APIKeyStrategy struct {
 	HTTPTimeout float64
 }
 
-func (s *APIKeyStrategy) Name() string { return "api_key" }
-
 func (s *APIKeyStrategy) IsAvailable() bool {
 	return s.loadToken() != ""
 }

--- a/internal/provider/zai/zai.go
+++ b/internal/provider/zai/zai.go
@@ -68,8 +68,6 @@ type APIKeyStrategy struct {
 	HTTPTimeout float64
 }
 
-func (s *APIKeyStrategy) Name() string { return "api_key" }
-
 func (s *APIKeyStrategy) IsAvailable() bool {
 	return s.loadToken() != ""
 }

--- a/internal/provider/zai/zai_test.go
+++ b/internal/provider/zai/zai_test.go
@@ -7,13 +7,6 @@ import (
 	"github.com/joshuadavidthomas/vibeusage/internal/models"
 )
 
-func TestAPIKeyStrategy_Name(t *testing.T) {
-	s := &APIKeyStrategy{}
-	if s.Name() != "api_key" {
-		t.Errorf("Name() = %q, want %q", s.Name(), "api_key")
-	}
-}
-
 func TestAPIKeyStrategy_IsAvailable_EnvVar(t *testing.T) {
 	t.Setenv("ZAI_API_KEY", "test-key")
 	s := &APIKeyStrategy{}


### PR DESCRIPTION
## Problem

Every strategy had a `Name() string` method that returned a static string literal (`"oauth"`, `"api_key"`, `"web"`, etc.) — 18 identical one-liners across all providers.

`Name()` populated two things:
- `FetchOutcome.Source` — used in debug logs and JSON output (useful)
- `FetchAttempt.Strategy` — built by the pipeline, **never read by any production code**

## Changes

- **Remove `Name()` from the `Strategy` interface** — 18 method implementations deleted
- **Remove `FetchAttempt` type and `Attempts` field from `FetchOutcome`** — dead tracking data
- **Derive `FetchOutcome.Source` from the struct type name** via `reflect` (e.g. `*claude.OAuthStrategy` → `"oauth"`)
- **Simplify pipeline** — tracks `anyAttempted`/`lastErr` inline instead of building an attempts slice

The `Strategy` interface is now just:
```go
type Strategy interface {
    IsAvailable() bool
    Fetch(ctx context.Context) (FetchResult, error)
}
```

Pipeline behavior is unchanged: strategies tried in order, unavailable skipped, cache fallback policy still distinguishes 'no credentials' from 'API down'.

**Net: -238 lines**