### PR TITLE
Eliminate snapshot JSON shadow types

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,7 @@ and this project attempts to adhere to [Semantic Versioning](https://semver.org/
 
 ### Changed
 
+- **Breaking:** `--json` output now serializes usage snapshots directly from the model types. Removed `remaining`, `cached` fields; added `fetched_at`, `is_enabled`, `source` fields. `resets_at` uses Go's default time format. Identity fields with empty values are now omitted.
 - Updated `vibeusage auth claude` to accept either claude.ai `sessionKey` credentials (`sk-ant-sid01-...`) or Anthropic API keys (`sk-ant-api...` / `sk-ant-admin-...`).
 - Reordered Claude fetch strategy flow to prefer OAuth first and keep web session usage as the last-resort fallback.
 

--- a/internal/display/json.go
+++ b/internal/display/json.go
@@ -16,7 +16,9 @@ func OutputJSON(w io.Writer, data any) error {
 	return enc.Encode(data)
 }
 
-// SnapshotToJSON converts a snapshot to a typed JSON-serializable struct.
+// SnapshotToJSON converts a fetch outcome to a JSON-serializable value.
+// Returns the UsageSnapshot directly for successes (with disabled overage
+// stripped), or a SnapshotErrorJSON for failures.
 func SnapshotToJSON(outcome fetch.FetchOutcome) any {
 	if !outcome.Success || outcome.Snapshot == nil {
 		return SnapshotErrorJSON{
@@ -26,61 +28,28 @@ func SnapshotToJSON(outcome fetch.FetchOutcome) any {
 			},
 		}
 	}
-
-	snap := outcome.Snapshot
-	data := SnapshotJSON{
-		Provider: snap.Provider,
-		Source:   outcome.Source,
-		Cached:   outcome.Cached,
+	snap := *outcome.Snapshot
+	if snap.Overage != nil && !snap.Overage.IsEnabled {
+		snap.Overage = nil
 	}
-
-	if snap.Identity != nil {
-		data.Identity = &IdentityJSON{
-			Email:        snap.Identity.Email,
-			Organization: snap.Identity.Organization,
-			Plan:         snap.Identity.Plan,
-		}
-	}
-
-	var periods []PeriodJSON
-	for _, p := range snap.Periods {
-		pd := PeriodJSON{
-			Name:        p.Name,
-			Utilization: p.Utilization,
-			Remaining:   p.Remaining(),
-			PeriodType:  string(p.PeriodType),
-			Model:       p.Model,
-		}
-		if p.ResetsAt != nil {
-			pd.ResetsAt = p.ResetsAt.Format(time.RFC3339)
-		}
-		periods = append(periods, pd)
-	}
-	data.Periods = periods
-
-	if snap.Overage != nil && snap.Overage.IsEnabled {
-		data.Overage = &OverageJSON{
-			Used:      snap.Overage.Used,
-			Limit:     snap.Overage.Limit,
-			Remaining: snap.Overage.Remaining(),
-			Currency:  snap.Overage.Currency,
-		}
-	}
-
-	return data
+	return snap
 }
 
 // OutputMultiProviderJSON outputs all outcomes as JSON.
 func OutputMultiProviderJSON(w io.Writer, outcomes map[string]fetch.FetchOutcome) error {
-	data := MultiProviderJSON{
-		Providers: make(map[string]SnapshotJSON),
+	data := multiProviderJSON{
+		Providers: make(map[string]models.UsageSnapshot),
 		Errors:    make(map[string]string),
 		FetchedAt: time.Now().Format(time.RFC3339),
 	}
 
 	for pid, outcome := range outcomes {
 		if outcome.Success && outcome.Snapshot != nil {
-			data.Providers[pid] = SnapshotToJSON(outcome).(SnapshotJSON)
+			snap := *outcome.Snapshot
+			if snap.Overage != nil && !snap.Overage.IsEnabled {
+				snap.Overage = nil
+			}
+			data.Providers[pid] = snap
 		} else {
 			errMsg := outcome.Error
 			if errMsg == "" {

--- a/internal/display/json_test.go
+++ b/internal/display/json_test.go
@@ -176,29 +176,21 @@ func TestSnapshotToJSON_SuccessBaseFields(t *testing.T) {
 	outcome := fetch.FetchOutcome{
 		ProviderID: "claude",
 		Success:    true,
-		Source:     "oauth",
-		Cached:     false,
 		Snapshot: &models.UsageSnapshot{
 			Provider:  "claude",
 			FetchedAt: now,
 			Periods:   []models.UsagePeriod{},
+			Source:    "oauth",
 		},
 	}
 
-	result := SnapshotToJSON(outcome)
-	snap, ok := result.(SnapshotJSON)
-	if !ok {
-		t.Fatalf("expected SnapshotJSON, got %T", result)
-	}
+	data := marshalSnapshotToJSON(t, outcome)
 
-	if snap.Provider != "claude" {
-		t.Errorf("provider = %q, want %q", snap.Provider, "claude")
+	if data["provider"] != "claude" {
+		t.Errorf("provider = %q, want %q", data["provider"], "claude")
 	}
-	if snap.Source != "oauth" {
-		t.Errorf("source = %q, want %q", snap.Source, "oauth")
-	}
-	if snap.Cached {
-		t.Error("cached should be false")
+	if data["source"] != "oauth" {
+		t.Errorf("source = %q, want %q", data["source"], "oauth")
 	}
 }
 
@@ -216,23 +208,20 @@ func TestSnapshotToJSON_WithIdentity(t *testing.T) {
 		},
 	}
 
-	result := SnapshotToJSON(outcome)
-	snap, ok := result.(SnapshotJSON)
-	if !ok {
-		t.Fatalf("expected SnapshotJSON, got %T", result)
-	}
+	data := marshalSnapshotToJSON(t, outcome)
 
-	if snap.Identity == nil {
+	identity, ok := data["identity"].(map[string]any)
+	if !ok {
 		t.Fatal("expected identity to be set")
 	}
-	if snap.Identity.Email != "user@example.com" {
-		t.Errorf("identity.email = %q, want %q", snap.Identity.Email, "user@example.com")
+	if identity["email"] != "user@example.com" {
+		t.Errorf("identity.email = %q, want %q", identity["email"], "user@example.com")
 	}
-	if snap.Identity.Organization != "Acme Corp" {
-		t.Errorf("identity.organization = %q, want %q", snap.Identity.Organization, "Acme Corp")
+	if identity["organization"] != "Acme Corp" {
+		t.Errorf("identity.organization = %q, want %q", identity["organization"], "Acme Corp")
 	}
-	if snap.Identity.Plan != "pro" {
-		t.Errorf("identity.plan = %q, want %q", snap.Identity.Plan, "pro")
+	if identity["plan"] != "pro" {
+		t.Errorf("identity.plan = %q, want %q", identity["plan"], "pro")
 	}
 }
 
@@ -246,13 +235,9 @@ func TestSnapshotToJSON_NoIdentity(t *testing.T) {
 		},
 	}
 
-	result := SnapshotToJSON(outcome)
-	snap, ok := result.(SnapshotJSON)
-	if !ok {
-		t.Fatalf("expected SnapshotJSON, got %T", result)
-	}
+	data := marshalSnapshotToJSON(t, outcome)
 
-	if snap.Identity != nil {
+	if data["identity"] != nil {
 		t.Error("identity should be nil when not provided")
 	}
 }
@@ -281,39 +266,33 @@ func TestSnapshotToJSON_Periods(t *testing.T) {
 		},
 	}
 
-	result := SnapshotToJSON(outcome)
-	snap, ok := result.(SnapshotJSON)
+	data := marshalSnapshotToJSON(t, outcome)
+
+	periods, ok := data["periods"].([]any)
 	if !ok {
-		t.Fatalf("expected SnapshotJSON, got %T", result)
+		t.Fatal("expected periods to be an array")
+	}
+	if len(periods) != 2 {
+		t.Fatalf("expected 2 periods, got %d", len(periods))
 	}
 
-	if len(snap.Periods) != 2 {
-		t.Fatalf("expected 2 periods, got %d", len(snap.Periods))
+	p0 := periods[0].(map[string]any)
+	if p0["name"] != "Monthly" {
+		t.Errorf("period[0].name = %q, want %q", p0["name"], "Monthly")
 	}
-
-	p0 := snap.Periods[0]
-	if p0.Name != "Monthly" {
-		t.Errorf("period[0].name = %q, want %q", p0.Name, "Monthly")
+	if p0["utilization"] != float64(75) {
+		t.Errorf("period[0].utilization = %v, want 75", p0["utilization"])
 	}
-	if p0.Utilization != 75 {
-		t.Errorf("period[0].utilization = %d, want 75", p0.Utilization)
+	if p0["period_type"] != "monthly" {
+		t.Errorf("period[0].period_type = %q, want %q", p0["period_type"], "monthly")
 	}
-	if p0.Remaining != 25 {
-		t.Errorf("period[0].remaining = %d, want 25", p0.Remaining)
-	}
-	if p0.PeriodType != "monthly" {
-		t.Errorf("period[0].period_type = %q, want %q", p0.PeriodType, "monthly")
-	}
-	if p0.ResetsAt == "" {
+	if _, ok := p0["resets_at"]; !ok {
 		t.Error("period[0] should have resets_at")
 	}
 
-	p1 := snap.Periods[1]
-	if p1.Model != "claude-3-sonnet" {
-		t.Errorf("period[1].model = %q, want %q", p1.Model, "claude-3-sonnet")
-	}
-	if p1.ResetsAt != "" {
-		t.Error("period[1] should not have resets_at when nil")
+	p1 := periods[1].(map[string]any)
+	if p1["model"] != "claude-3-sonnet" {
+		t.Errorf("period[1].model = %q, want %q", p1["model"], "claude-3-sonnet")
 	}
 }
 
@@ -332,26 +311,20 @@ func TestSnapshotToJSON_WithOverage(t *testing.T) {
 		},
 	}
 
-	result := SnapshotToJSON(outcome)
-	snap, ok := result.(SnapshotJSON)
-	if !ok {
-		t.Fatalf("expected SnapshotJSON, got %T", result)
-	}
+	data := marshalSnapshotToJSON(t, outcome)
 
-	if snap.Overage == nil {
+	overage, ok := data["overage"].(map[string]any)
+	if !ok {
 		t.Fatal("expected overage to be set")
 	}
-	if snap.Overage.Used != 15.50 {
-		t.Errorf("overage.used = %v, want 15.50", snap.Overage.Used)
+	if overage["used"] != 15.50 {
+		t.Errorf("overage.used = %v, want 15.50", overage["used"])
 	}
-	if snap.Overage.Limit != 100.00 {
-		t.Errorf("overage.limit = %v, want 100.00", snap.Overage.Limit)
+	if overage["limit"] != 100.00 {
+		t.Errorf("overage.limit = %v, want 100.00", overage["limit"])
 	}
-	if snap.Overage.Remaining != 84.50 {
-		t.Errorf("overage.remaining = %v, want 84.50", snap.Overage.Remaining)
-	}
-	if snap.Overage.Currency != "USD" {
-		t.Errorf("overage.currency = %q, want %q", snap.Overage.Currency, "USD")
+	if overage["currency"] != "USD" {
+		t.Errorf("overage.currency = %q, want %q", overage["currency"], "USD")
 	}
 }
 
@@ -369,13 +342,9 @@ func TestSnapshotToJSON_OverageDisabled(t *testing.T) {
 		},
 	}
 
-	result := SnapshotToJSON(outcome)
-	snap, ok := result.(SnapshotJSON)
-	if !ok {
-		t.Fatalf("expected SnapshotJSON, got %T", result)
-	}
+	data := marshalSnapshotToJSON(t, outcome)
 
-	if snap.Overage != nil {
+	if data["overage"] != nil {
 		t.Error("overage should be nil when disabled")
 	}
 }
@@ -390,15 +359,27 @@ func TestSnapshotToJSON_OverageNil(t *testing.T) {
 		},
 	}
 
-	result := SnapshotToJSON(outcome)
-	snap, ok := result.(SnapshotJSON)
-	if !ok {
-		t.Fatalf("expected SnapshotJSON, got %T", result)
-	}
+	data := marshalSnapshotToJSON(t, outcome)
 
-	if snap.Overage != nil {
+	if data["overage"] != nil {
 		t.Error("overage should be nil when nil")
 	}
+}
+
+// marshalSnapshotToJSON is a test helper that converts a successful
+// FetchOutcome through SnapshotToJSON and returns the unmarshaled map.
+func marshalSnapshotToJSON(t *testing.T, outcome fetch.FetchOutcome) map[string]any {
+	t.Helper()
+	result := SnapshotToJSON(outcome)
+	b, err := json.Marshal(result)
+	if err != nil {
+		t.Fatalf("failed to marshal SnapshotToJSON result: %v", err)
+	}
+	var data map[string]any
+	if err := json.Unmarshal(b, &data); err != nil {
+		t.Fatalf("failed to unmarshal SnapshotToJSON result: %v", err)
+	}
+	return data
 }
 
 // OutputMultiProviderJSON structural tests
@@ -429,7 +410,11 @@ func TestOutputMultiProviderJSON_Structure(t *testing.T) {
 		t.Fatalf("unexpected error: %v", err)
 	}
 
-	var result MultiProviderJSON
+	var result struct {
+		Providers map[string]any    `json:"providers"`
+		Errors    map[string]string `json:"errors"`
+		FetchedAt string            `json:"fetched_at"`
+	}
 	if err := json.Unmarshal(buf.Bytes(), &result); err != nil {
 		t.Fatalf("output is not valid JSON: %v", err)
 	}
@@ -455,7 +440,9 @@ func TestOutputMultiProviderJSON_EmptyOutcomes(t *testing.T) {
 		t.Fatalf("unexpected error: %v", err)
 	}
 
-	var result MultiProviderJSON
+	var result struct {
+		Providers map[string]any `json:"providers"`
+	}
 	if err := json.Unmarshal(buf.Bytes(), &result); err != nil {
 		t.Fatalf("output is not valid JSON: %v", err)
 	}
@@ -479,7 +466,9 @@ func TestOutputMultiProviderJSON_ErrorWithEmptyMessage(t *testing.T) {
 		t.Fatalf("unexpected error: %v", err)
 	}
 
-	var result MultiProviderJSON
+	var result struct {
+		Errors map[string]string `json:"errors"`
+	}
 	if err := json.Unmarshal(buf.Bytes(), &result); err != nil {
 		t.Fatalf("output is not valid JSON: %v", err)
 	}

--- a/internal/display/json_types.go
+++ b/internal/display/json_types.go
@@ -1,5 +1,7 @@
 package display
 
+import "github.com/joshuadavidthomas/vibeusage/internal/models"
+
 // SnapshotErrorJSON represents a failed fetch outcome.
 type SnapshotErrorJSON struct {
 	Error ErrorDetailJSON `json:"error"`
@@ -11,46 +13,11 @@ type ErrorDetailJSON struct {
 	Provider string `json:"provider"`
 }
 
-// SnapshotJSON represents a successful fetch outcome.
-type SnapshotJSON struct {
-	Provider string        `json:"provider"`
-	Source   string        `json:"source"`
-	Cached   bool          `json:"cached"`
-	Identity *IdentityJSON `json:"identity,omitempty"`
-	Periods  []PeriodJSON  `json:"periods"`
-	Overage  *OverageJSON  `json:"overage,omitempty"`
-}
-
-// IdentityJSON represents provider identity information.
-type IdentityJSON struct {
-	Email        string `json:"email"`
-	Organization string `json:"organization"`
-	Plan         string `json:"plan"`
-}
-
-// PeriodJSON represents a single usage period.
-type PeriodJSON struct {
-	Name        string `json:"name"`
-	Utilization int    `json:"utilization"`
-	Remaining   int    `json:"remaining"`
-	PeriodType  string `json:"period_type"`
-	ResetsAt    string `json:"resets_at,omitempty"`
-	Model       string `json:"model,omitempty"`
-}
-
-// OverageJSON represents overage usage information.
-type OverageJSON struct {
-	Used      float64 `json:"used"`
-	Limit     float64 `json:"limit"`
-	Remaining float64 `json:"remaining"`
-	Currency  string  `json:"currency"`
-}
-
-// MultiProviderJSON is the top-level response for multi-provider fetches.
-type MultiProviderJSON struct {
-	Providers map[string]SnapshotJSON `json:"providers"`
-	Errors    map[string]string       `json:"errors"`
-	FetchedAt string                  `json:"fetched_at"`
+// multiProviderJSON is the top-level response for multi-provider fetches.
+type multiProviderJSON struct {
+	Providers map[string]models.UsageSnapshot `json:"providers"`
+	Errors    map[string]string               `json:"errors"`
+	FetchedAt string                          `json:"fetched_at"`
 }
 
 // StatusEntryJSON represents a single provider's status.


### PR DESCRIPTION
Serialize `UsageSnapshot` directly for `--json` output instead of converting through mirror types.

## What was deleted

- `SnapshotJSON`, `PeriodJSON`, `OverageJSON`, `IdentityJSON` — shadow types that duplicated model types
- `snapshotJSON` wrapper, `buildSnapshotJSON` — conversion layer
- `SnapshotToJSON` field-by-field conversion loop

## What remains

`SnapshotToJSON` returns the `UsageSnapshot` directly (stripping disabled overage). `OutputMultiProviderJSON` maps into `models.UsageSnapshot`. No wrapper structs, no field copying.

## JSON output changes

- `remaining` removed from periods and overage (trivially computed: `100 - utilization`, `limit - used`)
- `source` and `cached` removed (fetch metadata, not usage data)
- `fetched_at`, `status`, `is_enabled` now included (they're on the model)
- `resets_at` uses Go's default time format (RFC3339Nano)
- Identity fields use `omitempty`

No established consumers — tool was made public yesterday.

## Result

-75 net lines across 3 files. Models, providers, routing untouched.