### PR TITLE
Extract duplicated provider plumbing into shared helpers

### DIFF
--- a/internal/httpclient/response.go
+++ b/internal/httpclient/response.go
@@ -1,0 +1,17 @@
+package httpclient
+
+import "strings"
+
+// SummarizeBody returns a short summary of an HTTP response body suitable for
+// error messages. Empty bodies return "empty body"; bodies longer than 120
+// characters are truncated with "...".
+func SummarizeBody(body []byte) string {
+	s := strings.TrimSpace(string(body))
+	if s == "" {
+		return "empty body"
+	}
+	if len(s) > 120 {
+		return s[:120] + "..."
+	}
+	return s
+}

--- a/internal/models/util.go
+++ b/internal/models/util.go
@@ -1,0 +1,31 @@
+package models
+
+import (
+	"strings"
+	"time"
+)
+
+// ParseRFC3339Ptr parses an RFC 3339 timestamp and returns a pointer to the
+// resulting time. Returns nil if the input is empty, whitespace-only, or
+// not a valid RFC 3339 string.
+func ParseRFC3339Ptr(raw string) *time.Time {
+	if strings.TrimSpace(raw) == "" {
+		return nil
+	}
+	t, err := time.Parse(time.RFC3339, raw)
+	if err != nil {
+		return nil
+	}
+	return &t
+}
+
+// ClampPct clamps an integer percentage to the range [0, 100].
+func ClampPct(v int) int {
+	if v < 0 {
+		return 0
+	}
+	if v > 100 {
+		return 100
+	}
+	return v
+}

--- a/internal/provider/antigravity/response.go
+++ b/internal/provider/antigravity/response.go
@@ -4,6 +4,7 @@ import (
 	"encoding/base64"
 	"time"
 
+	"github.com/joshuadavidthomas/vibeusage/internal/models"
 	"github.com/joshuadavidthomas/vibeusage/internal/provider/googleauth"
 	"google.golang.org/protobuf/encoding/protowire"
 )
@@ -43,13 +44,10 @@ func (q *QuotaInfo) Utilization() int {
 
 // ResetTimeUTC parses the resetTime as a time.Time.
 func (q *QuotaInfo) ResetTimeUTC() *time.Time {
-	if q == nil || q.ResetTime == "" {
+	if q == nil {
 		return nil
 	}
-	if t, err := time.Parse(time.RFC3339, q.ResetTime); err == nil {
-		return &t
-	}
-	return nil
+	return models.ParseRFC3339Ptr(q.ResetTime)
 }
 
 // CodeAssistResponse represents the response from the

--- a/internal/provider/claude/claude.go
+++ b/internal/provider/claude/claude.go
@@ -376,11 +376,7 @@ func (s *OAuthStrategy) parseOAuthUsageResponse(resp OAuthUsageResponse) *models
 			Utilization: int(sp.data.Utilization),
 			PeriodType:  sp.info.periodType,
 		}
-		if sp.data.ResetsAt != "" {
-			if t, err := time.Parse(time.RFC3339, sp.data.ResetsAt); err == nil {
-				p.ResetsAt = &t
-			}
-		}
+		p.ResetsAt = models.ParseRFC3339Ptr(sp.data.ResetsAt)
 		periods = append(periods, p)
 	}
 
@@ -403,11 +399,7 @@ func (s *OAuthStrategy) parseOAuthUsageResponse(resp OAuthUsageResponse) *models
 			PeriodType:  models.PeriodWeekly,
 			Model:       strings.ToLower(mp.modelName),
 		}
-		if mp.data.ResetsAt != "" {
-			if t, err := time.Parse(time.RFC3339, mp.data.ResetsAt); err == nil {
-				p.ResetsAt = &t
-			}
-		}
+		p.ResetsAt = models.ParseRFC3339Ptr(mp.data.ResetsAt)
 		periods = append(periods, p)
 	}
 
@@ -609,12 +601,7 @@ func (s *WebStrategy) parseWebUsageResponse(resp WebUsageResponse, overage *mode
 
 	if resp.UsageLimit > 0 {
 		utilization := int((resp.UsageAmount / resp.UsageLimit) * 100)
-		var resetsAt *time.Time
-		if resp.PeriodEnd != "" {
-			if t, err := time.Parse(time.RFC3339, resp.PeriodEnd); err == nil {
-				resetsAt = &t
-			}
-		}
+		resetsAt := models.ParseRFC3339Ptr(resp.PeriodEnd)
 		periods = append(periods, models.UsagePeriod{
 			Name:        "Usage",
 			Utilization: utilization,

--- a/internal/provider/copilot/copilot.go
+++ b/internal/provider/copilot/copilot.go
@@ -132,12 +132,7 @@ func (s *DeviceFlowStrategy) loadCredentials() *OAuthCredentials {
 func (s *DeviceFlowStrategy) parseTypedUsageResponse(resp UserResponse) *models.UsageSnapshot {
 	var periods []models.UsagePeriod
 
-	var resetsAt *time.Time
-	if resp.QuotaResetDateUTC != "" {
-		if t, err := time.Parse(time.RFC3339, resp.QuotaResetDateUTC); err == nil {
-			resetsAt = &t
-		}
-	}
+	resetsAt := models.ParseRFC3339Ptr(resp.QuotaResetDateUTC)
 
 	if resp.QuotaSnapshots != nil {
 		type quotaEntry struct {

--- a/internal/provider/gemini/response.go
+++ b/internal/provider/gemini/response.go
@@ -3,6 +3,7 @@ package gemini
 import (
 	"time"
 
+	"github.com/joshuadavidthomas/vibeusage/internal/models"
 	"github.com/joshuadavidthomas/vibeusage/internal/provider/googleauth"
 )
 
@@ -31,13 +32,7 @@ func (b *QuotaBucket) Utilization() int {
 
 // ResetTimeUTC parses the reset_time as a time.Time.
 func (b *QuotaBucket) ResetTimeUTC() *time.Time {
-	if b.ResetTime == "" {
-		return nil
-	}
-	if t, err := time.Parse(time.RFC3339, b.ResetTime); err == nil {
-		return &t
-	}
-	return nil
+	return models.ParseRFC3339Ptr(b.ResetTime)
 }
 
 // CodeAssistResponse represents the response from the Gemini code assist endpoint.

--- a/internal/provider/kimicode/response.go
+++ b/internal/provider/kimicode/response.go
@@ -55,13 +55,10 @@ func (u *UsageDetail) Utilization() int {
 
 // ResetTimeUTC parses the resetTime as a time.Time.
 func (u *UsageDetail) ResetTimeUTC() *time.Time {
-	if u == nil || u.ResetTime == "" {
+	if u == nil {
 		return nil
 	}
-	if t, err := time.Parse(time.RFC3339, u.ResetTime); err == nil {
-		return &t
-	}
-	return nil
+	return models.ParseRFC3339Ptr(u.ResetTime)
 }
 
 // Limit represents a per-window usage limit.

--- a/internal/provider/minimax/minimax_test.go
+++ b/internal/provider/minimax/minimax_test.go
@@ -18,7 +18,7 @@ func TestAPIKeyStrategy_IsAvailable_EnvVar(t *testing.T) {
 func TestAPIKeyStrategy_IsAvailable_NoEnvVar(t *testing.T) {
 	t.Setenv("MINIMAX_API_KEY", "")
 	s := &APIKeyStrategy{}
-	if s.loadToken() == "" && s.IsAvailable() {
+	if minimaxAPIKey.Load() == "" && s.IsAvailable() {
 		t.Error("IsAvailable() = true, want false when no token available")
 	}
 }
@@ -26,7 +26,7 @@ func TestAPIKeyStrategy_IsAvailable_NoEnvVar(t *testing.T) {
 func TestAPIKeyStrategy_Fetch_NoToken(t *testing.T) {
 	t.Setenv("MINIMAX_API_KEY", "")
 	s := &APIKeyStrategy{}
-	if s.loadToken() != "" {
+	if minimaxAPIKey.Load() != "" {
 		t.Skip("credential file present — skipping no-token test")
 	}
 

--- a/internal/provider/response.go
+++ b/internal/provider/response.go
@@ -1,0 +1,38 @@
+package provider
+
+import (
+	"fmt"
+
+	"github.com/joshuadavidthomas/vibeusage/internal/fetch"
+	"github.com/joshuadavidthomas/vibeusage/internal/httpclient"
+)
+
+// CheckResponse validates an HTTP response from a provider API. It returns a
+// non-nil FetchResult for error conditions (auth failures, unexpected status
+// codes, JSON parse errors) and nil when the response is OK for further
+// processing.
+//
+// The providerID is used to construct the `vibeusage auth <provider>` hint in
+// auth failure messages. The providerName is used in human-readable error
+// messages.
+func CheckResponse(resp *httpclient.Response, providerID, providerName string) *fetch.FetchResult {
+	if resp.StatusCode == 401 || resp.StatusCode == 403 {
+		r := fetch.ResultFatal(fmt.Sprintf(
+			"Token invalid or expired. Run `vibeusage auth %s` to re-authenticate.", providerID,
+		))
+		return &r
+	}
+	if resp.StatusCode != 200 {
+		r := fetch.ResultFail(fmt.Sprintf(
+			"%s request failed: HTTP %d (%s)", providerName, resp.StatusCode, httpclient.SummarizeBody(resp.Body),
+		))
+		return &r
+	}
+	if resp.JSONErr != nil {
+		r := fetch.ResultFail(fmt.Sprintf(
+			"Invalid response from %s API: %v", providerName, resp.JSONErr,
+		))
+		return &r
+	}
+	return nil
+}

--- a/internal/provider/zai/zai_test.go
+++ b/internal/provider/zai/zai_test.go
@@ -19,7 +19,7 @@ func TestAPIKeyStrategy_IsAvailable_NoEnvVar(t *testing.T) {
 	t.Setenv("ZAI_API_KEY", "")
 	s := &APIKeyStrategy{}
 	// Only assert false when no credential file exists either.
-	if s.loadToken() == "" && s.IsAvailable() {
+	if zaiAPIKey.Load() == "" && s.IsAvailable() {
 		t.Error("IsAvailable() = true, want false when no token available")
 	}
 }
@@ -27,7 +27,7 @@ func TestAPIKeyStrategy_IsAvailable_NoEnvVar(t *testing.T) {
 func TestAPIKeyStrategy_Fetch_NoToken(t *testing.T) {
 	t.Setenv("ZAI_API_KEY", "")
 	s := &APIKeyStrategy{}
-	if s.loadToken() != "" {
+	if zaiAPIKey.Load() != "" {
 		t.Skip("credential file present — skipping no-token test")
 	}
 


### PR DESCRIPTION
## Summary

Extract repeated helper functions from provider packages into shared locations, reducing copy-paste duplication across 11 provider files.

### Changes

**`httpclient.SummarizeBody()`** — Moved 3 identical copies (amp, openrouter, warp) into the httpclient package where it naturally belongs.

**`provider.LoadAPIKey()`** — New shared credential loader replacing 5 near-identical `loadToken()` methods across amp, openrouter, warp, minimax, and zai. Accepts env var names, credential path, and JSON keys as parameters to handle per-provider differences (e.g. warp's multiple env vars and JSON key fallback).

**`provider.CheckResponse()`** — New shared HTTP response checker encapsulating the common 401/403→Fatal, non-200→Fail with body summary, JSONErr→Fail pattern. Used by amp, openrouter, and warp (providers with custom response handling like copilot/codex keep their own logic).

**`models.ParseRFC3339Ptr()`** — New utility replacing warp's named `parseRFC3339Ptr` function plus 5 inline `time.Parse(time.RFC3339, s) → *time.Time` patterns across claude, copilot, kimicode, antigravity, and gemini.

**`models.ClampPct()`** — New utility replacing `clampPct` in warp and `clamp(v, 0, 100)` in zai.

### What's NOT changed

- Per-provider file structure and strategy shape are preserved
- Providers with custom response handling (copilot, codex, minimax, zai, claude, gemini, kimicode) keep their own logic
- No behavioral changes — all error messages and control flow are equivalent

### Stats

- **-55 net lines** (166 added, 221 removed)
- **3 new shared files**: `httpclient/response.go`, `models/util.go`, `provider/fetchutil.go`
- **0 test failures**, lint and fmt clean