### PR TITLE
feat(auth): add Escape key support to exit provider selection

### DIFF
--- a/internal/cli/auth.go
+++ b/internal/cli/auth.go
@@ -9,9 +9,9 @@ import (
 	"strings"
 	"time"
 
-	"github.com/spf13/cobra"
-
+	"github.com/charmbracelet/huh"
 	"github.com/charmbracelet/lipgloss"
+	"github.com/spf13/cobra"
 
 	"github.com/joshuadavidthomas/vibeusage/internal/config"
 	"github.com/joshuadavidthomas/vibeusage/internal/deviceflow"
@@ -118,7 +118,7 @@ func authSetup() error {
 
 	selected, err := prompt.Default.MultiSelect(prompt.MultiSelectConfig{
 		Title:       title,
-		Description: "Space to select, Enter to confirm",
+		Description: "Space to select, Enter to confirm, Esc to cancel",
 		Options:     options,
 		Validate: func(selected []string) error {
 			if len(selected) == 0 {
@@ -128,6 +128,9 @@ func authSetup() error {
 		},
 	})
 	if err != nil {
+		if errors.Is(err, huh.ErrUserAborted) {
+			return nil
+		}
 		return err
 	}
 

--- a/internal/prompt/prompt.go
+++ b/internal/prompt/prompt.go
@@ -1,6 +1,7 @@
 package prompt
 
 import (
+	"github.com/charmbracelet/bubbles/key"
 	"github.com/charmbracelet/huh"
 )
 
@@ -120,6 +121,10 @@ func (h *Huh) MultiSelect(cfg MultiSelectConfig) ([]string, error) {
 		})
 	}
 
-	err := huh.NewForm(huh.NewGroup(ms)).Run()
+	// Create a custom keymap that includes Escape to quit
+	keymap := huh.NewDefaultKeyMap()
+	keymap.Quit = key.NewBinding(key.WithKeys("esc", "ctrl+c"))
+
+	err := huh.NewForm(huh.NewGroup(ms)).WithKeyMap(keymap).Run()
 	return selected, err
 }


### PR DESCRIPTION
## Summary

Allow users to press **Escape** (in addition to Ctrl+C) to exit the provider selection list in `vibeusage auth`.

## Changes

- **`internal/prompt/prompt.go`**: Added a custom keymap to the MultiSelect that binds Escape to the Quit action (alongside Ctrl+C)
- **`internal/cli/auth.go`**: 
  - Handle `huh.ErrUserAborted` gracefully by returning `nil` instead of propagating the error
  - Updated the description to mention "Esc to cancel"

## Why

Previously, only Ctrl+C would exit the provider selection. Users expect Escape to work as a cancel action in interactive TUIs. The `huh` library maps Escape to filter operations by default, so a custom keymap was needed.

## Testing

- All existing tests pass
- Linting passes
- Code formatted with `gofmt`
