### PR TITLE
Remove v0.2.0 legacy migration compatibility layer

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -39,6 +39,7 @@ and this project attempts to adhere to [Semantic Versioning](https://semver.org/
 
 ### Removed
 
+- **Breaking:** Removed v0.2.0 legacy migration compatibility layer. Config and credentials are no longer read from or dual-written to legacy paths. Ensure you've run v0.2.0+ at least once before upgrading to ensure data is migrated.
 - **Breaking:** Removed `vibeusage key` command. All credential management is now handled through `vibeusage auth`. Use `vibeusage auth --status` instead of `vibeusage key` for credential status, `vibeusage auth <provider> --token <value>` instead of `vibeusage key <provider> set`, and `vibeusage auth <provider> --delete` instead of `vibeusage key <provider> delete`.
 - Removed Anthropic API key (`sk-ant-api...` / `sk-ant-admin-...`) support from Claude provider. Regular API keys cannot access consumer plan usage data — they live in a separate billing system with no access to Pro/Max rate limit information. Future Admin API key support tracked in [#97](https://github.com/joshuadavidthomas/vibeusage/issues/97). `vibeusage auth claude` now only accepts `sessionKey` cookies (`sk-ant-sid01-...`).
 - Removed `ANTHROPIC_API_KEY` environment variable support from the Claude provider.

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -182,16 +182,7 @@ func Load(path string) (Config, error) {
 
 	data, err := os.ReadFile(path)
 	if err != nil {
-		if legacyPath := legacyConfigFilePath(path); legacyPath != "" {
-			// TODO(v0.3.0): remove legacy config read fallback after the v0.2.0 migration window.
-			if legacyData, legacyErr := os.ReadFile(legacyPath); legacyErr == nil {
-				data = legacyData
-				err = nil
-			}
-		}
-		if err != nil {
-			return applyEnvOverrides(cfg), nil
-		}
+		return applyEnvOverrides(cfg), nil
 	}
 
 	if _, err := toml.Decode(string(data), &cfg); err != nil {
@@ -213,17 +204,7 @@ func Save(cfg Config, path string) error {
 	if path == "" {
 		path = ConfigFile()
 	}
-	if err := saveConfigFile(cfg, path); err != nil {
-		return err
-	}
-
-	legacyPath := legacyConfigFilePath(path)
-	if legacyPath != "" {
-		// TODO(v0.3.0): remove temporary dual-write compatibility after v0.2.0 migration window.
-		_ = saveConfigFile(cfg, legacyPath)
-	}
-
-	return nil
+	return saveConfigFile(cfg, path)
 }
 
 func saveConfigFile(cfg Config, path string) error {
@@ -239,18 +220,6 @@ func saveConfigFile(cfg Config, path string) error {
 		return fmt.Errorf("saving config: %w", err)
 	}
 	return nil
-}
-
-// TODO(v0.3.0): remove legacy config path fallback after the v0.2.0 migration window.
-func legacyConfigFilePath(path string) string {
-	if filepath.Clean(path) != filepath.Clean(ConfigFile()) {
-		return ""
-	}
-	legacy := legacyConfigFile()
-	if filepath.Clean(legacy) == filepath.Clean(path) {
-		return ""
-	}
-	return legacy
 }
 
 func applyEnvOverrides(cfg Config) Config {

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -9,7 +9,6 @@ import (
 	"testing"
 	"time"
 
-	"github.com/adrg/xdg"
 	"github.com/joshuadavidthomas/vibeusage/internal/models"
 )
 
@@ -186,27 +185,6 @@ func TestLoad_MissingFile_ReturnsDefaults(t *testing.T) {
 	}
 	if cfg.Providers == nil {
 		t.Error("Providers map should be initialized even on missing file")
-	}
-}
-
-func TestLoad_DefaultPathFallsBackToLegacyConfigFile(t *testing.T) {
-	dir := t.TempDir()
-	t.Setenv("VIBEUSAGE_CONFIG_DIR", "")
-	t.Setenv("XDG_CONFIG_HOME", filepath.Join(dir, "legacy-base"))
-
-	oldConfigHome := xdg.ConfigHome
-	xdg.ConfigHome = filepath.Join(dir, "primary-base")
-	t.Cleanup(func() { xdg.ConfigHome = oldConfigHome })
-
-	legacyPath := legacyConfigFile()
-	writeTestFile(t, legacyPath, []byte("[fetch]\ntimeout = 12.5\n"))
-
-	cfg, err := Load("")
-	if err != nil {
-		t.Fatalf("Load() error = %v, want nil", err)
-	}
-	if cfg.Fetch.Timeout != 12.5 {
-		t.Errorf("Fetch.Timeout = %v, want 12.5 from legacy config", cfg.Fetch.Timeout)
 	}
 }
 
@@ -700,33 +678,6 @@ func TestSubdirectoryPaths(t *testing.T) {
 	}
 }
 
-func TestSave_DualWritesLegacyConfigPath(t *testing.T) {
-	dir := t.TempDir()
-	t.Setenv("VIBEUSAGE_CONFIG_DIR", "")
-	t.Setenv("XDG_CONFIG_HOME", filepath.Join(dir, "legacy-base"))
-
-	oldConfigHome := xdg.ConfigHome
-	xdg.ConfigHome = filepath.Join(dir, "primary-base")
-	t.Cleanup(func() { xdg.ConfigHome = oldConfigHome })
-
-	cfg := DefaultConfig()
-	if err := Save(cfg, ""); err != nil {
-		t.Fatalf("Save() error: %v", err)
-	}
-
-	primary := ConfigFile()
-	legacy := legacyConfigFile()
-	if primary == legacy {
-		t.Fatalf("expected distinct primary and legacy paths, got %q", primary)
-	}
-	if _, err := os.Stat(primary); err != nil {
-		t.Fatalf("primary config file should exist: %v", err)
-	}
-	if _, err := os.Stat(legacy); err != nil {
-		t.Fatalf("legacy config file should exist: %v", err)
-	}
-}
-
 // Cache: Snapshots
 
 func TestCacheSnapshot_LoadCachedSnapshot_Roundtrip(t *testing.T) {
@@ -1102,30 +1053,6 @@ func TestWriteCredential_ReadCredential_Roundtrip(t *testing.T) {
 	}
 }
 
-func TestWriteCredential_DualWritesLegacyPath(t *testing.T) {
-	dir := t.TempDir()
-	t.Setenv("VIBEUSAGE_CONFIG_DIR", filepath.Join(dir, "config"))
-	t.Setenv("VIBEUSAGE_DATA_DIR", filepath.Join(dir, "data"))
-
-	path := CredentialPath("claude", "oauth")
-	content := []byte(`{"token":"dual-write"}`)
-
-	if err := WriteCredential(path, content); err != nil {
-		t.Fatalf("WriteCredential() error: %v", err)
-	}
-
-	legacy := legacyCredentialPath(path)
-	if legacy == "" {
-		t.Fatal("expected legacy credential path")
-	}
-	if _, err := os.Stat(path); err != nil {
-		t.Fatalf("primary credential should exist: %v", err)
-	}
-	if _, err := os.Stat(legacy); err != nil {
-		t.Fatalf("legacy credential should exist: %v", err)
-	}
-}
-
 func TestWriteCredential_FilePermissions(t *testing.T) {
 	dir := t.TempDir()
 	path := filepath.Join(dir, "cred.json")
@@ -1181,29 +1108,6 @@ func TestReadCredential_MissingFile_ReturnsNilNil(t *testing.T) {
 	}
 }
 
-func TestReadCredential_LegacyPathFallback(t *testing.T) {
-	dir := t.TempDir()
-	t.Setenv("VIBEUSAGE_CONFIG_DIR", filepath.Join(dir, "config"))
-	t.Setenv("VIBEUSAGE_DATA_DIR", filepath.Join(dir, "data"))
-
-	content := []byte(`{"token":"legacy"}`)
-	legacyPath := filepath.Join(legacyCredentialsDir(), "claude", "oauth.json")
-	if err := os.MkdirAll(filepath.Dir(legacyPath), 0o755); err != nil {
-		t.Fatalf("MkdirAll: %v", err)
-	}
-	if err := os.WriteFile(legacyPath, content, 0o600); err != nil {
-		t.Fatalf("WriteFile: %v", err)
-	}
-
-	got, err := ReadCredential(CredentialPath("claude", "oauth"))
-	if err != nil {
-		t.Fatalf("ReadCredential() error: %v", err)
-	}
-	if string(got) != string(content) {
-		t.Errorf("ReadCredential() = %q, want %q", got, content)
-	}
-}
-
 func TestDeleteCredential_ExistingFile(t *testing.T) {
 	dir := t.TempDir()
 	path := filepath.Join(dir, "cred.json")
@@ -1216,27 +1120,6 @@ func TestDeleteCredential_ExistingFile(t *testing.T) {
 	}
 	if _, err := os.Stat(path); !os.IsNotExist(err) {
 		t.Error("file should be deleted")
-	}
-}
-
-func TestDeleteCredential_LegacyPathFallback(t *testing.T) {
-	dir := t.TempDir()
-	t.Setenv("VIBEUSAGE_CONFIG_DIR", filepath.Join(dir, "config"))
-	t.Setenv("VIBEUSAGE_DATA_DIR", filepath.Join(dir, "data"))
-
-	legacyPath := filepath.Join(legacyCredentialsDir(), "claude", "session.json")
-	if err := os.MkdirAll(filepath.Dir(legacyPath), 0o755); err != nil {
-		t.Fatalf("MkdirAll: %v", err)
-	}
-	if err := os.WriteFile(legacyPath, []byte("legacy"), 0o600); err != nil {
-		t.Fatalf("WriteFile: %v", err)
-	}
-
-	if !DeleteCredential(CredentialPath("claude", "session")) {
-		t.Error("DeleteCredential() should return true when legacy credential exists")
-	}
-	if _, err := os.Stat(legacyPath); !os.IsNotExist(err) {
-		t.Error("legacy credential file should be deleted")
 	}
 }
 
@@ -1285,29 +1168,6 @@ func TestFindProviderCredential_VibeusageStorage(t *testing.T) {
 	}
 	if path != credPath {
 		t.Errorf("path = %q, want %q", path, credPath)
-	}
-}
-
-func TestFindProviderCredential_LegacyVibeusageStorage(t *testing.T) {
-	setupTempDirWithCredentialIsolation(t)
-
-	legacyPath := filepath.Join(legacyCredentialsDir(), "claude", "oauth.json")
-	if err := os.MkdirAll(filepath.Dir(legacyPath), 0o755); err != nil {
-		t.Fatalf("MkdirAll: %v", err)
-	}
-	if err := os.WriteFile(legacyPath, []byte(`{"token":"legacy"}`), 0o600); err != nil {
-		t.Fatalf("WriteFile: %v", err)
-	}
-
-	found, source, path := FindProviderCredential("claude", nil, nil)
-	if !found {
-		t.Error("should find credential in legacy vibeusage storage")
-	}
-	if source != "vibeusage" {
-		t.Errorf("source = %q, want %q", source, "vibeusage")
-	}
-	if path != legacyPath {
-		t.Errorf("path = %q, want %q", path, legacyPath)
 	}
 }
 

--- a/internal/config/paths.go
+++ b/internal/config/paths.go
@@ -20,15 +20,7 @@ func ConfigDir() string {
 		return canonical
 	}
 
-	preferred := filepath.Join(homeDir(), ".config", appName)
-	if regularFileExists(filepath.Join(preferred, "config.toml")) {
-		return preferred
-	}
-	if regularFileExists(filepath.Join(canonical, "config.toml")) {
-		// TODO(v0.3.0): remove legacy macOS config-path fallback after the v0.2.0 migration window.
-		return canonical
-	}
-	return preferred
+	return filepath.Join(homeDir(), ".config", appName)
 }
 
 func DataDir() string {
@@ -52,35 +44,6 @@ func OrgIDsDir() string            { return filepath.Join(CacheDir(), "org-ids")
 func ModelsFile() string           { return filepath.Join(CacheDir(), "models.json") }
 func MultipliersFile() string      { return filepath.Join(CacheDir(), "multipliers.json") }
 func ConfigFile() string           { return filepath.Join(ConfigDir(), "config.toml") }
-
-// TODO(v0.3.0): remove legacy config path helpers after the v0.2.0 migration window.
-func legacyConfigDir() string {
-	if v := os.Getenv("VIBEUSAGE_CONFIG_DIR"); v != "" {
-		return v
-	}
-	if d, err := os.UserConfigDir(); err == nil {
-		return filepath.Join(d, appName)
-	}
-	return filepath.Join(homeDir(), ".config", appName)
-}
-
-// TODO(v0.3.0): remove legacy config path helpers after the v0.2.0 migration window.
-func legacyConfigFile() string {
-	return filepath.Join(legacyConfigDir(), "config.toml")
-}
-
-// TODO(v0.3.0): remove legacy config path helpers after the v0.2.0 migration window.
-func legacyCredentialsDir() string {
-	return filepath.Join(legacyConfigDir(), "credentials")
-}
-
-func regularFileExists(path string) bool {
-	info, err := os.Stat(path)
-	if err != nil {
-		return false
-	}
-	return !info.IsDir()
-}
 
 func homeDir() string {
 	if d := xdg.Home; d != "" {


### PR DESCRIPTION
Closes the v0.2.0 migration window by removing all legacy fallback code.

## Summary

Removes all `TODO(v0.3.0)` items related to the v0.2.0 migration:

### Removed from `internal/config/config.go`
- Legacy config read fallback in `Load()`
- Dual-write compatibility in `Save()`
- `legacyConfigFilePath()` helper

### Removed from `internal/config/paths.go`
- macOS legacy config path fallback in `ConfigDir()`
- `legacyConfigDir()`, `legacyConfigFile()`, `legacyCredentialsDir()` helpers
- `regularFileExists()` helper (no longer needed)

### Removed from `internal/config/credentials.go`
- Legacy credential read fallback in `FindProviderCredential()`
- Dual-write compatibility in `WriteCredential()`
- Legacy credential read fallback in `ReadCredential()`
- Legacy credential delete fallback in `DeleteCredential()`
- `legacyCredentialPathFor()` and `legacyCredentialPath()` helpers

### Removed from `internal/config/config_test.go`
- Tests for legacy fallback behavior (6 tests removed)
- Unused `github.com/adrg/xdg` import

### Updated
- `CHANGELOG.md` - added breaking change notice

## Breaking Change

This is a breaking change for users upgrading **directly** from v0.1.x. Users must run v0.2.0+ at least once before upgrading to ensure data is migrated to the new XDG-compliant paths.