### PR TITLE
feat(status): add spinner UI, new status providers, and API refactoring

### DIFF
--- a/internal/provider/amp/amp.go
+++ b/internal/provider/amp/amp.go
@@ -17,6 +17,7 @@ func (a Amp) Meta() provider.Metadata {
 		Name:        "Amp",
 		Description: "Amp coding assistant",
 		Homepage:    "https://ampcode.com",
+		StatusURL:   "https://ampcodestatus.com",
 	}
 }
 
@@ -35,8 +36,8 @@ func (a Amp) FetchStrategies() []fetch.Strategy {
 	}
 }
 
-func (a Amp) FetchStatus(_ context.Context) models.ProviderStatus {
-	return models.ProviderStatus{Level: models.StatusUnknown}
+func (a Amp) FetchStatus(ctx context.Context) models.ProviderStatus {
+	return provider.FetchStatuspageStatus(ctx, "https://ampcodestatus.com")
 }
 
 func (a Amp) Auth() provider.AuthFlow {

--- a/internal/provider/claude/claude.go
+++ b/internal/provider/claude/claude.go
@@ -39,7 +39,7 @@ func (c Claude) FetchStrategies() []fetch.Strategy {
 }
 
 func (c Claude) FetchStatus(ctx context.Context) models.ProviderStatus {
-	return provider.FetchStatuspageStatus(ctx, "https://status.anthropic.com/api/v2/status.json")
+	return provider.FetchStatuspageStatus(ctx, "https://status.anthropic.com")
 }
 
 // Auth returns a manual credential flow for Claude.

--- a/internal/provider/codex/codex.go
+++ b/internal/provider/codex/codex.go
@@ -45,7 +45,7 @@ func (c Codex) FetchStrategies() []fetch.Strategy {
 }
 
 func (c Codex) FetchStatus(ctx context.Context) models.ProviderStatus {
-	return provider.FetchStatuspageStatus(ctx, "https://status.openai.com/api/v2/status.json")
+	return provider.FetchStatuspageStatus(ctx, "https://status.openai.com")
 }
 
 // Auth returns the manual bearer token flow for Codex.

--- a/internal/provider/copilot/copilot.go
+++ b/internal/provider/copilot/copilot.go
@@ -42,7 +42,7 @@ func (c Copilot) FetchStrategies() []fetch.Strategy {
 }
 
 func (c Copilot) FetchStatus(ctx context.Context) models.ProviderStatus {
-	return provider.FetchStatuspageStatus(ctx, "https://www.githubstatus.com/api/v2/status.json")
+	return provider.FetchStatuspageStatus(ctx, "https://www.githubstatus.com")
 }
 
 // Auth returns the GitHub device flow for Copilot.

--- a/internal/provider/cursor/cursor.go
+++ b/internal/provider/cursor/cursor.go
@@ -40,7 +40,7 @@ func (c Cursor) FetchStrategies() []fetch.Strategy {
 }
 
 func (c Cursor) FetchStatus(ctx context.Context) models.ProviderStatus {
-	return provider.FetchStatuspageStatus(ctx, "https://status.cursor.com/api/v2/status.json")
+	return provider.FetchStatuspageStatus(ctx, "https://status.cursor.com")
 }
 
 const (

--- a/internal/provider/kimicode/kimicode.go
+++ b/internal/provider/kimicode/kimicode.go
@@ -23,6 +23,7 @@ func (k KimiCode) Meta() provider.Metadata {
 		Name:        "Kimi Code",
 		Description: "Moonshot AI coding assistant",
 		Homepage:    "https://www.kimi.com",
+		StatusURL:   "https://status.moonshot.cn",
 	}
 }
 
@@ -40,8 +41,8 @@ func (k KimiCode) FetchStrategies() []fetch.Strategy {
 	}
 }
 
-func (k KimiCode) FetchStatus(_ context.Context) models.ProviderStatus {
-	return models.ProviderStatus{Level: models.StatusUnknown}
+func (k KimiCode) FetchStatus(ctx context.Context) models.ProviderStatus {
+	return provider.FetchStatuspageStatus(ctx, "https://status.moonshot.cn")
 }
 
 // Auth returns the Kimi Code device flow.

--- a/internal/provider/openrouter/openrouter.go
+++ b/internal/provider/openrouter/openrouter.go
@@ -19,6 +19,7 @@ func (o OpenRouter) Meta() provider.Metadata {
 		Name:        "OpenRouter",
 		Description: "OpenRouter unified model gateway",
 		Homepage:    "https://openrouter.ai",
+		StatusURL:   "https://status.openrouter.ai",
 	}
 }
 
@@ -31,8 +32,8 @@ func (o OpenRouter) FetchStrategies() []fetch.Strategy {
 	return []fetch.Strategy{&APIKeyStrategy{HTTPTimeout: timeout}}
 }
 
-func (o OpenRouter) FetchStatus(_ context.Context) models.ProviderStatus {
-	return models.ProviderStatus{Level: models.StatusUnknown}
+func (o OpenRouter) FetchStatus(ctx context.Context) models.ProviderStatus {
+	return provider.FetchOnlineOrNotStatus(ctx, "https://status.openrouter.ai")
 }
 
 func (o OpenRouter) Auth() provider.AuthFlow {

--- a/internal/provider/warp/warp.go
+++ b/internal/provider/warp/warp.go
@@ -21,6 +21,7 @@ func (w Warp) Meta() provider.Metadata {
 		Name:        "Warp",
 		Description: "Warp terminal AI",
 		Homepage:    "https://warp.dev",
+		StatusURL:   "https://status.warp.dev",
 	}
 }
 
@@ -33,8 +34,8 @@ func (w Warp) FetchStrategies() []fetch.Strategy {
 	return []fetch.Strategy{&APIKeyStrategy{HTTPTimeout: timeout}}
 }
 
-func (w Warp) FetchStatus(_ context.Context) models.ProviderStatus {
-	return models.ProviderStatus{Level: models.StatusUnknown}
+func (w Warp) FetchStatus(ctx context.Context) models.ProviderStatus {
+	return provider.FetchStatuspageStatus(ctx, "https://status.warp.dev")
 }
 
 func (w Warp) Auth() provider.AuthFlow {


### PR DESCRIPTION
This PR improves the `vibeusage status` command with the following changes:

## Features

### Spinner UI
- Added spinner feedback to `vibeusage status` command (matching the `usage` command behavior)
- Shows animated progress while fetching status from all providers
- Automatically hidden for --quiet, --json, or non-TTY output

### New Status Providers
Added real-time status fetching for 4 providers that previously showed "unknown":

| Provider | Status Page | Implementation |
|----------|-------------|----------------|
| **Amp** | https://ampcodestatus.com | Statuspage.io API |
| **Kimi Code** | https://status.moonshot.cn | Statuspage.io API |
| **OpenRouter** | https://status.openrouter.ai | OnlineOrNot RSS |
| **Warp** | https://status.warp.dev | Statuspage.io API |

### API Improvements
- Added `FetchOnlineOrNotStatus` helper for OnlineOrNot-powered status pages
- Refactored `FetchStatuspageStatus` and `FetchOnlineOrNotStatus` to accept **base URLs** instead of full API paths
  - Automatically appends `/api/v2/status.json` for Statuspage.io
  - Automatically appends `/incidents.rss` for OnlineOrNot
- Added `StatusURL` field to provider metadata

### Testing
- Added 7 new tests for `FetchOnlineOrNotStatus`
- Added 2 new tests for status command callback functionality
- All existing tests pass

## Example Output

Before:


After:


## Remaining Unknown Providers
- **Minimax**: No public status page found
- **Z.ai**: No public status page found