### PR TITLE
Fix inconsistent panel widths in dashboard view

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -36,6 +36,7 @@ and this project attempts to adhere to [Semantic Versioning](https://semver.org/
 
 ### Fixed
 
+- Fixed inconsistent panel widths in the dashboard view where providers without reset times (e.g., Amp) rendered narrower boxes than providers with reset countdowns.
 - Fixed confusing overage display when the API returns a null monthly spend limit.
 
 ## [0.3.0]


### PR DESCRIPTION
Providers without reset times (e.g., Amp) rendered narrower boxes than providers with reset countdowns because each panel was independently sized to its own content.

## Changes

- Added `RowWidth()` method to `PeriodColWidths` that computes the total visible width of a fully-populated period row (`name + gap + bar + gap + pct + gap + reset`)
- Added `minWidth` parameter to `renderTitledPanel` so callers can enforce a minimum body width
- `RenderProviderPanel` (dashboard view) passes `cw.RowWidth()` so all panels share the same width
- `renderUsagePanel` (detail view) passes `0` since it renders standalone

### Before
```
╭─Amp─────────────────────────────────────────────────╮
│ Daily                  ░░░░░░░░░░░░░░░░░░░░  0%     │
│ Extra: $0.00 USD (Unlimited)                        │
╰─────────────────────────────────────────────────────╯
╭─Claude──────────────────────────────────────────────────────────────╮
│ Session (5h)           ██░░░░░░░░░░░░░░░░░░ 11%    resets in 1h 54m │
╰─────────────────────────────────────────────────────────────────────╯
```

### After
```
╭─Amp─────────────────────────────────────────────────────────────────╮
│ Daily                  ░░░░░░░░░░░░░░░░░░░░  0%                     │
│ Extra: $0.00 USD (Unlimited)                                        │
╰─────────────────────────────────────────────────────────────────────╯
╭─Claude──────────────────────────────────────────────────────────────╮
│ Session (5h)           ██░░░░░░░░░░░░░░░░░░ 12%    resets in 1h 50m │
╰─────────────────────────────────────────────────────────────────────╯
```