### PR TITLE
Remove credential type aliases, use oauth.Credentials directly

### DIFF
--- a/internal/provider/antigravity/antigravity.go
+++ b/internal/provider/antigravity/antigravity.go
@@ -15,6 +15,7 @@ import (
 	"github.com/joshuadavidthomas/vibeusage/internal/fetch"
 	"github.com/joshuadavidthomas/vibeusage/internal/httpclient"
 	"github.com/joshuadavidthomas/vibeusage/internal/models"
+	"github.com/joshuadavidthomas/vibeusage/internal/oauth"
 	"github.com/joshuadavidthomas/vibeusage/internal/provider"
 	"github.com/joshuadavidthomas/vibeusage/internal/provider/googleauth"
 )
@@ -146,7 +147,7 @@ func (s *OAuthStrategy) Fetch(ctx context.Context) (fetch.FetchResult, error) {
 	return fetch.ResultOK(*snapshot), nil
 }
 
-func (s *OAuthStrategy) loadCredentials() *googleauth.OAuthCredentials {
+func (s *OAuthStrategy) loadCredentials() *oauth.Credentials {
 	// Try JSON credential files first
 	for _, path := range s.credentialPaths() {
 		data, err := config.ReadCredential(path)
@@ -163,7 +164,7 @@ func (s *OAuthStrategy) loadCredentials() *googleauth.OAuthCredentials {
 		}
 
 		// Try direct OAuth credentials format
-		var oauthCreds googleauth.OAuthCredentials
+		var oauthCreds oauth.Credentials
 		if err := json.Unmarshal(data, &oauthCreds); err == nil && oauthCreds.AccessToken != "" {
 			return &oauthCreds
 		}
@@ -180,7 +181,7 @@ func (s *OAuthStrategy) loadCredentials() *googleauth.OAuthCredentials {
 
 // vscdbResult holds credentials and subscription info read from the vscdb.
 type vscdbResult struct {
-	creds        *googleauth.OAuthCredentials
+	creds        *oauth.Credentials
 	subscription *SubscriptionInfo
 	email        string
 }
@@ -217,7 +218,7 @@ func loadFromVSCDB() *vscdbResult {
 	}
 
 	result := &vscdbResult{
-		creds: &googleauth.OAuthCredentials{
+		creds: &oauth.Credentials{
 			AccessToken: authStatus.APIKey,
 			// No refresh token available from the vscdb — the Antigravity
 			// IDE manages token refresh internally.

--- a/internal/provider/antigravity/auth.go
+++ b/internal/provider/antigravity/auth.go
@@ -12,6 +12,7 @@ import (
 	"github.com/joshuadavidthomas/vibeusage/internal/config"
 	"github.com/joshuadavidthomas/vibeusage/internal/deviceflow"
 	"github.com/joshuadavidthomas/vibeusage/internal/httpclient"
+	"github.com/joshuadavidthomas/vibeusage/internal/oauth"
 	"github.com/joshuadavidthomas/vibeusage/internal/provider/googleauth"
 )
 
@@ -137,7 +138,7 @@ func exchangeCode(w io.Writer, code, redirectURI string, quiet bool) (bool, erro
 		return false, fmt.Errorf("token exchange returned empty access token")
 	}
 
-	creds := &googleauth.OAuthCredentials{
+	creds := &oauth.Credentials{
 		AccessToken:  tokenResp.AccessToken,
 		RefreshToken: tokenResp.RefreshToken,
 	}

--- a/internal/provider/antigravity/response.go
+++ b/internal/provider/antigravity/response.go
@@ -5,6 +5,7 @@ import (
 	"time"
 
 	"github.com/joshuadavidthomas/vibeusage/internal/models"
+	"github.com/joshuadavidthomas/vibeusage/internal/oauth"
 	"github.com/joshuadavidthomas/vibeusage/internal/provider/googleauth"
 	"google.golang.org/protobuf/encoding/protowire"
 )
@@ -99,7 +100,7 @@ type AntigravityCredentials struct {
 }
 
 // ToOAuthCredentials converts the Antigravity credential format to OAuthCredentials.
-func (a *AntigravityCredentials) ToOAuthCredentials() *googleauth.OAuthCredentials {
+func (a *AntigravityCredentials) ToOAuthCredentials() *oauth.Credentials {
 	accessToken := a.AccessToken
 	if accessToken == "" {
 		accessToken = a.Token
@@ -107,7 +108,7 @@ func (a *AntigravityCredentials) ToOAuthCredentials() *googleauth.OAuthCredentia
 	if accessToken == "" {
 		return nil
 	}
-	creds := &googleauth.OAuthCredentials{
+	creds := &oauth.Credentials{
 		AccessToken:  accessToken,
 		RefreshToken: a.RefreshToken,
 		ExpiresAt:    a.ExpiresAt,

--- a/internal/provider/claude/oauth.go
+++ b/internal/provider/claude/oauth.go
@@ -147,7 +147,7 @@ func (s *OAuthStrategy) credentialPaths() []string {
 	return provider.CredentialSearchPaths("claude", "oauth", filepath.Join(home, ".claude", ".credentials.json"))
 }
 
-func (s *OAuthStrategy) loadCredentials() *OAuthCredentials {
+func (s *OAuthStrategy) loadCredentials() *oauth.Credentials {
 	for _, path := range s.credentialPaths() {
 		data, err := config.ReadCredential(path)
 		if err != nil || data == nil {
@@ -162,7 +162,7 @@ func (s *OAuthStrategy) loadCredentials() *OAuthCredentials {
 		}
 
 		// Standard vibeusage format
-		var creds OAuthCredentials
+		var creds oauth.Credentials
 		if err := json.Unmarshal(data, &creds); err != nil {
 			continue
 		}
@@ -173,7 +173,7 @@ func (s *OAuthStrategy) loadCredentials() *OAuthCredentials {
 	return s.loadKeychainCredentials()
 }
 
-func (s *OAuthStrategy) loadKeychainCredentials() *OAuthCredentials {
+func (s *OAuthStrategy) loadKeychainCredentials() *oauth.Credentials {
 	secret, err := readKeychainSecret(claudeKeychainSecret, "")
 	if err != nil || secret == "" {
 		return nil
@@ -191,7 +191,7 @@ func (s *OAuthStrategy) loadKeychainCredentials() *OAuthCredentials {
 	return &creds
 }
 
-func (s *OAuthStrategy) refreshToken(ctx context.Context, creds *OAuthCredentials) *OAuthCredentials {
+func (s *OAuthStrategy) refreshToken(ctx context.Context, creds *oauth.Credentials) *oauth.Credentials {
 	return oauth.Refresh(ctx, creds.RefreshToken, oauth.RefreshConfig{
 		TokenURL:    oauthTokenURL,
 		Headers:     []httpclient.RequestOption{httpclient.WithHeader("anthropic-beta", anthropicBetaTag)},

--- a/internal/provider/claude/oauth_test.go
+++ b/internal/provider/claude/oauth_test.go
@@ -6,6 +6,7 @@ import (
 	"time"
 
 	"github.com/joshuadavidthomas/vibeusage/internal/models"
+	"github.com/joshuadavidthomas/vibeusage/internal/oauth"
 )
 
 func floatPtr(f float64) *float64 { return &f }
@@ -345,17 +346,17 @@ func TestParseOAuthUsageResponse_NullMonthlyLimit(t *testing.T) {
 func TestOAuthCredentials_NeedsRefresh(t *testing.T) {
 	tests := []struct {
 		name  string
-		creds OAuthCredentials
+		creds oauth.Credentials
 		want  bool
 	}{
 		{
 			name:  "no expiry",
-			creds: OAuthCredentials{AccessToken: "tok"},
+			creds: oauth.Credentials{AccessToken: "tok"},
 			want:  false,
 		},
 		{
 			name: "not expired and outside buffer",
-			creds: OAuthCredentials{
+			creds: oauth.Credentials{
 				AccessToken: "tok",
 				ExpiresAt:   time.Now().UTC().Add(1 * time.Hour).Format(time.RFC3339),
 			},
@@ -363,7 +364,7 @@ func TestOAuthCredentials_NeedsRefresh(t *testing.T) {
 		},
 		{
 			name: "expired",
-			creds: OAuthCredentials{
+			creds: oauth.Credentials{
 				AccessToken: "tok",
 				ExpiresAt:   time.Now().UTC().Add(-1 * time.Hour).Format(time.RFC3339),
 			},
@@ -371,7 +372,7 @@ func TestOAuthCredentials_NeedsRefresh(t *testing.T) {
 		},
 		{
 			name: "within refresh buffer",
-			creds: OAuthCredentials{
+			creds: oauth.Credentials{
 				AccessToken: "tok",
 				ExpiresAt:   time.Now().UTC().Add(2 * time.Minute).Format(time.RFC3339),
 			},
@@ -379,7 +380,7 @@ func TestOAuthCredentials_NeedsRefresh(t *testing.T) {
 		},
 		{
 			name: "invalid date",
-			creds: OAuthCredentials{
+			creds: oauth.Credentials{
 				AccessToken: "tok",
 				ExpiresAt:   "garbage",
 			},

--- a/internal/provider/claude/response.go
+++ b/internal/provider/claude/response.go
@@ -41,9 +41,6 @@ type OAuthUsageResponse struct {
 	BillingType       string               `json:"billing_type,omitempty"`
 }
 
-// OAuthCredentials is an alias for the shared OAuth credential type.
-type OAuthCredentials = oauth.Credentials
-
 // ClaudeCLIOAuth represents the nested OAuth data inside Claude CLI credentials.
 type ClaudeCLIOAuth struct {
 	AccessToken  string  `json:"accessToken"`
@@ -51,9 +48,9 @@ type ClaudeCLIOAuth struct {
 	ExpiresAt    float64 `json:"expiresAt,omitempty"` // millisecond timestamp
 }
 
-// ToOAuthCredentials converts Claude CLI format to standard OAuthCredentials.
-func (c *ClaudeCLIOAuth) ToOAuthCredentials() OAuthCredentials {
-	creds := OAuthCredentials{
+// ToOAuthCredentials converts Claude CLI format to standard oauth.Credentials.
+func (c *ClaudeCLIOAuth) ToOAuthCredentials() oauth.Credentials {
+	creds := oauth.Credentials{
 		AccessToken:  c.AccessToken,
 		RefreshToken: c.RefreshToken,
 	}

--- a/internal/provider/claude/response_test.go
+++ b/internal/provider/claude/response_test.go
@@ -3,6 +3,8 @@ package claude
 import (
 	"encoding/json"
 	"testing"
+
+	"github.com/joshuadavidthomas/vibeusage/internal/oauth"
 )
 
 func TestOAuthUsageResponse_UnmarshalFullResponse(t *testing.T) {
@@ -277,7 +279,7 @@ func TestOAuthCredentials_Unmarshal(t *testing.T) {
 		"expires_at": "2025-02-19T22:00:00Z"
 	}`
 
-	var creds OAuthCredentials
+	var creds oauth.Credentials
 	if err := json.Unmarshal([]byte(raw), &creds); err != nil {
 		t.Fatalf("unmarshal failed: %v", err)
 	}
@@ -296,7 +298,7 @@ func TestOAuthCredentials_Unmarshal(t *testing.T) {
 func TestOAuthCredentials_UnmarshalMinimal(t *testing.T) {
 	raw := `{"access_token": "tok"}`
 
-	var creds OAuthCredentials
+	var creds oauth.Credentials
 	if err := json.Unmarshal([]byte(raw), &creds); err != nil {
 		t.Fatalf("unmarshal failed: %v", err)
 	}
@@ -386,7 +388,7 @@ func TestClaudeCLIOAuth_ToOAuthCredentials_ZeroExpiresAt(t *testing.T) {
 }
 
 func TestOAuthCredentials_Roundtrip(t *testing.T) {
-	original := OAuthCredentials{
+	original := oauth.Credentials{
 		AccessToken:  "my-token",
 		RefreshToken: "my-refresh",
 		ExpiresAt:    "2025-02-19T22:00:00Z",
@@ -397,7 +399,7 @@ func TestOAuthCredentials_Roundtrip(t *testing.T) {
 		t.Fatalf("marshal failed: %v", err)
 	}
 
-	var decoded OAuthCredentials
+	var decoded oauth.Credentials
 	if err := json.Unmarshal(data, &decoded); err != nil {
 		t.Fatalf("unmarshal failed: %v", err)
 	}

--- a/internal/provider/codex/codex.go
+++ b/internal/provider/codex/codex.go
@@ -140,7 +140,7 @@ func (s *OAuthStrategy) Fetch(ctx context.Context) (fetch.FetchResult, error) {
 	return s.fetchUsage(ctx, client, usageURL, creds)
 }
 
-func (s *OAuthStrategy) fetchUsage(ctx context.Context, client *httpclient.Client, usageURL string, creds *Credentials) (fetch.FetchResult, error) {
+func (s *OAuthStrategy) fetchUsage(ctx context.Context, client *httpclient.Client, usageURL string, creds *oauth.Credentials) (fetch.FetchResult, error) {
 	var usageResp UsageResponse
 	resp, err := client.GetJSONCtx(ctx, usageURL, &usageResp, httpclient.WithBearer(creds.AccessToken))
 	if err != nil {
@@ -173,7 +173,7 @@ func (s *OAuthStrategy) credentialPaths() []string {
 	return provider.CredentialSearchPaths("codex", "oauth", filepath.Join(home, ".codex", "auth.json"))
 }
 
-func (s *OAuthStrategy) loadCredentials() *Credentials {
+func (s *OAuthStrategy) loadCredentials() *oauth.Credentials {
 	for _, path := range s.credentialPaths() {
 		data, err := config.ReadCredential(path)
 		if err != nil || data == nil {
@@ -190,7 +190,7 @@ func (s *OAuthStrategy) loadCredentials() *Credentials {
 	return s.loadKeychainCredentials()
 }
 
-func (s *OAuthStrategy) loadKeychainCredentials() *Credentials {
+func (s *OAuthStrategy) loadKeychainCredentials() *oauth.Credentials {
 	secret, err := readKeychainSecret(codexKeychainLabel, codexKeychainAccount())
 	if err != nil || secret == "" {
 		return nil
@@ -228,7 +228,7 @@ func codexHomeDir() string {
 	return filepath.Join(home, ".codex")
 }
 
-func (s *OAuthStrategy) refreshToken(ctx context.Context, creds *Credentials) *Credentials {
+func (s *OAuthStrategy) refreshToken(ctx context.Context, creds *oauth.Credentials) *oauth.Credentials {
 	return oauth.Refresh(ctx, creds.RefreshToken, oauth.RefreshConfig{
 		TokenURL:    codexTokenURL,
 		FormFields:  map[string]string{"client_id": codexClientID},

--- a/internal/provider/codex/response.go
+++ b/internal/provider/codex/response.go
@@ -92,25 +92,24 @@ func (c *Credits) Balance() float64 {
 }
 
 // Credentials is an alias for the shared OAuth credential type.
-type Credentials = oauth.Credentials
 
 // CLICredentials represents the Codex CLI credential file format,
 // which may nest tokens under a "tokens" key or be flat.
 type CLICredentials struct {
-	Tokens       *Credentials `json:"tokens,omitempty"`
-	AccessToken  string       `json:"access_token,omitempty"`
-	RefreshToken string       `json:"refresh_token,omitempty"`
-	ExpiresAt    string       `json:"expires_at,omitempty"`
+	Tokens       *oauth.Credentials `json:"tokens,omitempty"`
+	AccessToken  string             `json:"access_token,omitempty"`
+	RefreshToken string             `json:"refresh_token,omitempty"`
+	ExpiresAt    string             `json:"expires_at,omitempty"`
 }
 
 // EffectiveCredentials returns the credentials from whichever format is present.
 // Returns nil if no access token is found.
-func (c *CLICredentials) EffectiveCredentials() *Credentials {
+func (c *CLICredentials) EffectiveCredentials() *oauth.Credentials {
 	if c.Tokens != nil && c.Tokens.AccessToken != "" {
 		return c.Tokens
 	}
 	if c.AccessToken != "" {
-		return &Credentials{
+		return &oauth.Credentials{
 			AccessToken:  c.AccessToken,
 			RefreshToken: c.RefreshToken,
 			ExpiresAt:    c.ExpiresAt,

--- a/internal/provider/codex/response_test.go
+++ b/internal/provider/codex/response_test.go
@@ -3,6 +3,8 @@ package codex
 import (
 	"encoding/json"
 	"testing"
+
+	"github.com/joshuadavidthomas/vibeusage/internal/oauth"
 )
 
 func TestUsageResponse_UnmarshalWithRateLimit(t *testing.T) {
@@ -206,7 +208,7 @@ func TestCredentials_Unmarshal(t *testing.T) {
 		"expires_at": "2025-02-19T22:00:00Z"
 	}`
 
-	var creds Credentials
+	var creds oauth.Credentials
 	if err := json.Unmarshal([]byte(raw), &creds); err != nil {
 		t.Fatalf("unmarshal failed: %v", err)
 	}
@@ -225,34 +227,34 @@ func TestCredentials_Unmarshal(t *testing.T) {
 func TestCredentials_NeedsRefresh(t *testing.T) {
 	tests := []struct {
 		name  string
-		creds Credentials
+		creds oauth.Credentials
 		want  bool
 	}{
 		{
 			name:  "no expiry",
-			creds: Credentials{AccessToken: "tok"},
+			creds: oauth.Credentials{AccessToken: "tok"},
 			want:  false,
 		},
 		{
 			name:  "expired",
-			creds: Credentials{AccessToken: "tok", ExpiresAt: "2020-01-01T00:00:00Z"},
+			creds: oauth.Credentials{AccessToken: "tok", ExpiresAt: "2020-01-01T00:00:00Z"},
 			want:  true,
 		},
 		{
 			name:  "far future",
-			creds: Credentials{AccessToken: "tok", ExpiresAt: "2099-01-01T00:00:00Z"},
+			creds: oauth.Credentials{AccessToken: "tok", ExpiresAt: "2099-01-01T00:00:00Z"},
 			want:  false,
 		},
 		{
 			name:  "invalid date",
-			creds: Credentials{AccessToken: "tok", ExpiresAt: "garbage"},
+			creds: oauth.Credentials{AccessToken: "tok", ExpiresAt: "garbage"},
 			want:  true,
 		},
 	}
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			// Credentials is an alias for oauth.Credentials, which uses a
+			// oauth.Credentials uses a
 			// 5-minute refresh buffer (shared across all providers).
 			got := tt.creds.NeedsRefresh()
 			if got != tt.want {
@@ -353,7 +355,7 @@ func TestCLICredentials_EffectiveCredentials(t *testing.T) {
 }
 
 func TestCredentials_Roundtrip(t *testing.T) {
-	original := Credentials{
+	original := oauth.Credentials{
 		AccessToken:  "my-token",
 		RefreshToken: "my-refresh",
 		ExpiresAt:    "2025-02-19T22:00:00Z",
@@ -364,7 +366,7 @@ func TestCredentials_Roundtrip(t *testing.T) {
 		t.Fatalf("marshal failed: %v", err)
 	}
 
-	var decoded Credentials
+	var decoded oauth.Credentials
 	if err := json.Unmarshal(data, &decoded); err != nil {
 		t.Fatalf("unmarshal failed: %v", err)
 	}

--- a/internal/provider/copilot/copilot.go
+++ b/internal/provider/copilot/copilot.go
@@ -164,12 +164,12 @@ func (s *DeviceFlowStrategy) Fetch(ctx context.Context) (fetch.FetchResult, erro
 	return fetch.ResultOK(*snapshot), nil
 }
 
-func (s *DeviceFlowStrategy) loadCredentials() *OAuthCredentials {
+func (s *DeviceFlowStrategy) loadCredentials() *oauth.Credentials {
 	data, err := config.ReadCredential(config.CredentialPath("copilot", "oauth"))
 	if err != nil || data == nil {
 		return nil
 	}
-	var creds OAuthCredentials
+	var creds oauth.Credentials
 	if err := json.Unmarshal(data, &creds); err != nil {
 		return nil
 	}
@@ -179,7 +179,7 @@ func (s *DeviceFlowStrategy) loadCredentials() *OAuthCredentials {
 	return &creds
 }
 
-func (s *DeviceFlowStrategy) refreshToken(ctx context.Context, creds *OAuthCredentials) *OAuthCredentials {
+func (s *DeviceFlowStrategy) refreshToken(ctx context.Context, creds *oauth.Credentials) *oauth.Credentials {
 	return oauth.Refresh(ctx, creds.RefreshToken, oauth.RefreshConfig{
 		TokenURL:    tokenURL,
 		FormFields:  map[string]string{"client_id": clientID},

--- a/internal/provider/copilot/response.go
+++ b/internal/provider/copilot/response.go
@@ -1,7 +1,5 @@
 package copilot
 
-import "github.com/joshuadavidthomas/vibeusage/internal/oauth"
-
 // UserResponse represents the response from the Copilot user API endpoint.
 type UserResponse struct {
 	QuotaResetDateUTC string          `json:"quota_reset_date_utc,omitempty"`
@@ -41,7 +39,5 @@ func (q *Quota) HasUsage() bool {
 	return q.Unlimited || q.Entitlement > 0
 }
 
-// OAuthCredentials is an alias for the shared OAuth credential type.
 // Legacy credentials with only access_token (no refresh_token/expires_at)
 // are a valid subset and load transparently.
-type OAuthCredentials = oauth.Credentials

--- a/internal/provider/copilot/response_test.go
+++ b/internal/provider/copilot/response_test.go
@@ -3,6 +3,8 @@ package copilot
 import (
 	"encoding/json"
 	"testing"
+
+	"github.com/joshuadavidthomas/vibeusage/internal/oauth"
 )
 
 func TestUserResponse_UnmarshalFullResponse(t *testing.T) {
@@ -153,7 +155,7 @@ func TestOAuthCredentials_UnmarshalLegacy(t *testing.T) {
 	// Legacy format: only access_token, no refresh or expiry
 	raw := `{"access_token": "gho_xxxx"}`
 
-	var creds OAuthCredentials
+	var creds oauth.Credentials
 	if err := json.Unmarshal([]byte(raw), &creds); err != nil {
 		t.Fatalf("unmarshal failed: %v", err)
 	}
@@ -180,7 +182,7 @@ func TestOAuthCredentials_UnmarshalFull(t *testing.T) {
 		"expires_at": "2025-02-20T06:00:00Z"
 	}`
 
-	var creds OAuthCredentials
+	var creds oauth.Credentials
 	if err := json.Unmarshal([]byte(raw), &creds); err != nil {
 		t.Fatalf("unmarshal failed: %v", err)
 	}
@@ -197,7 +199,7 @@ func TestOAuthCredentials_UnmarshalFull(t *testing.T) {
 }
 
 func TestOAuthCredentials_Roundtrip(t *testing.T) {
-	original := OAuthCredentials{
+	original := oauth.Credentials{
 		AccessToken:  "ghu_xxxx",
 		RefreshToken: "ghr_xxxx",
 		ExpiresAt:    "2025-02-20T06:00:00Z",
@@ -208,7 +210,7 @@ func TestOAuthCredentials_Roundtrip(t *testing.T) {
 		t.Fatalf("marshal failed: %v", err)
 	}
 
-	var decoded OAuthCredentials
+	var decoded oauth.Credentials
 	if err := json.Unmarshal(data, &decoded); err != nil {
 		t.Fatalf("unmarshal failed: %v", err)
 	}

--- a/internal/provider/gemini/oauth.go
+++ b/internal/provider/gemini/oauth.go
@@ -13,6 +13,7 @@ import (
 	"github.com/joshuadavidthomas/vibeusage/internal/fetch"
 	"github.com/joshuadavidthomas/vibeusage/internal/httpclient"
 	"github.com/joshuadavidthomas/vibeusage/internal/models"
+	"github.com/joshuadavidthomas/vibeusage/internal/oauth"
 	"github.com/joshuadavidthomas/vibeusage/internal/provider"
 	"github.com/joshuadavidthomas/vibeusage/internal/provider/googleauth"
 )
@@ -85,7 +86,7 @@ func (s *OAuthStrategy) Fetch(ctx context.Context) (fetch.FetchResult, error) {
 	return fetch.ResultOK(*snapshot), nil
 }
 
-func (s *OAuthStrategy) loadCredentials() *googleauth.OAuthCredentials {
+func (s *OAuthStrategy) loadCredentials() *oauth.Credentials {
 	for _, path := range s.credentialPaths() {
 		data, err := config.ReadCredential(path)
 		if err != nil || data == nil {

--- a/internal/provider/gemini/response.go
+++ b/internal/provider/gemini/response.go
@@ -4,6 +4,7 @@ import (
 	"time"
 
 	"github.com/joshuadavidthomas/vibeusage/internal/models"
+	"github.com/joshuadavidthomas/vibeusage/internal/oauth"
 	"github.com/joshuadavidthomas/vibeusage/internal/provider/googleauth"
 )
 
@@ -60,7 +61,7 @@ type GeminiCLIInstalled struct {
 }
 
 // ToOAuthCredentials converts the CLI installed format to OAuthCredentials.
-func (g *GeminiCLIInstalled) ToOAuthCredentials() *googleauth.OAuthCredentials {
+func (g *GeminiCLIInstalled) ToOAuthCredentials() *oauth.Credentials {
 	accessToken := g.Token
 	if accessToken == "" {
 		accessToken = g.AccessToken
@@ -68,7 +69,7 @@ func (g *GeminiCLIInstalled) ToOAuthCredentials() *googleauth.OAuthCredentials {
 	if accessToken == "" {
 		return nil
 	}
-	creds := &googleauth.OAuthCredentials{
+	creds := &oauth.Credentials{
 		AccessToken:  accessToken,
 		RefreshToken: g.RefreshToken,
 	}
@@ -77,14 +78,14 @@ func (g *GeminiCLIInstalled) ToOAuthCredentials() *googleauth.OAuthCredentials {
 }
 
 // EffectiveCredentials returns OAuthCredentials from whichever format is present.
-func (g *GeminiCLICredentials) EffectiveCredentials() *googleauth.OAuthCredentials {
+func (g *GeminiCLICredentials) EffectiveCredentials() *oauth.Credentials {
 	// Try "installed" nested format first
 	if g.Installed != nil {
 		return g.Installed.ToOAuthCredentials()
 	}
 	// Try "token" + "refresh_token" format
 	if g.Token != "" {
-		creds := &googleauth.OAuthCredentials{
+		creds := &oauth.Credentials{
 			AccessToken:  g.Token,
 			RefreshToken: g.RefreshToken,
 		}
@@ -93,7 +94,7 @@ func (g *GeminiCLICredentials) EffectiveCredentials() *googleauth.OAuthCredentia
 	}
 	// Try "access_token" format
 	if g.AccessToken != "" {
-		return &googleauth.OAuthCredentials{
+		return &oauth.Credentials{
 			AccessToken:  g.AccessToken,
 			RefreshToken: g.RefreshToken,
 			ExpiresAt:    g.ExpiresAt,

--- a/internal/provider/googleauth/googleauth.go
+++ b/internal/provider/googleauth/googleauth.go
@@ -15,9 +15,6 @@ const TokenURL = "https://oauth2.googleapis.com/token"
 // TokenResponse represents the response from the Google OAuth token refresh endpoint.
 type TokenResponse = oauth.TokenResponse
 
-// OAuthCredentials represents stored Google OAuth credentials.
-type OAuthCredentials = oauth.Credentials
-
 // RefreshConfig contains the provider-specific parameters for token refresh.
 type RefreshConfig struct {
 	ClientID     string
@@ -28,7 +25,7 @@ type RefreshConfig struct {
 
 // RefreshToken refreshes an expired Google OAuth token and saves the updated
 // credentials to disk. Returns nil if the refresh fails.
-func RefreshToken(ctx context.Context, creds *OAuthCredentials, cfg RefreshConfig) *OAuthCredentials {
+func RefreshToken(ctx context.Context, creds *oauth.Credentials, cfg RefreshConfig) *oauth.Credentials {
 	return oauth.Refresh(ctx, creds.RefreshToken, oauth.RefreshConfig{
 		TokenURL: TokenURL,
 		FormFields: map[string]string{

--- a/internal/provider/googleauth/googleauth_test.go
+++ b/internal/provider/googleauth/googleauth_test.go
@@ -4,6 +4,8 @@ import (
 	"encoding/json"
 	"testing"
 	"time"
+
+	"github.com/joshuadavidthomas/vibeusage/internal/oauth"
 )
 
 func TestTokenResponse_Unmarshal(t *testing.T) {
@@ -36,7 +38,7 @@ func TestOAuthCredentials_Unmarshal(t *testing.T) {
 		"expires_at": "2025-02-20T00:00:00Z"
 	}`
 
-	var creds OAuthCredentials
+	var creds oauth.Credentials
 	if err := json.Unmarshal([]byte(raw), &creds); err != nil {
 		t.Fatalf("unmarshal failed: %v", err)
 	}
@@ -49,32 +51,32 @@ func TestOAuthCredentials_Unmarshal(t *testing.T) {
 func TestOAuthCredentials_NeedsRefresh(t *testing.T) {
 	tests := []struct {
 		name  string
-		creds OAuthCredentials
+		creds oauth.Credentials
 		want  bool
 	}{
 		{
 			name:  "no expiry",
-			creds: OAuthCredentials{AccessToken: "tok"},
+			creds: oauth.Credentials{AccessToken: "tok"},
 			want:  false,
 		},
 		{
 			name:  "expired",
-			creds: OAuthCredentials{AccessToken: "tok", ExpiresAt: "2020-01-01T00:00:00Z"},
+			creds: oauth.Credentials{AccessToken: "tok", ExpiresAt: "2020-01-01T00:00:00Z"},
 			want:  true,
 		},
 		{
 			name:  "far future",
-			creds: OAuthCredentials{AccessToken: "tok", ExpiresAt: "2099-01-01T00:00:00Z"},
+			creds: oauth.Credentials{AccessToken: "tok", ExpiresAt: "2099-01-01T00:00:00Z"},
 			want:  false,
 		},
 		{
 			name:  "invalid",
-			creds: OAuthCredentials{AccessToken: "tok", ExpiresAt: "garbage"},
+			creds: oauth.Credentials{AccessToken: "tok", ExpiresAt: "garbage"},
 			want:  true,
 		},
 		{
 			name: "within buffer",
-			creds: OAuthCredentials{
+			creds: oauth.Credentials{
 				AccessToken: "tok",
 				ExpiresAt:   time.Now().UTC().Add(2 * time.Minute).Format(time.RFC3339),
 			},
@@ -82,7 +84,7 @@ func TestOAuthCredentials_NeedsRefresh(t *testing.T) {
 		},
 		{
 			name: "outside buffer",
-			creds: OAuthCredentials{
+			creds: oauth.Credentials{
 				AccessToken: "tok",
 				ExpiresAt:   time.Now().UTC().Add(10 * time.Minute).Format(time.RFC3339),
 			},
@@ -101,7 +103,7 @@ func TestOAuthCredentials_NeedsRefresh(t *testing.T) {
 }
 
 func TestOAuthCredentials_Roundtrip(t *testing.T) {
-	original := OAuthCredentials{
+	original := oauth.Credentials{
 		AccessToken:  "my-token",
 		RefreshToken: "my-refresh",
 		ExpiresAt:    "2025-02-20T00:00:00Z",
@@ -112,7 +114,7 @@ func TestOAuthCredentials_Roundtrip(t *testing.T) {
 		t.Fatalf("marshal failed: %v", err)
 	}
 
-	var decoded OAuthCredentials
+	var decoded oauth.Credentials
 	if err := json.Unmarshal(data, &decoded); err != nil {
 		t.Fatalf("unmarshal failed: %v", err)
 	}

--- a/internal/provider/kimicode/device.go
+++ b/internal/provider/kimicode/device.go
@@ -67,7 +67,7 @@ func (s *DeviceFlowStrategy) Fetch(ctx context.Context) (fetch.FetchResult, erro
 	return fetchUsage(ctx, creds.AccessToken, "device_flow", s.HTTPTimeout)
 }
 
-func (s *DeviceFlowStrategy) loadCredentials() *OAuthCredentials {
+func (s *DeviceFlowStrategy) loadCredentials() *oauth.Credentials {
 	for _, path := range s.credentialPaths() {
 		data, err := config.ReadCredential(path)
 		if err != nil || data == nil {
@@ -75,7 +75,7 @@ func (s *DeviceFlowStrategy) loadCredentials() *OAuthCredentials {
 		}
 
 		// Try current RFC3339 format first
-		var creds OAuthCredentials
+		var creds oauth.Credentials
 		if err := json.Unmarshal(data, &creds); err == nil && creds.AccessToken != "" {
 			// If ExpiresAt looks like a number string, it might be a
 			// partially-migrated legacy credential; skip to migration.
@@ -96,7 +96,7 @@ func (s *DeviceFlowStrategy) loadCredentials() *OAuthCredentials {
 	return nil
 }
 
-func (s *DeviceFlowStrategy) refreshToken(ctx context.Context, creds *OAuthCredentials) *OAuthCredentials {
+func (s *DeviceFlowStrategy) refreshToken(ctx context.Context, creds *oauth.Credentials) *oauth.Credentials {
 	return oauth.Refresh(ctx, creds.RefreshToken, oauth.RefreshConfig{
 		TokenURL:    oauthBaseURL() + tokenPath,
 		FormFields:  map[string]string{"client_id": clientID},

--- a/internal/provider/kimicode/response.go
+++ b/internal/provider/kimicode/response.go
@@ -122,9 +122,6 @@ func (w Window) DisplayName() string {
 	}
 }
 
-// OAuthCredentials is an alias for the shared OAuth credential type.
-type OAuthCredentials = oauth.Credentials
-
 // legacyOAuthCredentials represents the old Kimi credential format with a
 // float64 Unix timestamp for ExpiresAt.
 type legacyOAuthCredentials struct {
@@ -135,7 +132,7 @@ type legacyOAuthCredentials struct {
 
 // migrateCredentials converts legacy float64-timestamp credentials to RFC3339.
 // Returns nil if the data doesn't match the legacy format.
-func migrateCredentials(data []byte) *OAuthCredentials {
+func migrateCredentials(data []byte) *oauth.Credentials {
 	var legacy legacyOAuthCredentials
 	if err := json.Unmarshal(data, &legacy); err != nil || legacy.AccessToken == "" {
 		return nil
@@ -145,7 +142,7 @@ func migrateCredentials(data []byte) *OAuthCredentials {
 	if legacy.ExpiresAt == 0 {
 		return nil
 	}
-	creds := &OAuthCredentials{
+	creds := &oauth.Credentials{
 		AccessToken:  legacy.AccessToken,
 		RefreshToken: legacy.RefreshToken,
 	}

--- a/internal/provider/kimicode/response_test.go
+++ b/internal/provider/kimicode/response_test.go
@@ -6,6 +6,7 @@ import (
 	"time"
 
 	"github.com/joshuadavidthomas/vibeusage/internal/models"
+	"github.com/joshuadavidthomas/vibeusage/internal/oauth"
 )
 
 func TestUsageResponse_UnmarshalFullResponse(t *testing.T) {
@@ -294,32 +295,32 @@ func TestPlanName(t *testing.T) {
 func TestOAuthCredentials_NeedsRefresh(t *testing.T) {
 	tests := []struct {
 		name string
-		c    OAuthCredentials
+		c    oauth.Credentials
 		want bool
 	}{
 		{
 			name: "no expiry",
-			c:    OAuthCredentials{AccessToken: "tok"},
+			c:    oauth.Credentials{AccessToken: "tok"},
 			want: false,
 		},
 		{
 			name: "far future",
-			c:    OAuthCredentials{AccessToken: "tok", ExpiresAt: "2099-01-01T00:00:00Z"},
+			c:    oauth.Credentials{AccessToken: "tok", ExpiresAt: "2099-01-01T00:00:00Z"},
 			want: false,
 		},
 		{
 			name: "already expired",
-			c:    OAuthCredentials{AccessToken: "tok", ExpiresAt: "2020-01-01T00:00:00Z"},
+			c:    oauth.Credentials{AccessToken: "tok", ExpiresAt: "2020-01-01T00:00:00Z"},
 			want: true,
 		},
 		{
 			name: "within buffer",
-			c:    OAuthCredentials{AccessToken: "tok", ExpiresAt: time.Now().UTC().Add(2 * time.Minute).Format(time.RFC3339)},
+			c:    oauth.Credentials{AccessToken: "tok", ExpiresAt: time.Now().UTC().Add(2 * time.Minute).Format(time.RFC3339)},
 			want: true,
 		},
 		{
 			name: "outside buffer",
-			c:    OAuthCredentials{AccessToken: "tok", ExpiresAt: time.Now().UTC().Add(10 * time.Minute).Format(time.RFC3339)},
+			c:    oauth.Credentials{AccessToken: "tok", ExpiresAt: time.Now().UTC().Add(10 * time.Minute).Format(time.RFC3339)},
 			want: false,
 		},
 	}
@@ -335,7 +336,7 @@ func TestOAuthCredentials_NeedsRefresh(t *testing.T) {
 }
 
 func TestOAuthCredentials_Roundtrip(t *testing.T) {
-	original := OAuthCredentials{
+	original := oauth.Credentials{
 		AccessToken:  "tok",
 		RefreshToken: "rt",
 		ExpiresAt:    "2025-02-19T21:20:00Z",
@@ -346,7 +347,7 @@ func TestOAuthCredentials_Roundtrip(t *testing.T) {
 		t.Fatalf("marshal failed: %v", err)
 	}
 
-	var decoded OAuthCredentials
+	var decoded oauth.Credentials
 	if err := json.Unmarshal(data, &decoded); err != nil {
 		t.Fatalf("unmarshal failed: %v", err)
 	}


### PR DESCRIPTION
Five providers had `type XCredentials = oauth.Credentials` aliases that added a layer of indirection without value. Replaced all usages across 20 files with `oauth.Credentials` directly.

Aliases removed:
- `claude.OAuthCredentials`
- `codex.Credentials`
- `copilot.OAuthCredentials`
- `kimicode.OAuthCredentials`
- `googleauth.OAuthCredentials`

Also updated `gemini` and `antigravity` which referenced `googleauth.OAuthCredentials`.