### PR TITLE
Audit Kimi Code provider response structs against live API

### DIFF
--- a/internal/provider/kimicode/kimicode_test.go
+++ b/internal/provider/kimicode/kimicode_test.go
@@ -61,6 +61,7 @@ func TestParseUsageResponse_FullResponse(t *testing.T) {
 		},
 		Usage: &UsageDetail{
 			Limit:     "100",
+			Used:      "40",
 			Remaining: "60",
 			ResetTime: "2026-03-01T00:00:00Z",
 		},


### PR DESCRIPTION
Compared the typed response structs against the live Kimi Code API response. Found one missing field and updated the utilization calculation.

## Changes

- **Add `Used` field to `UsageDetail`** — the live API returns an explicit `used` count in the top-level `usage` object (`"used": "9"`) alongside `limit` and `remaining`
- **Update `Utilization()`** to prefer the explicit `used` field when present, falling back to the `limit - remaining` calculation for limit detail entries that don't include `used`
- **Update tests** for unmarshal, utilization calculation with/without the field, and omission in limit details

## Live API Response

```json
{
    "user": {
        "userId": "...",
        "region": "REGION_OVERSEA",
        "membership": { "level": "LEVEL_BASIC" },
        "businessId": ""
    },
    "usage": {
        "limit": "100",
        "used": "9",          ← NEW — was not captured
        "remaining": "91",
        "resetTime": "2026-03-04T04:01:38Z"
    },
    "limits": [{
        "window": { "duration": 300, "timeUnit": "TIME_UNIT_MINUTE" },
        "detail": { "limit": "100", "remaining": "100", "resetTime": "..." }
    }]
}
```

## Detail View Assessment

All fields from the API are now captured in typed structs. Observations on rendering:

- **`userId`/`region`**: Captured in structs but not displayed. Surfacing them would require adding fields to `ProviderIdentity` (currently only Email/Organization/Plan)
- **`used` raw count**: Now captured and used in utilization calculation. Showing raw counts (e.g. "9/100") instead of just percentages would require adding Used/Limit fields to `UsagePeriod`
- **`businessId`**: Always empty in testing — likely for enterprise/team accounts

Closes #125