### PR TITLE
Audit MiniMax provider response structs against live API

### DIFF
--- a/internal/provider/minimax/response_test.go
+++ b/internal/provider/minimax/response_test.go
@@ -67,6 +67,9 @@ func TestCodingPlanResponse_UnmarshalFullResponse(t *testing.T) {
 	if m.EndTime != 1771668000000 {
 		t.Errorf("end_time = %d, want 1771668000000", m.EndTime)
 	}
+	if m.RemainsTime != 8196068 {
+		t.Errorf("remains_time = %d, want 8196068", m.RemainsTime)
+	}
 	if m.CurrentIntervalTotalCount != 1500 {
 		t.Errorf("total_count = %d, want 1500", m.CurrentIntervalTotalCount)
 	}


### PR DESCRIPTION
## Audit Results

Curled the live MiniMax Coding Plan API (`/v1/api/openplatform/coding_plan/remains`) and compared against `internal/provider/minimax/response.go`.

**All fields are already captured.** The API response is straightforward:

### Live API Response Shape

```json
{
  "model_remains": [
    {
      "start_time": 1772254800000,
      "end_time": 1772272800000,
      "remains_time": 16055394,
      "current_interval_total_count": 1500,
      "current_interval_usage_count": 1500,
      "model_name": "MiniMax-M2"
    },
    // ... MiniMax-M2.1, MiniMax-M2.5
  ],
  "base_resp": {
    "status_code": 0,
    "status_msg": "success"
  }
}
```

### Field Coverage

| API Field | Struct Field | Status |
|-----------|-------------|--------|
| `model_remains[].start_time` | `ModelRemain.StartTime` | ✅ |
| `model_remains[].end_time` | `ModelRemain.EndTime` | ✅ |
| `model_remains[].remains_time` | `ModelRemain.RemainsTime` | ✅ |
| `model_remains[].current_interval_total_count` | `ModelRemain.CurrentIntervalTotalCount` | ✅ |
| `model_remains[].current_interval_usage_count` | `ModelRemain.CurrentIntervalUsageCount` | ✅ |
| `model_remains[].model_name` | `ModelRemain.ModelName` | ✅ |
| `base_resp.status_code` | `BaseResp.StatusCode` | ✅ |
| `base_resp.status_msg` | `BaseResp.StatusMsg` | ✅ |
| Top-level `status_code` (error shape) | `CodingPlanResponse.StatusCode` | ✅ |
| Top-level `status_msg` (error shape) | `CodingPlanResponse.StatusMsg` | ✅ |

### Changes

- Added explicit `RemainsTime` assertion to unmarshal test (was in the JSON fixture but not directly asserted)

### Rendering Review

The detail view currently renders:
- **Plan** (inferred from total count via `InferPlan`)
- **Per-model usage bars** with utilization percentage
- **Reset countdown** from `EndTime`
- **Source** label ("api_key")

**Potentially useful data not currently rendered:**
- **Absolute remaining count** (e.g., "750 / 1500 prompts remaining") — `ModelRemain` has both `CurrentIntervalUsageCount` (remaining) and `CurrentIntervalTotalCount` but `UsagePeriod` only stores a percentage (`Utilization`). Showing absolute counts would require adding `Used`/`Total`/`RemainingCount` fields to `UsagePeriod` or a similar mechanism, plus rendering changes.
- `RemainsTime` and `StartTime` are redundant with `EndTime` for display purposes (the display layer already computes countdown from `ResetsAt`).

No new rendering infrastructure is needed for the current field set. The absolute-counts enhancement would be a cross-provider feature since other providers (Cursor, Copilot, etc.) also have absolute usage data that gets collapsed to percentages.

Closes #126