### PR TITLE
Audit OpenRouter provider response structs against live API

### DIFF
--- a/internal/provider/openrouter/openrouter.go
+++ b/internal/provider/openrouter/openrouter.go
@@ -96,15 +96,6 @@ func fetchCredits(ctx context.Context, token string, httpTimeout float64) (fetch
 	return fetch.ResultOK(*snapshot), nil
 }
 
-type CreditsResponse struct {
-	Data CreditsData `json:"data"`
-}
-
-type CreditsData struct {
-	TotalCredits float64 `json:"total_credits"`
-	TotalUsage   float64 `json:"total_usage"`
-}
-
 func parseCreditsSnapshot(resp CreditsResponse) (*models.UsageSnapshot, error) {
 	total := resp.Data.TotalCredits
 	used := resp.Data.TotalUsage

--- a/internal/provider/openrouter/response.go
+++ b/internal/provider/openrouter/response.go
@@ -1,0 +1,45 @@
+package openrouter
+
+// CreditsResponse represents the response from the OpenRouter credits endpoint
+// (GET /api/v1/credits).
+type CreditsResponse struct {
+	Data CreditsData `json:"data"`
+}
+
+// CreditsData contains credit balance information.
+type CreditsData struct {
+	TotalCredits float64 `json:"total_credits"` // total credits purchased
+	TotalUsage   float64 `json:"total_usage"`   // total credits consumed
+}
+
+// KeyResponse represents the response from the OpenRouter key info endpoint
+// (GET /api/v1/key). This provides richer account data than /api/v1/credits
+// including tier, usage breakdowns, and rate limits.
+type KeyResponse struct {
+	Data KeyData `json:"data"`
+}
+
+// KeyData contains API key metadata, tier information, and usage breakdowns.
+type KeyData struct {
+	Label              string   `json:"label"`
+	IsFreeTier         bool     `json:"is_free_tier"`
+	Limit              *float64 `json:"limit"`
+	LimitReset         *string  `json:"limit_reset"`
+	LimitRemaining     *float64 `json:"limit_remaining"`
+	IncludeBYOKInLimit bool     `json:"include_byok_in_limit"`
+	Usage              float64  `json:"usage"`
+	UsageDaily         float64  `json:"usage_daily"`
+	UsageWeekly        float64  `json:"usage_weekly"`
+	UsageMonthly       float64  `json:"usage_monthly"`
+	BYOKUsage          float64  `json:"byok_usage"`
+	BYOKUsageDaily     float64  `json:"byok_usage_daily"`
+	BYOKUsageWeekly    float64  `json:"byok_usage_weekly"`
+	BYOKUsageMonthly   float64  `json:"byok_usage_monthly"`
+	RateLimit          KeyRate  `json:"rate_limit"`
+}
+
+// KeyRate contains rate limit information for the API key.
+type KeyRate struct {
+	Requests int `json:"requests"`
+	Interval int `json:"interval"`
+}

--- a/internal/provider/openrouter/response_test.go
+++ b/internal/provider/openrouter/response_test.go
@@ -1,0 +1,167 @@
+package openrouter
+
+import (
+	"encoding/json"
+	"testing"
+)
+
+func TestCreditsResponse_UnmarshalFullResponse(t *testing.T) {
+	raw := `{
+		"data": {
+			"total_credits": 50.0,
+			"total_usage": 12.75
+		}
+	}`
+
+	var resp CreditsResponse
+	if err := json.Unmarshal([]byte(raw), &resp); err != nil {
+		t.Fatalf("unmarshal failed: %v", err)
+	}
+
+	if resp.Data.TotalCredits != 50.0 {
+		t.Errorf("total_credits = %f, want 50.0", resp.Data.TotalCredits)
+	}
+	if resp.Data.TotalUsage != 12.75 {
+		t.Errorf("total_usage = %f, want 12.75", resp.Data.TotalUsage)
+	}
+}
+
+func TestCreditsResponse_UnmarshalZeroBalance(t *testing.T) {
+	raw := `{"data": {"total_credits": 0, "total_usage": 0}}`
+
+	var resp CreditsResponse
+	if err := json.Unmarshal([]byte(raw), &resp); err != nil {
+		t.Fatalf("unmarshal failed: %v", err)
+	}
+
+	if resp.Data.TotalCredits != 0 {
+		t.Errorf("total_credits = %f, want 0", resp.Data.TotalCredits)
+	}
+	if resp.Data.TotalUsage != 0 {
+		t.Errorf("total_usage = %f, want 0", resp.Data.TotalUsage)
+	}
+}
+
+func TestKeyResponse_UnmarshalFullResponse(t *testing.T) {
+	raw := `{
+		"data": {
+			"label": "my-key",
+			"is_free_tier": false,
+			"limit": 100.0,
+			"limit_reset": "monthly",
+			"limit_remaining": 75.5,
+			"include_byok_in_limit": false,
+			"usage": 24.5,
+			"usage_daily": 5.0,
+			"usage_weekly": 15.0,
+			"usage_monthly": 24.5,
+			"byok_usage": 0,
+			"byok_usage_daily": 0,
+			"byok_usage_weekly": 0,
+			"byok_usage_monthly": 0,
+			"rate_limit": {
+				"requests": 200,
+				"interval": 10
+			}
+		}
+	}`
+
+	var resp KeyResponse
+	if err := json.Unmarshal([]byte(raw), &resp); err != nil {
+		t.Fatalf("unmarshal failed: %v", err)
+	}
+
+	d := resp.Data
+	if d.Label != "my-key" {
+		t.Errorf("label = %q, want %q", d.Label, "my-key")
+	}
+	if d.IsFreeTier {
+		t.Error("is_free_tier = true, want false")
+	}
+	if d.Limit == nil || *d.Limit != 100.0 {
+		t.Errorf("limit = %v, want 100.0", d.Limit)
+	}
+	if d.LimitReset == nil || *d.LimitReset != "monthly" {
+		t.Errorf("limit_reset = %v, want %q", d.LimitReset, "monthly")
+	}
+	if d.LimitRemaining == nil || *d.LimitRemaining != 75.5 {
+		t.Errorf("limit_remaining = %v, want 75.5", d.LimitRemaining)
+	}
+	if d.IncludeBYOKInLimit {
+		t.Error("include_byok_in_limit = true, want false")
+	}
+	if d.Usage != 24.5 {
+		t.Errorf("usage = %f, want 24.5", d.Usage)
+	}
+	if d.UsageDaily != 5.0 {
+		t.Errorf("usage_daily = %f, want 5.0", d.UsageDaily)
+	}
+	if d.UsageWeekly != 15.0 {
+		t.Errorf("usage_weekly = %f, want 15.0", d.UsageWeekly)
+	}
+	if d.UsageMonthly != 24.5 {
+		t.Errorf("usage_monthly = %f, want 24.5", d.UsageMonthly)
+	}
+	if d.BYOKUsage != 0 {
+		t.Errorf("byok_usage = %f, want 0", d.BYOKUsage)
+	}
+	if d.BYOKUsageDaily != 0 {
+		t.Errorf("byok_usage_daily = %f, want 0", d.BYOKUsageDaily)
+	}
+	if d.BYOKUsageWeekly != 0 {
+		t.Errorf("byok_usage_weekly = %f, want 0", d.BYOKUsageWeekly)
+	}
+	if d.BYOKUsageMonthly != 0 {
+		t.Errorf("byok_usage_monthly = %f, want 0", d.BYOKUsageMonthly)
+	}
+	if d.RateLimit.Requests != 200 {
+		t.Errorf("rate_limit.requests = %d, want 200", d.RateLimit.Requests)
+	}
+	if d.RateLimit.Interval != 10 {
+		t.Errorf("rate_limit.interval = %d, want 10", d.RateLimit.Interval)
+	}
+}
+
+func TestKeyResponse_UnmarshalFreeTier(t *testing.T) {
+	raw := `{
+		"data": {
+			"label": "",
+			"is_free_tier": true,
+			"limit": null,
+			"limit_reset": null,
+			"limit_remaining": null,
+			"include_byok_in_limit": false,
+			"usage": 0.5,
+			"usage_daily": 0.1,
+			"usage_weekly": 0.3,
+			"usage_monthly": 0.5,
+			"byok_usage": 0,
+			"byok_usage_daily": 0,
+			"byok_usage_weekly": 0,
+			"byok_usage_monthly": 0,
+			"rate_limit": {
+				"requests": 10,
+				"interval": 10
+			}
+		}
+	}`
+
+	var resp KeyResponse
+	if err := json.Unmarshal([]byte(raw), &resp); err != nil {
+		t.Fatalf("unmarshal failed: %v", err)
+	}
+
+	d := resp.Data
+	if !d.IsFreeTier {
+		t.Error("is_free_tier = false, want true")
+	}
+	if d.Limit != nil {
+		t.Errorf("limit = %v, want nil", d.Limit)
+	}
+	if d.LimitReset != nil {
+		t.Errorf("limit_reset = %v, want nil", d.LimitReset)
+	}
+	if d.LimitRemaining != nil {
+		t.Errorf("limit_remaining = %v, want nil", d.LimitRemaining)
+	}
+}


### PR DESCRIPTION
## Audit Results

Audited the OpenRouter provider response structs against the API documentation and multiple third-party implementations (no OpenRouter credentials available locally for a live curl, so this is a documentation/code-based audit).

### `/api/v1/credits` — All fields captured ✅

The credits endpoint returns only two fields, both already captured:

| API Field | Struct Field | Status |
|-----------|-------------|--------|
| `data.total_credits` | `CreditsData.TotalCredits` | ✅ |
| `data.total_usage` | `CreditsData.TotalUsage` | ✅ |

Verified against: [socrates8300/openrouter_api](https://github.com/socrates8300/openrouter_api/blob/main/src/types/credits.rs), [steipete/CodexBar](https://github.com/steipete/CodexBar), [songquanpeng/one-api](https://github.com/songquanpeng/one-api), and the official OpenRouter docs.

### `/api/v1/key` — New typed structs added

Discovered that OpenRouter provides a much richer `/api/v1/key` endpoint that returns account tier, usage breakdowns, and rate limits. Added typed `KeyResponse`/`KeyData`/`KeyRate` structs for this endpoint (not yet fetched — structs only):

| Field | Type | Notes |
|-------|------|-------|
| `label` | string | Key label |
| `is_free_tier` | bool | Whether user has ever paid |
| `limit` | *float64 | Credit limit (null if unlimited) |
| `limit_reset` | *string | Reset period type (null if no limit) |
| `limit_remaining` | *float64 | Remaining credits toward limit |
| `include_byok_in_limit` | bool | Count BYOK usage in limit |
| `usage` | float64 | All-time usage |
| `usage_daily` | float64 | Daily usage |
| `usage_weekly` | float64 | Weekly usage |
| `usage_monthly` | float64 | Monthly usage |
| `byok_usage` | float64 | All-time BYOK usage |
| `byok_usage_{daily,weekly,monthly}` | float64 | BYOK breakdowns |
| `rate_limit.requests` | int | Request limit |
| `rate_limit.interval` | int | Interval for rate limit |

### Changes

- **Extracted** `CreditsResponse`/`CreditsData` from `openrouter.go` to `response.go` (consistency with other providers)
- **Added** `KeyResponse`/`KeyData`/`KeyRate` structs for the `/api/v1/key` endpoint
- **Added** `response_test.go` with JSON unmarshal tests for both endpoints

### Rendering Review

The detail view currently renders:
- **Credits period** as a monthly utilization bar (`used / total * 100`)
- **Overage** section with dollar amounts (Used / Limit)

**Useful data from `/api/v1/key` not yet rendered:**
- **Tier** (`is_free_tier`) → could map to `ProviderIdentity.Plan` ("Free" / "Paid")
- **Usage breakdowns** (`usage_daily`, `usage_weekly`, `usage_monthly`) → natural fit for multi-period display (daily/weekly/monthly bars)
- **Key label** → could show which key is being used
- **Rate limits** → no current rendering infrastructure for request rate limits (separate from usage quotas)

Fetching `/api/v1/key` alongside `/api/v1/credits` would be a follow-up enhancement — the structs are ready.

### Note on verification

No OpenRouter API key was available in the sandbox or environment. The audit was performed against official OpenRouter documentation and corroborated with implementations from 4+ open-source projects. If a live curl is required, credentials would need to be set up first via `vibeusage auth openrouter`.

Closes #127