### PR TITLE
Audit Z.ai provider response structs against live API

### DIFF
--- a/internal/provider/zai/response_test.go
+++ b/internal/provider/zai/response_test.go
@@ -84,11 +84,26 @@ func TestQuotaResponse_UnmarshalFullResponse(t *testing.T) {
 	if timeLim.Type != "TIME_LIMIT" {
 		t.Errorf("type = %q, want %q", timeLim.Type, "TIME_LIMIT")
 	}
+	if timeLim.Unit != 5 {
+		t.Errorf("unit = %d, want 5", timeLim.Unit)
+	}
+	if timeLim.Number != 1 {
+		t.Errorf("number = %d, want 1", timeLim.Number)
+	}
 	if timeLim.Usage != 1000 {
 		t.Errorf("usage = %d, want 1000", timeLim.Usage)
 	}
+	if timeLim.CurrentValue != 0 {
+		t.Errorf("currentValue = %d, want 0", timeLim.CurrentValue)
+	}
 	if timeLim.Remaining != 1000 {
 		t.Errorf("remaining = %d, want 1000", timeLim.Remaining)
+	}
+	if timeLim.Percentage != 0 {
+		t.Errorf("percentage = %d, want 0", timeLim.Percentage)
+	}
+	if timeLim.NextResetTime != 1773596236985 {
+		t.Errorf("nextResetTime = %d, want 1773596236985", timeLim.NextResetTime)
 	}
 	if len(timeLim.UsageDetails) != 3 {
 		t.Fatalf("expected 3 usage details, got %d", len(timeLim.UsageDetails))


### PR DESCRIPTION
## Audit Results

Curled the live Z.ai quota/limit API (`https://api.z.ai/api/monitor/usage/quota/limit`) and compared against `internal/provider/zai/response.go`.

**All fields are already captured.** The response shape is straightforward:

### Live API Response Shape

```json
{
  "code": 200,
  "msg": "Operation successful",
  "data": {
    "limits": [
      {
        "type": "TIME_LIMIT",
        "unit": 5,
        "number": 1,
        "usage": 1000,
        "currentValue": 0,
        "remaining": 1000,
        "percentage": 0,
        "nextResetTime": 1773596236982,
        "usageDetails": [
          {"modelCode": "search-prime", "usage": 0},
          {"modelCode": "web-reader", "usage": 0},
          {"modelCode": "zread", "usage": 0}
        ]
      },
      {
        "type": "TOKENS_LIMIT",
        "unit": 3,
        "number": 5,
        "percentage": 1,
        "nextResetTime": 1772272043542
      }
    ],
    "level": "pro"
  },
  "success": true
}
```

### Field Coverage

| API Field | Struct Field | Status |
|-----------|-------------|--------|
| `code` | `QuotaResponse.Code` | ✅ |
| `msg` | `QuotaResponse.Msg` | ✅ |
| `success` | `QuotaResponse.Success` | ✅ |
| `data` | `QuotaResponse.Data` | ✅ |
| `data.level` | `QuotaData.Level` | ✅ |
| `data.limits` | `QuotaData.Limits` | ✅ |
| `limits[].type` | `QuotaLimit.Type` | ✅ |
| `limits[].unit` | `QuotaLimit.Unit` | ✅ |
| `limits[].number` | `QuotaLimit.Number` | ✅ |
| `limits[].percentage` | `QuotaLimit.Percentage` | ✅ |
| `limits[].nextResetTime` | `QuotaLimit.NextResetTime` | ✅ |
| `limits[].usage` | `QuotaLimit.Usage` | ✅ |
| `limits[].currentValue` | `QuotaLimit.CurrentValue` | ✅ |
| `limits[].remaining` | `QuotaLimit.Remaining` | ✅ |
| `limits[].usageDetails` | `QuotaLimit.UsageDetails` | ✅ |
| `usageDetails[].modelCode` | `UsageDetail.ModelCode` | ✅ |
| `usageDetails[].usage` | `UsageDetail.Usage` | ✅ |

### Changes

- Added missing assertions for `unit`, `number`, `currentValue`, `percentage`, and `nextResetTime` on the TIME_LIMIT entry in the unmarshal test (fields were in the JSON fixture but not directly asserted)

### Rendering Review

The detail view currently renders:
- **Plan** (from `QuotaData.Level` → `ProviderIdentity.Plan`: "Pro")
- **Auth source** ("API Key")
- **Session (5h)** — TOKENS_LIMIT with utilization bar and reset countdown
- **Monthly Tools** — TIME_LIMIT with utilization bar and reset countdown

**Captured but not currently rendered:**
- **Absolute counts** (`Usage`, `CurrentValue`, `Remaining`) — e.g., "0 / 1000 tool uses" for TIME_LIMIT entries. `UsagePeriod` only carries a percentage (`Utilization`), so showing absolute counts would require adding `Used`/`Total`/`RemainingCount` fields to `UsagePeriod` plus rendering changes. This is the same cross-provider pattern noted in the MiniMax audit (#126) — Cursor, Copilot, and others also collapse absolute data to percentages.
- **Per-tool breakdown** (`UsageDetails`) — search-prime, web-reader, zread usage counts within the TIME_LIMIT. These could be rendered as model-specific sub-periods in the detail view, but since the API only provides absolute counts per tool (not per-tool percentages or limits), computing utilization bars isn't possible without assumptions. Could be shown as a simple count list instead.

No new rendering infrastructure is needed for the current field set. Both enhancements (absolute counts and per-tool breakdowns) would be cross-provider features.

Closes #129