### PR TITLE
Add 1s fresh snapshot reuse for bursty CLI calls

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,10 @@ and this project attempts to adhere to [Semantic Versioning](https://semver.org/
 
 ## [Unreleased]
 
+### Changed
+
+- Repeated CLI invocations now reuse a successful snapshot for 1 second before refetching. This protects scripts, statuslines, and other programmatic uses from accidentally spamming provider calls while keeping output effectively live. Use `--no-cache` to force a fresh fetch every time.
+
 ## [0.5.0]
 
 ### Added

--- a/README.md
+++ b/README.md
@@ -93,7 +93,9 @@ vibeusage --json
 vibeusage usage codex --json
 ```
 
-Skip cache and fail fast if APIs are unreachable:
+For scripts, widgets, and statuslines, vibeusage reuses a successful snapshot for 1 second before refetching. That keeps output effectively live while protecting you from accidentally hammering the same provider with bursty repeat calls.
+
+Skip cached snapshots entirely and always fetch live:
 
 ```bash
 vibeusage --no-cache
@@ -366,7 +368,7 @@ The following arguments are available globally for every command:
 | `--no-color` | | Disable colored output |
 | `--verbose` | `-v` | Show detailed output |
 | `--quiet` | `-q` | Minimal output |
-| `--no-cache` | | Disable cache fallback on API failure |
+| `--no-cache` | | Disable cached snapshot reuse and fallback |
 
 ## Configuration
 
@@ -455,13 +457,18 @@ Then run `vibeusage auth --status` again.
 
 ### Clearing the cache
 
-vibeusage caches usage data to gracefully handle API failures. If you see `(2h ago)` in output, the API was down and cached data was served. To clear this cache:
+vibeusage caches usage data in two ways:
+
+- very recent successful snapshots are reused for up to 1 second to avoid bursty repeat fetches from scripts and statuslines
+- older snapshots are kept as a fallback when an API call fails
+
+If you see `(2h ago)` in output, the API was down and cached data was served. To clear this cache:
 
 ```bash
 rm -rf "$(vibeusage config path --cache)"
 ```
 
-Use `--no-cache` to bypass the cache and fail fast if the API is unreachable.
+Use `--no-cache` to bypass both 1-second snapshot reuse and stale fallback, and fail fast if the API is unreachable.
 
 ## Updating
 

--- a/internal/cli/root.go
+++ b/internal/cli/root.go
@@ -35,6 +35,8 @@ import (
 // version is injected at build time via -ldflags.
 var version = "dev"
 
+const freshSnapshotReuseTTL = time.Second
+
 var (
 	jsonOutput bool
 	noColor    bool
@@ -77,7 +79,7 @@ func init() {
 	rootCmd.PersistentFlags().BoolVar(&noColor, "no-color", false, "Disable colored output")
 	rootCmd.PersistentFlags().BoolVarP(&verbose, "verbose", "v", false, "Show detailed output")
 	rootCmd.PersistentFlags().BoolVarP(&quiet, "quiet", "q", false, "Minimal output")
-	rootCmd.PersistentFlags().BoolVar(&noCache, "no-cache", false, "Disable cache fallback on API failure")
+	rootCmd.PersistentFlags().BoolVar(&noCache, "no-cache", false, "Disable cached snapshot reuse and fallback")
 	rootCmd.Flags().Bool("version", false, "Show version and exit")
 
 	rootCmd.AddCommand(authCmd)
@@ -346,8 +348,9 @@ func fetchAndDisplayProvider(ctx context.Context, providerID string) error {
 
 func pipelineConfigFromConfig(cfg config.Config) fetch.PipelineConfig {
 	return fetch.PipelineConfig{
-		Timeout: time.Duration(cfg.Fetch.Timeout * float64(time.Second)),
-		Cache:   config.FileCache{},
+		Timeout:       time.Duration(cfg.Fetch.Timeout * float64(time.Second)),
+		Cache:         config.FileCache{},
+		FreshCacheTTL: freshSnapshotReuseTTL,
 	}
 }
 

--- a/internal/fetch/orchestrator.go
+++ b/internal/fetch/orchestrator.go
@@ -6,8 +6,10 @@ import (
 )
 
 // FetchAllProviders fetches usage from all providers concurrently.
-// When useCache is true, stale cached data is used as a fallback if all strategies fail.
-// Concurrency and pipeline parameters are provided via cfg rather than read from a global singleton.
+// When useCache is true, recent cached snapshots may be reused to dedupe bursty
+// repeat invocations, and stale cached data is still used as a fallback if all
+// strategies fail. Concurrency and pipeline parameters are provided via cfg
+// rather than read from a global singleton.
 func FetchAllProviders(ctx context.Context, providerMap map[string][]Strategy, useCache bool, cfg OrchestratorConfig, onComplete func(FetchOutcome)) map[string]FetchOutcome {
 	maxConcurrent := cfg.MaxConcurrent
 	if maxConcurrent <= 0 {
@@ -43,8 +45,10 @@ func FetchAllProviders(ctx context.Context, providerMap map[string][]Strategy, u
 }
 
 // FetchEnabledProviders fetches only enabled providers.
-// When useCache is true, stale cached data is used as a fallback if all strategies fail.
-// The isEnabled predicate replaces the previous config.Get().IsProviderEnabled dependency.
+// When useCache is true, recent cached snapshots may be reused to dedupe bursty
+// repeat invocations, and stale cached data is still used as a fallback if all
+// strategies fail. The isEnabled predicate replaces the previous
+// config.Get().IsProviderEnabled dependency.
 func FetchEnabledProviders(ctx context.Context, providerMap map[string][]Strategy, useCache bool, cfg OrchestratorConfig, isEnabled func(string) bool, onComplete func(FetchOutcome)) map[string]FetchOutcome {
 	enabledMap := make(map[string][]Strategy)
 	for pid, strategies := range providerMap {

--- a/internal/fetch/pipeline.go
+++ b/internal/fetch/pipeline.go
@@ -3,14 +3,29 @@ package fetch
 import (
 	"context"
 	"time"
+
+	"github.com/joshuadavidthomas/vibeusage/internal/models"
 )
 
 // ExecutePipeline tries each strategy in order until one succeeds.
-// All configuration (timeout, stale threshold, cache) is provided via cfg
-// rather than read from a global singleton.
+// When enabled, a very short fresh-cache window deduplicates bursty repeat
+// invocations before any live fetch is attempted. All configuration is
+// provided via cfg rather than read from a global singleton.
 func ExecutePipeline(ctx context.Context, providerID string, strategies []Strategy, useCache bool, cfg PipelineConfig) FetchOutcome {
 	anyAttempted := false
 	lastErr := ""
+
+	if useCache && cfg.Cache != nil && cfg.FreshCacheTTL > 0 && hasAvailableStrategy(strategies) {
+		if cached := cfg.Cache.Load(providerID); isFreshSnapshot(cached, cfg.FreshCacheTTL) {
+			return FetchOutcome{
+				ProviderID: providerID,
+				Success:    true,
+				Snapshot:   cached,
+				Source:     "cache",
+				Cached:     true,
+			}
+		}
+	}
 
 	for _, strategy := range strategies {
 		if !strategy.IsAvailable() {
@@ -102,4 +117,20 @@ func ExecutePipeline(ctx context.Context, providerID string, strategies []Strate
 type fetchAttemptResult struct {
 	result FetchResult
 	err    error
+}
+
+func hasAvailableStrategy(strategies []Strategy) bool {
+	for _, strategy := range strategies {
+		if strategy.IsAvailable() {
+			return true
+		}
+	}
+	return false
+}
+
+func isFreshSnapshot(snapshot *models.UsageSnapshot, ttl time.Duration) bool {
+	if snapshot == nil || snapshot.FetchedAt.IsZero() || ttl <= 0 {
+		return false
+	}
+	return time.Since(snapshot.FetchedAt) <= ttl
 }

--- a/internal/fetch/pipeline_test.go
+++ b/internal/fetch/pipeline_test.go
@@ -406,6 +406,168 @@ func TestExecutePipeline_CacheFallback(t *testing.T) {
 	}
 }
 
+func TestExecutePipeline_FreshCacheHitSkipsFetch(t *testing.T) {
+	cache := newMemCache()
+	cached := models.UsageSnapshot{
+		Provider:  "test-provider",
+		FetchedAt: time.Now().Add(-500 * time.Millisecond).UTC(),
+		Periods:   []models.UsagePeriod{{Name: "monthly", Utilization: 30}},
+		Source:    "previous-fetch",
+	}
+	cache.data["test-provider"] = cached
+
+	cfg := PipelineConfig{
+		Timeout:       30 * time.Second,
+		Cache:         cache,
+		FreshCacheTTL: time.Second,
+	}
+
+	fetchCalled := false
+	strategy := &mockStrategy{
+		available: true,
+		fetchFn: func(ctx context.Context) (FetchResult, error) {
+			fetchCalled = true
+			return ResultOK(testSnapshot("test-provider", "mock", 99)), nil
+		},
+	}
+
+	ctx := context.Background()
+	outcome := ExecutePipeline(ctx, "test-provider", []Strategy{strategy}, true, cfg)
+
+	if !outcome.Success {
+		t.Fatalf("expected success from fresh cache reuse, got error: %s", outcome.Error)
+	}
+	if !outcome.Cached {
+		t.Error("expected Cached=true for fresh cache reuse")
+	}
+	if outcome.Source != "cache" {
+		t.Errorf("expected source %q, got %q", "cache", outcome.Source)
+	}
+	if fetchCalled {
+		t.Error("expected fresh cache hit to skip live fetch")
+	}
+	if outcome.Snapshot == nil {
+		t.Fatal("expected cached snapshot")
+	}
+	if !outcome.Snapshot.FetchedAt.Equal(cached.FetchedAt) {
+		t.Errorf("cached snapshot timestamp changed: got %v want %v", outcome.Snapshot.FetchedAt, cached.FetchedAt)
+	}
+}
+
+func TestExecutePipeline_FreshCacheMissFallsThroughToFetch(t *testing.T) {
+	cache := newMemCache()
+	cache.data["test-provider"] = models.UsageSnapshot{
+		Provider:  "test-provider",
+		FetchedAt: time.Now().Add(-2 * time.Second).UTC(),
+		Periods:   []models.UsagePeriod{{Name: "monthly", Utilization: 30}},
+		Source:    "previous-fetch",
+	}
+
+	cfg := PipelineConfig{
+		Timeout:       30 * time.Second,
+		Cache:         cache,
+		FreshCacheTTL: time.Second,
+	}
+
+	fetchCalled := false
+	strategy := &mockStrategy{
+		available: true,
+		fetchFn: func(ctx context.Context) (FetchResult, error) {
+			fetchCalled = true
+			return ResultOK(testSnapshot("test-provider", "mock", 55)), nil
+		},
+	}
+
+	ctx := context.Background()
+	outcome := ExecutePipeline(ctx, "test-provider", []Strategy{strategy}, true, cfg)
+
+	if !outcome.Success {
+		t.Fatalf("expected live fetch success, got error: %s", outcome.Error)
+	}
+	if outcome.Cached {
+		t.Error("expected stale cache to fall through to live fetch")
+	}
+	if !fetchCalled {
+		t.Error("expected stale cache miss to call live fetch")
+	}
+	if outcome.Source != "mock" {
+		t.Errorf("expected source %q, got %q", "mock", outcome.Source)
+	}
+}
+
+func TestExecutePipeline_FreshCacheDisabledWithNoCacheFlag(t *testing.T) {
+	cache := newMemCache()
+	cache.data["test-provider"] = models.UsageSnapshot{
+		Provider:  "test-provider",
+		FetchedAt: time.Now().Add(-500 * time.Millisecond).UTC(),
+		Periods:   []models.UsagePeriod{{Name: "monthly", Utilization: 30}},
+	}
+
+	cfg := PipelineConfig{
+		Timeout:       30 * time.Second,
+		Cache:         cache,
+		FreshCacheTTL: time.Second,
+	}
+
+	fetchCalled := false
+	strategy := &mockStrategy{
+		available: true,
+		fetchFn: func(ctx context.Context) (FetchResult, error) {
+			fetchCalled = true
+			return ResultOK(testSnapshot("test-provider", "mock", 65)), nil
+		},
+	}
+
+	ctx := context.Background()
+	outcome := ExecutePipeline(ctx, "test-provider", []Strategy{strategy}, false, cfg)
+
+	if !outcome.Success {
+		t.Fatalf("expected live fetch success with cache disabled, got error: %s", outcome.Error)
+	}
+	if outcome.Cached {
+		t.Error("expected Cached=false when cache is disabled")
+	}
+	if !fetchCalled {
+		t.Error("expected --no-cache behavior to bypass fresh cache reuse")
+	}
+}
+
+func TestExecutePipeline_FreshCacheRejectsZeroFetchedAt(t *testing.T) {
+	cache := newMemCache()
+	cache.data["test-provider"] = models.UsageSnapshot{
+		Provider: "test-provider",
+		Periods:  []models.UsagePeriod{{Name: "monthly", Utilization: 30}},
+	}
+
+	cfg := PipelineConfig{
+		Timeout:       30 * time.Second,
+		Cache:         cache,
+		FreshCacheTTL: time.Second,
+	}
+
+	fetchCalled := false
+	strategy := &mockStrategy{
+		available: true,
+		fetchFn: func(ctx context.Context) (FetchResult, error) {
+			fetchCalled = true
+			return ResultOK(testSnapshot("test-provider", "mock", 70)), nil
+		},
+	}
+
+	ctx := context.Background()
+	outcome := ExecutePipeline(ctx, "test-provider", []Strategy{strategy}, true, cfg)
+
+	if !outcome.Success {
+		t.Fatalf("expected live fetch success, got error: %s", outcome.Error)
+	}
+	if outcome.Cached {
+		t.Error("expected zero-timestamp cache entry to be ignored for fresh reuse")
+	}
+	if !fetchCalled {
+		t.Error("expected zero-timestamp cache entry to be treated as stale")
+	}
+}
+
 func TestExecutePipeline_CacheFallbackServesStaleWhenFetchAttempted(t *testing.T) {
 	cache := newMemCache()
 	cache.data["test-provider"] = models.UsageSnapshot{
@@ -736,17 +898,19 @@ func TestExecutePipeline_SkipsUnavailableTriesAvailable(t *testing.T) {
 
 func TestExecutePipeline_NoCacheFallbackWhenNotConfigured(t *testing.T) {
 	// When no strategies are available (unconfigured provider), cache should NOT be served
-	// even if fresh data exists. This prevents misleading users with old data.
+	// even if the snapshot is fresh. This prevents misleading users with stale or
+	// recently cached data after credentials disappear.
 	cache := newMemCache()
 	cache.data["test-provider"] = models.UsageSnapshot{
 		Provider:  "test-provider",
-		FetchedAt: time.Now().Add(-10 * time.Minute).UTC(),
+		FetchedAt: time.Now().Add(-500 * time.Millisecond).UTC(),
 		Periods:   []models.UsagePeriod{{Name: "monthly", Utilization: 30}},
 	}
 
 	cfg := PipelineConfig{
-		Timeout: 5 * time.Second,
-		Cache:   cache,
+		Timeout:       5 * time.Second,
+		Cache:         cache,
+		FreshCacheTTL: time.Second,
 	}
 
 	strategy := &mockStrategy{

--- a/internal/fetch/strategy.go
+++ b/internal/fetch/strategy.go
@@ -20,8 +20,9 @@ type Cache interface {
 // PipelineConfig holds the parameters that ExecutePipeline needs,
 // replacing the previous hidden dependency on config.Get().
 type PipelineConfig struct {
-	Timeout time.Duration
-	Cache   Cache
+	Timeout       time.Duration
+	Cache         Cache
+	FreshCacheTTL time.Duration
 }
 
 // OrchestratorConfig holds parameters for FetchAllProviders and


### PR DESCRIPTION
## Summary
- add a 1s fresh-cache reuse window in the shared fetch pipeline to dedupe bursty repeat invocations
- keep existing stale-cache fallback behavior after live fetch failures
- make `--no-cache` disable both fresh reuse and stale fallback
- add pipeline tests covering fresh hits, stale misses, disabled cache, zero timestamps, and unconfigured providers

## Validation
- just fmt
- just test
- just lint