### PR TITLE
Refresh Claude usage to match Anthropic's updated UI

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,9 +20,19 @@ and this project attempts to adhere to [Semantic Versioning](https://semver.org/
 
 ## [Unreleased]
 
+### Added
+
+- Added daily routine run quota for Claude (visible for web-session users), rendered as `used / limit` instead of a percentage.
+- Claude's extra-usage billing now shows a reset date (first of next month UTC) alongside the spend.
+
 ### Changed
 
 - Repeated CLI invocations now reuse a successful snapshot for 1 second before refetching. This protects scripts, statuslines, and other programmatic uses from accidentally spamming provider calls while keeping output effectively live. Use `--no-cache` to force a fresh fetch every time.
+- Refreshed Claude's per-model weekly breakdown to match Anthropic's updated usage UI, adding "Claude Design" (plus its promotional variant) and "Iguana Necktie" rows.
+
+### Removed
+
+- Removed Claude's "Monthly" and 7-day Haiku rows. Anthropic's API no longer returns these buckets.
 
 ## [0.5.0]
 

--- a/README.md
+++ b/README.md
@@ -225,7 +225,7 @@ vibeusage auth amp
 > [!IMPORTANT]
 > **On Terms of Service:** Anthropic's [Consumer Terms of Service](https://www.anthropic.com/legal/terms) broadly restrict automated access to their services, and their [Claude Code legal docs](https://code.claude.com/docs/en/legal-and-compliance) (updated February 2026) state that using OAuth tokens in third-party tools is not permitted. vibeusage makes **zero inference requests** — it only reads a usage percentage, the equivalent of checking your data plan on your carrier's website. We believe this is defensible, but want to be transparent: under a strict reading of the TOS, this tool may technically be in violation. We'd happily switch to a sanctioned API if Anthropic ever provides one (a read-only usage endpoint on regular API keys would be perfect 🙏).
 
-[claude.ai](https://claude.ai) — Anthropic's Claude AI assistant. Reports session (5-hour) and weekly usage periods, plus overage spend if enabled. Shows your plan tier (Pro, Max, etc.).
+[claude.ai](https://claude.ai) — Anthropic's Claude AI assistant. Reports session (5-hour) and weekly usage periods, plus overage spend if enabled. Web-session users also see daily routine-run usage. Shows your plan tier (Pro, Max, etc.).
 
 If you have Claude Code installed, vibeusage reads its OAuth credentials automatically — from `~/.claude/.credentials.json` on Linux/Windows, or from macOS Keychain on macOS — including token refresh. This is the recommended path.
 

--- a/internal/display/display.go
+++ b/internal/display/display.go
@@ -77,7 +77,7 @@ func buildPeriodTable(rows []periodTableRow) string {
 	for _, r := range rows {
 		p := r.period
 		color := pace.Assess(p.PaceRatio(), p.Utilization, p.ElapsedRatio()).Color()
-		pct := colorStyle(color).Render(fmt.Sprintf("%d%%", p.Utilization))
+		pct := colorStyle(color).Render(formatPeriodValue(p))
 		bar := RenderBar(p.Utilization, 20, color)
 
 		reset := ""
@@ -93,6 +93,15 @@ func buildPeriodTable(rows []periodTableRow) string {
 	}
 
 	return strings.Join(lines, "\n")
+}
+
+// formatPeriodValue renders the value column for a usage period.
+// Count-based periods show "used / limit"; percentage periods show "N%".
+func formatPeriodValue(p models.UsagePeriod) string {
+	if p.IsCountBased() {
+		return fmt.Sprintf("%d / %d", *p.Used, *p.Limit)
+	}
+	return fmt.Sprintf("%d%%", p.Utilization)
 }
 
 // cleanPeriodTableOutput strips the single leading border space and trailing
@@ -162,12 +171,21 @@ func formatBalance(billing *models.BillingDetail) string {
 func formatBillingDetail(snapshot models.UsageSnapshot) string {
 	var parts []string
 
-	// Reset date from the monthly period (billing cycle reset)
-	for _, p := range snapshot.Periods {
-		if p.PeriodType == models.PeriodMonthly && p.ResetsAt != nil {
-			parts = append(parts, "Resets "+p.ResetsAt.Format("Jan 2"))
-			break
+	// Reset date: prefer the overage reset (Claude's monthly spend boundary),
+	// fall back to the monthly period if one is present.
+	var resetsAt *time.Time
+	if snapshot.Overage != nil && snapshot.Overage.ResetsAt != nil {
+		resetsAt = snapshot.Overage.ResetsAt
+	} else {
+		for _, p := range snapshot.Periods {
+			if p.PeriodType == models.PeriodMonthly && p.ResetsAt != nil {
+				resetsAt = p.ResetsAt
+				break
+			}
 		}
+	}
+	if resetsAt != nil {
+		parts = append(parts, "Resets "+resetsAt.Format("Jan 2"))
 	}
 
 	if snapshot.Billing != nil {
@@ -376,7 +394,7 @@ func GlobalPeriodColWidths(snapshots []models.UsageSnapshot) PeriodColWidths {
 	for _, s := range snapshots {
 		for _, p := range collectDisplayPeriods(s) {
 			cw.Name = max(cw.Name, len(p.Name))
-			cw.Pct = max(cw.Pct, len(fmt.Sprintf("%d%%", p.Utilization)))
+			cw.Pct = max(cw.Pct, len(formatPeriodValue(p)))
 			if d := p.TimeUntilReset(); d != nil {
 				cw.Reset = max(cw.Reset, len("resets in "+FormatResetCountdown(d)))
 			}
@@ -553,7 +571,7 @@ func buildPeriodTableWithWidths(rows []periodTableRow, cw PeriodColWidths) strin
 	for _, r := range rows {
 		p := r.period
 		color := pace.Assess(p.PaceRatio(), p.Utilization, p.ElapsedRatio()).Color()
-		pct := colorStyle(color).Render(fmt.Sprintf("%d%%", p.Utilization))
+		pct := colorStyle(color).Render(formatPeriodValue(p))
 		bar := RenderBar(p.Utilization, 20, color)
 
 		reset := ""

--- a/internal/models/models.go
+++ b/internal/models/models.go
@@ -35,6 +35,14 @@ type UsagePeriod struct {
 	PeriodType  PeriodType `json:"period_type"`
 	ResetsAt    *time.Time `json:"resets_at,omitempty"`
 	Model       string     `json:"model,omitempty"`
+	Used        *int       `json:"used,omitempty"`
+	Limit       *int       `json:"limit,omitempty"`
+}
+
+// IsCountBased reports whether this period is a count-based quota
+// (e.g. daily routine runs) rather than a percentage-based utilization.
+func (p UsagePeriod) IsCountBased() bool {
+	return p.Used != nil && p.Limit != nil
 }
 
 func (p UsagePeriod) Remaining() int {
@@ -82,10 +90,11 @@ type BillingDetail struct {
 }
 
 type OverageUsage struct {
-	Used      float64 `json:"used"`
-	Limit     float64 `json:"limit"`
-	Currency  string  `json:"currency"`
-	IsEnabled bool    `json:"is_enabled"`
+	Used      float64    `json:"used"`
+	Limit     float64    `json:"limit"`
+	Currency  string     `json:"currency"`
+	IsEnabled bool       `json:"is_enabled"`
+	ResetsAt  *time.Time `json:"resets_at,omitempty"`
 }
 
 func (o OverageUsage) Remaining() float64 {

--- a/internal/provider/claude/oauth.go
+++ b/internal/provider/claude/oauth.go
@@ -219,5 +219,5 @@ func (s *OAuthStrategy) refreshToken(ctx context.Context, creds *oauth.Credentia
 }
 
 func (s *OAuthStrategy) parseOAuthUsageResponse(resp OAuthUsageResponse) *models.UsageSnapshot {
-	return parseUsageResponse(resp, "oauth", nil)
+	return parseUsageResponse(resp, "oauth")
 }

--- a/internal/provider/claude/oauth_test.go
+++ b/internal/provider/claude/oauth_test.go
@@ -21,10 +21,6 @@ func TestParseOAuthUsageResponse_FullResponse(t *testing.T) {
 			Utilization: 75.0,
 			ResetsAt:    "2025-02-26T00:00:00Z",
 		},
-		Monthly: &UsagePeriodResponse{
-			Utilization: 30.0,
-			ResetsAt:    "2025-03-01T00:00:00Z",
-		},
 		SevenDaySonnet: &UsagePeriodResponse{
 			Utilization: 60.0,
 			ResetsAt:    "2025-02-26T00:00:00Z",
@@ -33,14 +29,15 @@ func TestParseOAuthUsageResponse_FullResponse(t *testing.T) {
 			Utilization: 10.0,
 			ResetsAt:    "2025-02-26T00:00:00Z",
 		},
-		SevenDayHaiku: &UsagePeriodResponse{
-			Utilization: 90.0,
+		SevenDayOmelette: &UsagePeriodResponse{
+			Utilization: 3.0,
 			ResetsAt:    "2025-02-26T00:00:00Z",
 		},
 		ExtraUsage: &ExtraUsageResponse{
 			IsEnabled:    true,
 			UsedCredits:  550,
 			MonthlyLimit: floatPtr(10000),
+			Currency:     "USD",
 		},
 	}
 
@@ -57,9 +54,9 @@ func TestParseOAuthUsageResponse_FullResponse(t *testing.T) {
 		t.Errorf("source = %q, want %q", snapshot.Source, "oauth")
 	}
 
-	// Should have 6 periods: 3 standard + 3 model-specific
-	if len(snapshot.Periods) != 6 {
-		t.Fatalf("len(periods) = %d, want 6", len(snapshot.Periods))
+	// Should have 5 periods: 2 standard (5h + 7d) + 3 model-specific (sonnet, opus, omelette)
+	if len(snapshot.Periods) != 5 {
+		t.Fatalf("len(periods) = %d, want 5", len(snapshot.Periods))
 	}
 
 	// Find periods by name
@@ -94,17 +91,6 @@ func TestParseOAuthUsageResponse_FullResponse(t *testing.T) {
 		t.Errorf("All Models period_type = %q, want %q", sevenDay.PeriodType, models.PeriodWeekly)
 	}
 
-	monthly, ok := periodByName["Monthly"]
-	if !ok {
-		t.Fatal("missing Monthly period")
-	}
-	if monthly.Utilization != 30 {
-		t.Errorf("Monthly utilization = %d, want 30", monthly.Utilization)
-	}
-	if monthly.PeriodType != models.PeriodMonthly {
-		t.Errorf("Monthly period_type = %q, want %q", monthly.PeriodType, models.PeriodMonthly)
-	}
-
 	// Model-specific periods
 	sonnet, ok := periodByName["Sonnet"]
 	if !ok {
@@ -128,12 +114,15 @@ func TestParseOAuthUsageResponse_FullResponse(t *testing.T) {
 		t.Errorf("Opus utilization = %d, want 10", opus.Utilization)
 	}
 
-	haiku, ok := periodByName["Haiku"]
+	design, ok := periodByName["Claude Design"]
 	if !ok {
-		t.Fatal("missing Haiku period")
+		t.Fatal("missing Claude Design period")
 	}
-	if haiku.Utilization != 90 {
-		t.Errorf("Haiku utilization = %d, want 90", haiku.Utilization)
+	if design.Utilization != 3 {
+		t.Errorf("Claude Design utilization = %d, want 3", design.Utilization)
+	}
+	if design.Model != "omelette" {
+		t.Errorf("Claude Design model = %q, want %q", design.Model, "omelette")
 	}
 
 	// Overage

--- a/internal/provider/claude/response.go
+++ b/internal/provider/claude/response.go
@@ -21,24 +21,23 @@ type ExtraUsageResponse struct {
 	UsedCredits  float64  `json:"used_credits"`
 	MonthlyLimit *float64 `json:"monthly_limit"`
 	Utilization  *float64 `json:"utilization"`
+	Currency     string   `json:"currency,omitempty"`
 }
 
 // OAuthUsageResponse represents the usage response returned by both the OAuth
 // endpoint (/api/oauth/usage) and the web session endpoint
 // (/api/organizations/{orgID}/usage).
 type OAuthUsageResponse struct {
-	FiveHour          *UsagePeriodResponse `json:"five_hour,omitempty"`
-	SevenDay          *UsagePeriodResponse `json:"seven_day,omitempty"`
-	Monthly           *UsagePeriodResponse `json:"monthly,omitempty"`
-	SevenDaySonnet    *UsagePeriodResponse `json:"seven_day_sonnet,omitempty"`
-	SevenDayOpus      *UsagePeriodResponse `json:"seven_day_opus,omitempty"`
-	SevenDayHaiku     *UsagePeriodResponse `json:"seven_day_haiku,omitempty"`
-	SevenDayOAuthApps *UsagePeriodResponse `json:"seven_day_oauth_apps,omitempty"`
-	SevenDayCowork    *UsagePeriodResponse `json:"seven_day_cowork,omitempty"`
-	IguanaNecktie     *UsagePeriodResponse `json:"iguana_necktie,omitempty"`
-	ExtraUsage        *ExtraUsageResponse  `json:"extra_usage,omitempty"`
-	Plan              string               `json:"plan,omitempty"`
-	BillingType       string               `json:"billing_type,omitempty"`
+	FiveHour            *UsagePeriodResponse `json:"five_hour,omitempty"`
+	SevenDay            *UsagePeriodResponse `json:"seven_day,omitempty"`
+	SevenDaySonnet      *UsagePeriodResponse `json:"seven_day_sonnet,omitempty"`
+	SevenDayOpus        *UsagePeriodResponse `json:"seven_day_opus,omitempty"`
+	SevenDayOAuthApps   *UsagePeriodResponse `json:"seven_day_oauth_apps,omitempty"`
+	SevenDayCowork      *UsagePeriodResponse `json:"seven_day_cowork,omitempty"`
+	SevenDayOmelette    *UsagePeriodResponse `json:"seven_day_omelette,omitempty"`
+	OmelettePromotional *UsagePeriodResponse `json:"omelette_promotional,omitempty"`
+	IguanaNecktie       *UsagePeriodResponse `json:"iguana_necktie,omitempty"`
+	ExtraUsage          *ExtraUsageResponse  `json:"extra_usage,omitempty"`
 }
 
 // ClaudeCLIOAuth represents the nested OAuth data inside Claude CLI credentials.
@@ -64,27 +63,6 @@ func (c *ClaudeCLIOAuth) ToOAuthCredentials() oauth.Credentials {
 // ClaudeCLICredentials represents the Claude CLI credentials file format.
 type ClaudeCLICredentials struct {
 	ClaudeAiOauth *ClaudeCLIOAuth `json:"claudeAiOauth,omitempty"`
-}
-
-// WebOverageResponse represents the response from /api/organizations/{orgID}/overage_spend_limit.
-type WebOverageResponse struct {
-	HasHardLimit bool    `json:"has_hard_limit"`
-	CurrentSpend float64 `json:"current_spend"`
-	HardLimit    float64 `json:"hard_limit"`
-}
-
-// ToOverageUsage converts the web overage response to a models.OverageUsage.
-// Returns nil if there is no hard limit.
-func (r *WebOverageResponse) ToOverageUsage() *models.OverageUsage {
-	if !r.HasHardLimit {
-		return nil
-	}
-	return &models.OverageUsage{
-		Used:      r.CurrentSpend / 100.0,
-		Limit:     r.HardLimit / 100.0,
-		Currency:  "USD",
-		IsEnabled: true,
-	}
 }
 
 // WebOrganization represents a single organization from /api/organizations.
@@ -150,9 +128,19 @@ func (o *OAuthAccountOrganization) HasCapability(cap string) bool {
 // WebPrepaidCreditsResponse represents the response from
 // /api/organizations/{orgID}/prepaid/credits.
 type WebPrepaidCreditsResponse struct {
-	Amount             int             `json:"amount"`               // cents, can be negative
-	Currency           string          `json:"currency"`             // "USD"
-	AutoReloadSettings json.RawMessage `json:"auto_reload_settings"` // null = off
+	Amount                    int             `json:"amount"`               // cents, can be negative
+	Currency                  string          `json:"currency"`             // "USD"
+	AutoReloadSettings        json.RawMessage `json:"auto_reload_settings"` // null = off
+	PendingInvoiceAmountCents *int            `json:"pending_invoice_amount_cents,omitempty"`
+}
+
+// RoutinesBudgetResponse represents the response from
+// https://claude.ai/v1/code/routines/run-budget. The limit and used fields
+// are returned as strings by the API.
+type RoutinesBudgetResponse struct {
+	Limit                 json.Number `json:"limit"`
+	Used                  json.Number `json:"used"`
+	UnifiedBillingEnabled bool        `json:"unified_billing_enabled"`
 }
 
 // IsAutoReloadEnabled reports whether auto-reload is configured.

--- a/internal/provider/claude/response_test.go
+++ b/internal/provider/claude/response_test.go
@@ -11,11 +11,11 @@ func TestOAuthUsageResponse_UnmarshalFullResponse(t *testing.T) {
 	raw := `{
 		"five_hour": {"utilization": 42.0, "resets_at": "2025-02-19T22:00:00Z"},
 		"seven_day": {"utilization": 75.0, "resets_at": "2025-02-26T00:00:00Z"},
-		"monthly": {"utilization": 30.0, "resets_at": "2025-03-01T00:00:00Z"},
 		"seven_day_sonnet": {"utilization": 60.0, "resets_at": "2025-02-26T00:00:00Z"},
 		"seven_day_opus": {"utilization": 10.0, "resets_at": "2025-02-26T00:00:00Z"},
-		"seven_day_haiku": {"utilization": 90.0, "resets_at": "2025-02-26T00:00:00Z"},
-		"extra_usage": {"is_enabled": true, "used_credits": 550, "monthly_limit": 10000}
+		"seven_day_omelette": {"utilization": 3.0, "resets_at": "2025-02-26T00:00:00Z"},
+		"omelette_promotional": {"utilization": 1.0, "resets_at": "2025-02-26T00:00:00Z"},
+		"extra_usage": {"is_enabled": true, "used_credits": 550, "monthly_limit": 10000, "currency": "USD"}
 	}`
 
 	var resp OAuthUsageResponse
@@ -41,13 +41,6 @@ func TestOAuthUsageResponse_UnmarshalFullResponse(t *testing.T) {
 		t.Errorf("seven_day utilization = %v, want 75.0", resp.SevenDay.Utilization)
 	}
 
-	if resp.Monthly == nil {
-		t.Fatal("expected monthly to be present")
-	}
-	if resp.Monthly.Utilization != 30.0 {
-		t.Errorf("monthly utilization = %v, want 30.0", resp.Monthly.Utilization)
-	}
-
 	// Model-specific periods
 	if resp.SevenDaySonnet == nil {
 		t.Fatal("expected seven_day_sonnet to be present")
@@ -63,11 +56,18 @@ func TestOAuthUsageResponse_UnmarshalFullResponse(t *testing.T) {
 		t.Errorf("seven_day_opus utilization = %v, want 10.0", resp.SevenDayOpus.Utilization)
 	}
 
-	if resp.SevenDayHaiku == nil {
-		t.Fatal("expected seven_day_haiku to be present")
+	if resp.SevenDayOmelette == nil {
+		t.Fatal("expected seven_day_omelette to be present")
 	}
-	if resp.SevenDayHaiku.Utilization != 90.0 {
-		t.Errorf("seven_day_haiku utilization = %v, want 90.0", resp.SevenDayHaiku.Utilization)
+	if resp.SevenDayOmelette.Utilization != 3.0 {
+		t.Errorf("seven_day_omelette utilization = %v, want 3.0", resp.SevenDayOmelette.Utilization)
+	}
+
+	if resp.OmelettePromotional == nil {
+		t.Fatal("expected omelette_promotional to be present")
+	}
+	if resp.OmelettePromotional.Utilization != 1.0 {
+		t.Errorf("omelette_promotional utilization = %v, want 1.0", resp.OmelettePromotional.Utilization)
 	}
 
 	// Extra usage
@@ -82,6 +82,9 @@ func TestOAuthUsageResponse_UnmarshalFullResponse(t *testing.T) {
 	}
 	if resp.ExtraUsage.MonthlyLimit == nil || *resp.ExtraUsage.MonthlyLimit != 10000 {
 		t.Errorf("extra_usage.monthly_limit = %v, want 10000", resp.ExtraUsage.MonthlyLimit)
+	}
+	if resp.ExtraUsage.Currency != "USD" {
+		t.Errorf("extra_usage.currency = %q, want %q", resp.ExtraUsage.Currency, "USD")
 	}
 }
 
@@ -106,11 +109,11 @@ func TestOAuthUsageResponse_UnmarshalMinimalResponse(t *testing.T) {
 	if resp.SevenDay != nil {
 		t.Error("expected seven_day to be nil")
 	}
-	if resp.Monthly != nil {
-		t.Error("expected monthly to be nil")
-	}
 	if resp.SevenDaySonnet != nil {
 		t.Error("expected seven_day_sonnet to be nil")
+	}
+	if resp.SevenDayOmelette != nil {
+		t.Error("expected seven_day_omelette to be nil")
 	}
 	if resp.ExtraUsage != nil {
 		t.Error("expected extra_usage to be nil")
@@ -131,8 +134,8 @@ func TestOAuthUsageResponse_UnmarshalEmptyResponse(t *testing.T) {
 	if resp.SevenDay != nil {
 		t.Error("expected seven_day to be nil")
 	}
-	if resp.Monthly != nil {
-		t.Error("expected monthly to be nil")
+	if resp.SevenDayOmelette != nil {
+		t.Error("expected seven_day_omelette to be nil")
 	}
 }
 

--- a/internal/provider/claude/usage.go
+++ b/internal/provider/claude/usage.go
@@ -7,26 +7,27 @@ import (
 	"github.com/joshuadavidthomas/vibeusage/internal/models"
 )
 
+// codenameLabels maps Anthropic's internal weekly-bucket codenames to
+// their human-readable display names.
+var codenameLabels = map[string]string{
+	"omelette":             "Claude Design",
+	"omelette_promotional": "Claude Design (Promo)",
+	"iguana_necktie":       "Iguana Necktie",
+}
+
 // parseUsageResponse converts an OAuthUsageResponse (returned by both the
 // OAuth and web session endpoints) into a UsageSnapshot. The source parameter
-// identifies which strategy produced the data ("oauth" or "web"). An optional
-// overage override can be provided for strategies that fetch overage data from
-// a separate endpoint.
-func parseUsageResponse(resp OAuthUsageResponse, source string, overageOverride *models.OverageUsage) *models.UsageSnapshot {
+// identifies which strategy produced the data ("oauth" or "web").
+func parseUsageResponse(resp OAuthUsageResponse, source string) *models.UsageSnapshot {
 	var periods []models.UsagePeriod
 
-	type periodInfo struct {
+	standardPeriods := []struct {
+		data       *UsagePeriodResponse
 		name       string
 		periodType models.PeriodType
-	}
-
-	standardPeriods := []struct {
-		data *UsagePeriodResponse
-		info periodInfo
 	}{
-		{resp.FiveHour, periodInfo{"Session (5h)", models.PeriodSession}},
-		{resp.SevenDay, periodInfo{"All Models", models.PeriodWeekly}},
-		{resp.Monthly, periodInfo{"Monthly", models.PeriodMonthly}},
+		{resp.FiveHour, "Session (5h)", models.PeriodSession},
+		{resp.SevenDay, "All Models", models.PeriodWeekly},
 	}
 
 	for _, sp := range standardPeriods {
@@ -34,24 +35,26 @@ func parseUsageResponse(resp OAuthUsageResponse, source string, overageOverride 
 			continue
 		}
 		p := models.UsagePeriod{
-			Name:        sp.info.name,
+			Name:        sp.name,
 			Utilization: int(sp.data.Utilization),
-			PeriodType:  sp.info.periodType,
+			PeriodType:  sp.periodType,
 		}
 		p.ResetsAt = models.ParseRFC3339Ptr(sp.data.ResetsAt)
 		periods = append(periods, p)
 	}
 
 	modelPeriods := []struct {
-		data      *UsagePeriodResponse
-		modelName string
+		data    *UsagePeriodResponse
+		display string
+		model   string
 	}{
-		{resp.SevenDaySonnet, "Sonnet"},
-		{resp.SevenDayOpus, "Opus"},
-		{resp.SevenDayHaiku, "Haiku"},
-		{resp.SevenDayOAuthApps, "OAuth Apps"},
-		{resp.SevenDayCowork, "Cowork"},
-		{resp.IguanaNecktie, "Iguana Necktie"},
+		{resp.SevenDaySonnet, "Sonnet", "sonnet"},
+		{resp.SevenDayOpus, "Opus", "opus"},
+		{resp.SevenDayOAuthApps, "OAuth Apps", "oauth_apps"},
+		{resp.SevenDayCowork, "Cowork", "cowork"},
+		{resp.SevenDayOmelette, codenameLabels["omelette"], "omelette"},
+		{resp.OmelettePromotional, codenameLabels["omelette_promotional"], "omelette_promotional"},
+		{resp.IguanaNecktie, codenameLabels["iguana_necktie"], "iguana_necktie"},
 	}
 
 	for _, mp := range modelPeriods {
@@ -59,41 +62,33 @@ func parseUsageResponse(resp OAuthUsageResponse, source string, overageOverride 
 			continue
 		}
 		p := models.UsagePeriod{
-			Name:        mp.modelName,
+			Name:        mp.display,
 			Utilization: int(mp.data.Utilization),
 			PeriodType:  models.PeriodWeekly,
-			Model:       strings.ToLower(strings.ReplaceAll(mp.modelName, " ", "_")),
+			Model:       strings.ToLower(strings.ReplaceAll(mp.model, " ", "_")),
 		}
 		p.ResetsAt = models.ParseRFC3339Ptr(mp.data.ResetsAt)
 		periods = append(periods, p)
 	}
 
-	// Prefer inline extra_usage from the response; fall back to the
-	// override provided by the caller (e.g. from a separate endpoint).
 	var overage *models.OverageUsage
 	if resp.ExtraUsage != nil && resp.ExtraUsage.IsEnabled {
 		var limit float64
 		if resp.ExtraUsage.MonthlyLimit != nil {
 			limit = *resp.ExtraUsage.MonthlyLimit / 100.0
 		}
+		currency := resp.ExtraUsage.Currency
+		if currency == "" {
+			currency = "USD"
+		}
+		resetsAt := firstOfNextMonthUTC(time.Now().UTC())
 		overage = &models.OverageUsage{
 			Used:      resp.ExtraUsage.UsedCredits / 100.0,
 			Limit:     limit,
-			Currency:  "USD",
+			Currency:  currency,
 			IsEnabled: true,
+			ResetsAt:  &resetsAt,
 		}
-	} else if overageOverride != nil {
-		overage = overageOverride
-	}
-
-	// Build identity from plan field or infer from usage features.
-	plan := resp.Plan
-	if plan == "" && resp.BillingType != "" {
-		plan = resp.BillingType
-	}
-	var identity *models.ProviderIdentity
-	if plan != "" {
-		identity = &models.ProviderIdentity{Plan: plan}
 	}
 
 	now := time.Now().UTC()
@@ -102,7 +97,14 @@ func parseUsageResponse(resp OAuthUsageResponse, source string, overageOverride 
 		FetchedAt: now,
 		Periods:   periods,
 		Overage:   overage,
-		Identity:  identity,
 		Source:    source,
 	}
+}
+
+// firstOfNextMonthUTC returns midnight UTC on the first day of the month
+// following the given time. This is the reset boundary Anthropic uses for
+// extra-usage spending caps (matches purchases_reset_at in /prepaid/bundles).
+func firstOfNextMonthUTC(now time.Time) time.Time {
+	year, month, _ := now.Date()
+	return time.Date(year, month+1, 1, 0, 0, 0, 0, time.UTC)
 }

--- a/internal/provider/claude/web.go
+++ b/internal/provider/claude/web.go
@@ -12,7 +12,10 @@ import (
 	"github.com/joshuadavidthomas/vibeusage/internal/models"
 )
 
-const webBaseURL = "https://claude.ai/api/organizations"
+const (
+	webBaseURL     = "https://claude.ai/api/organizations"
+	webRoutinesURL = "https://claude.ai/v1/code/routines/run-budget"
+)
 
 // WebStrategy fetches Claude usage using a session cookie.
 type WebStrategy struct {
@@ -38,24 +41,24 @@ func (s *WebStrategy) Fetch(ctx context.Context) (fetch.FetchResult, error) {
 	sessionCookie := httpclient.WithCookie("sessionKey", sessionKey)
 	orgBase := webBaseURL + "/" + orgID
 
-	// Fetch usage, overage, and prepaid credits concurrently.
-	// Overage and credits are best-effort — failures are silently ignored.
+	// Fetch usage, prepaid credits, and routines budget concurrently.
+	// Credits and routines are best-effort — failures are silently ignored.
 	type usageOutcome struct {
 		resp    OAuthUsageResponse
 		status  int
 		jsonErr error
 		err     error
 	}
-	type overageOutcome struct {
-		overage *models.OverageUsage
-	}
 	type creditsOutcome struct {
 		credits *WebPrepaidCreditsResponse
 	}
+	type routinesOutcome struct {
+		routines *RoutinesBudgetResponse
+	}
 
 	usageCh := make(chan usageOutcome, 1)
-	overageCh := make(chan overageOutcome, 1)
 	creditsCh := make(chan creditsOutcome, 1)
+	routinesCh := make(chan routinesOutcome, 1)
 
 	go func() {
 		var usageResp OAuthUsageResponse
@@ -68,16 +71,6 @@ func (s *WebStrategy) Fetch(ctx context.Context) (fetch.FetchResult, error) {
 	}()
 
 	go func() {
-		var overageResp WebOverageResponse
-		resp, err := client.GetJSONCtx(ctx, orgBase+"/overage_spend_limit", &overageResp, sessionCookie)
-		if err != nil || resp.StatusCode != 200 || resp.JSONErr != nil {
-			overageCh <- overageOutcome{}
-			return
-		}
-		overageCh <- overageOutcome{overage: overageResp.ToOverageUsage()}
-	}()
-
-	go func() {
 		var creditsResp WebPrepaidCreditsResponse
 		resp, err := client.GetJSONCtx(ctx, orgBase+"/prepaid/credits", &creditsResp, sessionCookie)
 		if err != nil || resp.StatusCode != 200 || resp.JSONErr != nil {
@@ -87,9 +80,19 @@ func (s *WebStrategy) Fetch(ctx context.Context) (fetch.FetchResult, error) {
 		creditsCh <- creditsOutcome{credits: &creditsResp}
 	}()
 
+	go func() {
+		var routinesResp RoutinesBudgetResponse
+		resp, err := client.GetJSONCtx(ctx, webRoutinesURL, &routinesResp, sessionCookie)
+		if err != nil || resp.StatusCode != 200 || resp.JSONErr != nil {
+			routinesCh <- routinesOutcome{}
+			return
+		}
+		routinesCh <- routinesOutcome{routines: &routinesResp}
+	}()
+
 	usage := <-usageCh
-	overage := <-overageCh
 	credits := <-creditsCh
+	routines := <-routinesCh
 
 	if usage.err != nil {
 		return fetch.ResultFail("Request failed: " + usage.err.Error()), nil
@@ -104,13 +107,48 @@ func (s *WebStrategy) Fetch(ctx context.Context) (fetch.FetchResult, error) {
 		return fetch.ResultFail(fmt.Sprintf("Invalid usage response: %v", usage.jsonErr)), nil
 	}
 
-	snapshot := parseUsageResponse(usage.resp, "web", overage.overage)
+	snapshot := parseUsageResponse(usage.resp, "web")
 
 	if credits.credits != nil {
 		snapshot.Billing = credits.credits.ToBillingDetail()
 	}
 
+	if routines.routines != nil {
+		if p := routinesToPeriod(routines.routines); p != nil {
+			snapshot.Periods = append(snapshot.Periods, *p)
+		}
+	}
+
 	return fetch.ResultOK(*snapshot), nil
+}
+
+// routinesToPeriod converts a routines budget response into a count-based
+// usage period. Returns nil if the response cannot be parsed.
+func routinesToPeriod(r *RoutinesBudgetResponse) *models.UsagePeriod {
+	limit, err := r.Limit.Int64()
+	if err != nil {
+		return nil
+	}
+	used, err := r.Used.Int64()
+	if err != nil {
+		return nil
+	}
+	usedInt := int(used)
+	limitInt := int(limit)
+	utilization := 0
+	if limitInt > 0 {
+		utilization = int((float64(usedInt) / float64(limitInt)) * 100)
+		if utilization > 100 {
+			utilization = 100
+		}
+	}
+	return &models.UsagePeriod{
+		Name:        "Daily routine runs",
+		Utilization: utilization,
+		PeriodType:  models.PeriodDaily,
+		Used:        &usedInt,
+		Limit:       &limitInt,
+	}
 }
 
 func (s *WebStrategy) loadSessionKey() string {

--- a/internal/provider/claude/web_response_test.go
+++ b/internal/provider/claude/web_response_test.go
@@ -5,65 +5,6 @@ import (
 	"testing"
 )
 
-func TestWebOverageResponse_UnmarshalWithHardLimit(t *testing.T) {
-	raw := `{
-		"has_hard_limit": true,
-		"current_spend": 2550,
-		"hard_limit": 10000
-	}`
-
-	var resp WebOverageResponse
-	if err := json.Unmarshal([]byte(raw), &resp); err != nil {
-		t.Fatalf("unmarshal failed: %v", err)
-	}
-
-	if !resp.HasHardLimit {
-		t.Error("expected has_hard_limit to be true")
-	}
-	if resp.CurrentSpend != 2550 {
-		t.Errorf("current_spend = %v, want 2550", resp.CurrentSpend)
-	}
-	if resp.HardLimit != 10000 {
-		t.Errorf("hard_limit = %v, want 10000", resp.HardLimit)
-	}
-}
-
-func TestWebOverageResponse_UnmarshalNoHardLimit(t *testing.T) {
-	raw := `{
-		"has_hard_limit": false,
-		"current_spend": 0,
-		"hard_limit": 0
-	}`
-
-	var resp WebOverageResponse
-	if err := json.Unmarshal([]byte(raw), &resp); err != nil {
-		t.Fatalf("unmarshal failed: %v", err)
-	}
-
-	if resp.HasHardLimit {
-		t.Error("expected has_hard_limit to be false")
-	}
-	if resp.CurrentSpend != 0 {
-		t.Errorf("current_spend = %v, want 0", resp.CurrentSpend)
-	}
-	if resp.HardLimit != 0 {
-		t.Errorf("hard_limit = %v, want 0", resp.HardLimit)
-	}
-}
-
-func TestWebOverageResponse_UnmarshalEmptyResponse(t *testing.T) {
-	raw := `{}`
-
-	var resp WebOverageResponse
-	if err := json.Unmarshal([]byte(raw), &resp); err != nil {
-		t.Fatalf("unmarshal failed: %v", err)
-	}
-
-	if resp.HasHardLimit {
-		t.Error("expected has_hard_limit to be false")
-	}
-}
-
 func TestWebOrganization_UnmarshalWithUUID(t *testing.T) {
 	raw := `{
 		"uuid": "org-uuid-123",
@@ -285,56 +226,5 @@ func TestWebSessionCredentials_UnmarshalEmpty(t *testing.T) {
 
 	if creds.SessionKey != "" {
 		t.Errorf("session_key = %q, want empty", creds.SessionKey)
-	}
-}
-
-func TestWebOverageResponse_ToOverageUsage(t *testing.T) {
-	tests := []struct {
-		name     string
-		resp     WebOverageResponse
-		wantNil  bool
-		wantUsed float64
-	}{
-		{
-			name: "with hard limit",
-			resp: WebOverageResponse{
-				HasHardLimit: true,
-				CurrentSpend: 2550,
-				HardLimit:    10000,
-			},
-			wantNil:  false,
-			wantUsed: 25.50,
-		},
-		{
-			name: "without hard limit",
-			resp: WebOverageResponse{
-				HasHardLimit: false,
-			},
-			wantNil: true,
-		},
-	}
-
-	for _, tt := range tests {
-		t.Run(tt.name, func(t *testing.T) {
-			got := tt.resp.ToOverageUsage()
-			if tt.wantNil {
-				if got != nil {
-					t.Errorf("ToOverageUsage() = %+v, want nil", got)
-				}
-				return
-			}
-			if got == nil {
-				t.Fatal("ToOverageUsage() = nil, want non-nil")
-			}
-			if got.Used != tt.wantUsed {
-				t.Errorf("Used = %v, want %v", got.Used, tt.wantUsed)
-			}
-			if got.Currency != "USD" {
-				t.Errorf("Currency = %q, want %q", got.Currency, "USD")
-			}
-			if !got.IsEnabled {
-				t.Error("expected IsEnabled to be true")
-			}
-		})
 	}
 }

--- a/internal/provider/claude/web_test.go
+++ b/internal/provider/claude/web_test.go
@@ -13,7 +13,7 @@ func TestParseUsageResponse_WebSource(t *testing.T) {
 		SevenDaySonnet: &UsagePeriodResponse{Utilization: 15.0, ResetsAt: "2025-02-26T00:00:00Z"},
 	}
 
-	snapshot := parseUsageResponse(resp, "web", nil)
+	snapshot := parseUsageResponse(resp, "web")
 
 	if snapshot == nil {
 		t.Fatal("expected non-nil snapshot")
@@ -50,47 +50,18 @@ func TestParseUsageResponse_WebSource(t *testing.T) {
 	}
 }
 
-func TestParseUsageResponse_WebWithOverageOverride(t *testing.T) {
-	resp := OAuthUsageResponse{
-		FiveHour: &UsagePeriodResponse{Utilization: 50.0},
-	}
-	overage := &models.OverageUsage{
-		Used:      25.50,
-		Limit:     100.00,
-		Currency:  "USD",
-		IsEnabled: true,
-	}
-
-	snapshot := parseUsageResponse(resp, "web", overage)
-
-	if snapshot == nil {
-		t.Fatal("expected non-nil snapshot")
-	}
-	if snapshot.Overage == nil {
-		t.Fatal("expected overage to be present")
-	}
-	if snapshot.Overage.Used != 25.50 {
-		t.Errorf("overage used = %v, want 25.50", snapshot.Overage.Used)
-	}
-}
-
-func TestParseUsageResponse_InlineExtraUsageTakesPrecedence(t *testing.T) {
+func TestParseUsageResponse_InlineExtraUsagePopulatesOverage(t *testing.T) {
 	resp := OAuthUsageResponse{
 		FiveHour: &UsagePeriodResponse{Utilization: 50.0},
 		ExtraUsage: &ExtraUsageResponse{
 			IsEnabled:    true,
 			UsedCredits:  1000,
 			MonthlyLimit: floatPtr(5000),
+			Currency:     "USD",
 		},
 	}
-	overrideOverage := &models.OverageUsage{
-		Used:      99.99,
-		Limit:     200.00,
-		Currency:  "USD",
-		IsEnabled: true,
-	}
 
-	snapshot := parseUsageResponse(resp, "web", overrideOverage)
+	snapshot := parseUsageResponse(resp, "web")
 
 	if snapshot == nil {
 		t.Fatal("expected non-nil snapshot")
@@ -98,16 +69,27 @@ func TestParseUsageResponse_InlineExtraUsageTakesPrecedence(t *testing.T) {
 	if snapshot.Overage == nil {
 		t.Fatal("expected overage to be present")
 	}
-	// Inline extra_usage should win over the override
 	if snapshot.Overage.Used != 10.0 { // 1000 / 100.0
-		t.Errorf("overage used = %v, want 10.0 (from inline extra_usage)", snapshot.Overage.Used)
+		t.Errorf("overage used = %v, want 10.0", snapshot.Overage.Used)
+	}
+	if snapshot.Overage.Limit != 50.0 { // 5000 / 100.0
+		t.Errorf("overage limit = %v, want 50.0", snapshot.Overage.Limit)
+	}
+	if snapshot.Overage.Currency != "USD" {
+		t.Errorf("overage currency = %q, want USD", snapshot.Overage.Currency)
+	}
+	if snapshot.Overage.ResetsAt == nil {
+		t.Fatal("expected overage.resets_at to be set (first of next month)")
+	}
+	if snapshot.Overage.ResetsAt.Day() != 1 {
+		t.Errorf("overage.resets_at day = %d, want 1", snapshot.Overage.ResetsAt.Day())
 	}
 }
 
 func TestParseUsageResponse_EmptyResponse(t *testing.T) {
 	resp := OAuthUsageResponse{}
 
-	snapshot := parseUsageResponse(resp, "web", nil)
+	snapshot := parseUsageResponse(resp, "web")
 
 	if snapshot == nil {
 		t.Fatal("expected non-nil snapshot")


### PR DESCRIPTION
Anthropic refreshed their usage UI and the underlying responses shifted with it — some buckets renamed, some gone, new routines quota added, and the previously-separate overage endpoint now duplicates what's already on `/usage`. This brings the Claude provider back in line.

## User-visible changes

**Added**

- Daily routine run quota (only visible for web-session users, since the `/v1/code/routines/run-budget` endpoint lives on `claude.ai` with no OAuth equivalent). Rendered as `used / limit` instead of a percentage.
- Extra-usage billing now shows a reset date (first of next month UTC) alongside the spend.

**Changed**

- Per-model weekly breakdown now includes "Claude Design" (`omelette`), its promotional variant, and "Iguana Necktie" — matching the new bucket names in Anthropic's response.

**Removed**

- "Monthly" and 7-day Haiku rows. Anthropic's usage API no longer returns these buckets.

## Under the hood

- Dropped the separate `/overage_spend_limit` fetch for web-session users. Its schema had diverged from what vibeusage expected and was silently failing; the same data arrives inline via `extra_usage` on the main `/usage` response anyway. Net: one fewer request per Claude web fetch.
- Added optional `Used` / `Limit` pointers to `UsagePeriod` so count-based quotas (like daily routines) can coexist with the existing percentage-based model without a second type. `IsCountBased()` predicate gates the new render path.
- `parseUsageResponse` signature simplified — the overage-override parameter was only needed to plumb the old separate-endpoint data back in.

## Follow-ups

While debugging a 429 from the usage endpoint during manual testing, we noticed the provider makes 2 concurrent requests per fetch (`/oauth/usage` + `/oauth/account`) with no throttling beyond a 1s snapshot-reuse window. Three separate small PRs planned to address that, not part of this one:

1. Gate `/oauth/account` fetches on stale identity — halves per-fetch request count.
2. Bump `freshSnapshotReuseTTL` from 1s to ~60s to match Anthropic's own UI refresh cadence.
3. Respect `Retry-After` on 429 responses with a persisted cooldown marker.

## Testing

- `just test` — all passing
- `just lint` — 0 issues
- `just fmt` — clean

End-to-end CLI validation was blocked by rate limiting during the work. The OAuth path only exercises the existing buckets (so its behavior change is the Monthly/Haiku removal plus the new bucket names appearing if the user's account has them). The web-session path adds the daily-routines row — will verify that once I can get a session key into the sandbox.
