### PR TITLE
Skip Claude /oauth/account when cached identity is fresh

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -29,6 +29,7 @@ and this project attempts to adhere to [Semantic Versioning](https://semver.org/
 
 - Repeated CLI invocations now reuse a successful snapshot for 1 second before refetching. This protects scripts, statuslines, and other programmatic uses from accidentally spamming provider calls while keeping output effectively live. Use `--no-cache` to force a fresh fetch every time.
 - Refreshed Claude's per-model weekly breakdown to match Anthropic's updated usage UI, adding "Claude Design" (plus its promotional variant) and "Iguana Necktie" rows.
+- Claude now skips the `/oauth/account` request when a cached identity (email, plan, org) is less than 24 hours old, halving the per-fetch request count during active use. Identity data changes rarely, so reuse is safe; `--no-cache` still forces a fresh fetch of everything.
 
 ### Removed
 

--- a/internal/provider/claude/oauth.go
+++ b/internal/provider/claude/oauth.go
@@ -6,6 +6,7 @@ import (
 	"fmt"
 	"os"
 	"path/filepath"
+	"time"
 
 	"github.com/joshuadavidthomas/vibeusage/internal/auth/oauth"
 	"github.com/joshuadavidthomas/vibeusage/internal/config"
@@ -22,6 +23,12 @@ const (
 	oauthClientID        = "9d1c250a-e61b-44d9-88ed-5944d1962f5e"
 	anthropicBetaTag     = "oauth-2025-04-20"
 	claudeKeychainSecret = "Claude Code-credentials"
+
+	// accountReuseTTL is how long a cached identity (email, plan, org)
+	// is trusted before we re-fetch /oauth/account. Identity data changes
+	// on the order of months (plan upgrades, org renames); reusing it for
+	// a day halves the per-fetch request count at negligible freshness cost.
+	accountReuseTTL = 24 * time.Hour
 )
 
 var readKeychainSecret = keychain.ReadGenericPassword
@@ -84,8 +91,10 @@ func (s *OAuthStrategy) Fetch(ctx context.Context) (fetch.FetchResult, error) {
 		httpclient.WithHeader("anthropic-beta", anthropicBetaTag),
 	}
 
-	// Fetch usage and account concurrently. Account enrichment is
-	// best-effort — failures are silently ignored.
+	cachedIdentity := loadCachedIdentity()
+
+	// Fetch usage, and (when no recent cached identity) account concurrently.
+	// Account enrichment is best-effort — failures are silently ignored.
 	type usageOutcome struct {
 		resp    OAuthUsageResponse
 		status  int
@@ -109,15 +118,19 @@ func (s *OAuthStrategy) Fetch(ctx context.Context) (fetch.FetchResult, error) {
 		usageCh <- usageOutcome{resp: usageResp, status: resp.StatusCode, jsonErr: resp.JSONErr}
 	}()
 
-	go func() {
-		var acctResp OAuthAccountResponse
-		resp, err := client.GetJSONCtx(ctx, oauthAccountURL, &acctResp, authOpts...)
-		if err != nil || resp.StatusCode != 200 || resp.JSONErr != nil {
-			accountCh <- accountOutcome{}
-			return
-		}
-		accountCh <- accountOutcome{resp: &acctResp}
-	}()
+	if cachedIdentity != nil {
+		accountCh <- accountOutcome{}
+	} else {
+		go func() {
+			var acctResp OAuthAccountResponse
+			resp, err := client.GetJSONCtx(ctx, oauthAccountURL, &acctResp, authOpts...)
+			if err != nil || resp.StatusCode != 200 || resp.JSONErr != nil {
+				accountCh <- accountOutcome{}
+				return
+			}
+			accountCh <- accountOutcome{resp: &acctResp}
+		}()
+	}
 
 	usage := <-usageCh
 	account := <-accountCh
@@ -140,9 +153,31 @@ func (s *OAuthStrategy) Fetch(ctx context.Context) (fetch.FetchResult, error) {
 
 	snapshot := s.parseOAuthUsageResponse(usage.resp)
 
-	enrichWithAccount(snapshot, account.resp)
+	if cachedIdentity != nil {
+		snapshot.Identity = cachedIdentity
+	} else {
+		enrichWithAccount(snapshot, account.resp)
+	}
 
 	return fetch.ResultOK(*snapshot), nil
+}
+
+// loadCachedIdentity returns the cached Claude identity if the on-disk
+// snapshot is within accountReuseTTL and has a populated Identity. Returns
+// nil otherwise, signalling that /oauth/account should be fetched.
+func loadCachedIdentity() *models.ProviderIdentity {
+	cached := config.LoadCachedSnapshot("claude")
+	if cached == nil || cached.Identity == nil {
+		return nil
+	}
+	if time.Since(cached.FetchedAt) > accountReuseTTL {
+		return nil
+	}
+	id := cached.Identity
+	if id.Email == "" && id.Plan == "" && id.Organization == "" {
+		return nil
+	}
+	return id
 }
 
 func (s *OAuthStrategy) externalPaths() []string {

--- a/internal/provider/claude/oauth_test.go
+++ b/internal/provider/claude/oauth_test.go
@@ -6,7 +6,9 @@ import (
 	"time"
 
 	"github.com/joshuadavidthomas/vibeusage/internal/auth/oauth"
+	"github.com/joshuadavidthomas/vibeusage/internal/config"
 	"github.com/joshuadavidthomas/vibeusage/internal/models"
+	"github.com/joshuadavidthomas/vibeusage/internal/testenv"
 )
 
 func floatPtr(f float64) *float64 { return &f }
@@ -411,6 +413,90 @@ func TestLoadKeychainCredentials(t *testing.T) {
 	}
 	if creds.RefreshToken != "ref" {
 		t.Errorf("refresh_token = %q, want ref", creds.RefreshToken)
+	}
+}
+
+func TestLoadCachedIdentity(t *testing.T) {
+	tests := []struct {
+		name    string
+		setup   func(t *testing.T)
+		wantNil bool
+	}{
+		{
+			name:    "no cache",
+			setup:   func(t *testing.T) {},
+			wantNil: true,
+		},
+		{
+			name: "cache present but identity nil",
+			setup: func(t *testing.T) {
+				snap := models.UsageSnapshot{
+					Provider:  "claude",
+					FetchedAt: time.Now().UTC(),
+				}
+				if err := config.CacheSnapshot(snap); err != nil {
+					t.Fatalf("CacheSnapshot: %v", err)
+				}
+			},
+			wantNil: true,
+		},
+		{
+			name: "cache present but identity empty",
+			setup: func(t *testing.T) {
+				snap := models.UsageSnapshot{
+					Provider:  "claude",
+					FetchedAt: time.Now().UTC(),
+					Identity:  &models.ProviderIdentity{},
+				}
+				if err := config.CacheSnapshot(snap); err != nil {
+					t.Fatalf("CacheSnapshot: %v", err)
+				}
+			},
+			wantNil: true,
+		},
+		{
+			name: "cache stale",
+			setup: func(t *testing.T) {
+				snap := models.UsageSnapshot{
+					Provider:  "claude",
+					FetchedAt: time.Now().UTC().Add(-25 * time.Hour),
+					Identity:  &models.ProviderIdentity{Email: "u@example.com", Plan: "Max 20x"},
+				}
+				if err := config.CacheSnapshot(snap); err != nil {
+					t.Fatalf("CacheSnapshot: %v", err)
+				}
+			},
+			wantNil: true,
+		},
+		{
+			name: "cache fresh with identity",
+			setup: func(t *testing.T) {
+				snap := models.UsageSnapshot{
+					Provider:  "claude",
+					FetchedAt: time.Now().UTC().Add(-1 * time.Hour),
+					Identity:  &models.ProviderIdentity{Email: "u@example.com", Plan: "Max 20x"},
+				}
+				if err := config.CacheSnapshot(snap); err != nil {
+					t.Fatalf("CacheSnapshot: %v", err)
+				}
+			},
+			wantNil: false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			testenv.ApplyVibeusage(t.Setenv, t.TempDir())
+			tt.setup(t)
+
+			got := loadCachedIdentity()
+			if tt.wantNil && got != nil {
+				t.Errorf("loadCachedIdentity() = %+v, want nil", got)
+			}
+			if !tt.wantNil && got == nil {
+				t.Error("loadCachedIdentity() = nil, want non-nil")
+			}
+		})
 	}
 }
 


### PR DESCRIPTION
First of three follow-ups to #155 aimed at reducing request pressure on Anthropic's usage endpoints.

The Claude provider makes two concurrent requests per fetch — `/oauth/usage` (the actual data) and `/oauth/account` (identity: email, plan tier, org name). Identity data changes rarely — users change plans maybe once a month, orgs never rename. But we were re-fetching it on every single invocation.

This PR gates the `/oauth/account` fetch on whether the cached snapshot already has an identity that's less than 24 hours old. If so, we skip the request entirely and copy the cached identity onto the new snapshot. Halves the per-fetch request count during active use.

## Behavior

- First fetch, or cache older than 24h → both endpoints called (same as today).
- Subsequent fetches within 24h → only `/oauth/usage` called, identity reused from cache.
- `--no-cache` → bypasses, fetches both (same as today).
- Cache contains snapshot but `Identity` is nil (e.g. `/oauth/account` previously failed) → gate doesn't apply, account is re-fetched.

## Testing

Added `TestLoadCachedIdentity` covering: no cache, cache with nil identity, cache with empty identity, cache stale (>24h), cache fresh with populated identity.

`just test`, `just lint`, `just fmt` all clean.

## Part of a three-PR series

1. **This PR** — gate account fetches on cached identity.
2. Bump `freshSnapshotReuseTTL` from 1s to ~60s.
3. Respect `Retry-After` on 429 with persisted cooldown.
