### PR TITLE
Bump fresh snapshot reuse TTL from 1s to 60s

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -28,7 +28,7 @@ and this project attempts to adhere to [Semantic Versioning](https://semver.org/
 
 ### Changed
 
-- Repeated CLI invocations now reuse a successful snapshot for 1 second before refetching. This protects scripts, statuslines, and other programmatic uses from accidentally spamming provider calls while keeping output effectively live. Use `--no-cache` to force a fresh fetch every time.
+- Repeated CLI invocations now reuse a successful snapshot for 60 seconds before refetching. This matches the refresh cadence of most providers' own usage UIs (Anthropic's usage dashboard, for example, refreshes about once a minute) and protects scripts, statuslines, and other programmatic uses from hammering provider APIs. Use `--no-cache` to force a fresh fetch every time.
 - Refreshed Claude's per-model weekly breakdown to match Anthropic's updated usage UI, adding "Claude Design" (plus its promotional variant) and "Iguana Necktie" rows.
 - Claude now skips the `/oauth/account` request when a cached identity (email, plan, org) is less than 24 hours old, halving the per-fetch request count during active use. Identity data changes rarely, so reuse is safe; `--no-cache` still forces a fresh fetch of everything.
 

--- a/README.md
+++ b/README.md
@@ -93,7 +93,7 @@ vibeusage --json
 vibeusage usage codex --json
 ```
 
-For scripts, widgets, and statuslines, vibeusage reuses a successful snapshot for 1 second before refetching. That keeps output effectively live while protecting you from accidentally hammering the same provider with bursty repeat calls.
+For scripts, widgets, and statuslines, vibeusage reuses a successful snapshot for 60 seconds before refetching. This matches the refresh cadence of most providers' own usage UIs and protects you from accidentally hammering an API with bursty repeat calls.
 
 Skip cached snapshots entirely and always fetch live:
 
@@ -459,7 +459,7 @@ Then run `vibeusage auth --status` again.
 
 vibeusage caches usage data in two ways:
 
-- very recent successful snapshots are reused for up to 1 second to avoid bursty repeat fetches from scripts and statuslines
+- recent successful snapshots are reused for up to 60 seconds to match providers' own UI refresh cadences and avoid bursty repeat fetches from scripts and statuslines
 - older snapshots are kept as a fallback when an API call fails
 
 If you see `(2h ago)` in output, the API was down and cached data was served. To clear this cache:
@@ -468,7 +468,7 @@ If you see `(2h ago)` in output, the API was down and cached data was served. To
 rm -rf "$(vibeusage config path --cache)"
 ```
 
-Use `--no-cache` to bypass both 1-second snapshot reuse and stale fallback, and fail fast if the API is unreachable.
+Use `--no-cache` to bypass both the 60-second snapshot reuse and stale fallback, and fail fast if the API is unreachable.
 
 ## Updating
 

--- a/internal/cli/root.go
+++ b/internal/cli/root.go
@@ -35,7 +35,12 @@ import (
 // version is injected at build time via -ldflags.
 var version = "dev"
 
-const freshSnapshotReuseTTL = time.Second
+// freshSnapshotReuseTTL is how long a cached snapshot is considered
+// "fresh enough" to skip the network entirely. Matches the ~1 minute
+// refresh cadence of Anthropic's own usage UI and broadly suits other
+// providers whose quotas update on similar timescales. --no-cache
+// bypasses this window and always fetches live.
+const freshSnapshotReuseTTL = 60 * time.Second
 
 var (
 	jsonOutput bool


### PR DESCRIPTION
Second of three follow-ups to #155.

The fresh-snapshot reuse window (added in #154) was set to 1 second, which is tight — it really only dedupes statusline calls firing twice in the same second. Providers' own usage UIs refresh on roughly one-minute cadences (Anthropic's dashboard is about every 2 minutes, Cursor's is similar), so asking their APIs more often than that isn't giving the user any newer data anyway.

Bumps `freshSnapshotReuseTTL` from `time.Second` to `60 * time.Second`. `--no-cache` still bypasses entirely, which is the escape hatch for "I just did something and want to see it reflected right now."

## Trade-off

If you run `vibeusage` twice 30 seconds apart expecting a fresh read, you'll get the same snapshot both times. In practice:
- The data you'd get live wouldn't differ in any meaningful way anyway.
- `--no-cache` is there if you really need live.
- Statuslines, scripts, widgets — the main audience for this cache — benefit significantly from fewer network calls.

README and CHANGELOG updated in the same places that referenced the 1s value.

## Testing

`just test`, `just lint`, `just fmt` clean. Pipeline tests pass their own `FreshCacheTTL` into the config and are unaffected by the CLI-level constant change.

## Part of a three-PR series

1. #156 — gate Claude `/oauth/account` on cached identity.
2. **This PR** — bump `freshSnapshotReuseTTL` from 1s to 60s.
3. Respect `Retry-After` on 429 with persisted cooldown.
