### PR TITLE
Respect Retry-After on Claude 429 responses

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,6 +24,7 @@ and this project attempts to adhere to [Semantic Versioning](https://semver.org/
 
 - Added daily routine run quota for Claude (visible for web-session users), rendered as `used / limit` instead of a percentage.
 - Claude's extra-usage billing now shows a reset date (first of next month UTC) alongside the spend.
+- Honor `Retry-After` on 429 responses from Claude: vibeusage persists a per-provider cooldown, serves cached data (tagged `cache (throttled)`) during the window, and resumes live fetches automatically once the cooldown passes. `--no-cache` bypasses the cooldown.
 
 ### Changed
 

--- a/internal/cli/root.go
+++ b/internal/cli/root.go
@@ -350,6 +350,7 @@ func pipelineConfigFromConfig(cfg config.Config) fetch.PipelineConfig {
 	return fetch.PipelineConfig{
 		Timeout:       time.Duration(cfg.Fetch.Timeout * float64(time.Second)),
 		Cache:         config.FileCache{},
+		Throttles:     config.FileThrottleStore{},
 		FreshCacheTTL: freshSnapshotReuseTTL,
 	}
 }

--- a/internal/config/cache.go
+++ b/internal/config/cache.go
@@ -5,7 +5,9 @@ import (
 	"fmt"
 	"os"
 	"path/filepath"
+	"time"
 
+	"github.com/joshuadavidthomas/vibeusage/internal/fetch"
 	"github.com/joshuadavidthomas/vibeusage/internal/models"
 )
 
@@ -79,6 +81,7 @@ func ClearOrgIDCache(providerID string) {
 func ClearProviderCache(providerID string) {
 	_ = os.Remove(SnapshotPath(providerID))
 	_ = os.Remove(OrgIDPath(providerID))
+	_ = os.Remove(ThrottlePath(providerID))
 }
 
 func ClearSnapshotCache(providerID string) {
@@ -90,6 +93,49 @@ func ClearSnapshotCache(providerID string) {
 	for _, e := range entries {
 		_ = os.Remove(filepath.Join(SnapshotsDir(), e.Name()))
 	}
+}
+
+func ThrottlePath(providerID string) string {
+	return filepath.Join(ThrottlesDir(), providerID+".json")
+}
+
+func SaveThrottle(providerID string, marker fetch.ThrottleMarker) error {
+	path := ThrottlePath(providerID)
+	if err := os.MkdirAll(filepath.Dir(path), 0o755); err != nil {
+		return fmt.Errorf("saving throttle for %s: %w", providerID, err)
+	}
+	data, err := json.Marshal(marker)
+	if err != nil {
+		return fmt.Errorf("saving throttle for %s: %w", providerID, err)
+	}
+	if err := os.WriteFile(path, data, 0o644); err != nil {
+		return fmt.Errorf("saving throttle for %s: %w", providerID, err)
+	}
+	return nil
+}
+
+// LoadThrottle returns the persisted throttle marker for the provider,
+// or nil if none exists or it has expired. Expired markers are deleted
+// lazily so the on-disk state stays tidy.
+func LoadThrottle(providerID string) *fetch.ThrottleMarker {
+	path := ThrottlePath(providerID)
+	data, err := os.ReadFile(path)
+	if err != nil {
+		return nil
+	}
+	var m fetch.ThrottleMarker
+	if err := json.Unmarshal(data, &m); err != nil {
+		return nil
+	}
+	if time.Now().After(m.RetryAt) {
+		_ = os.Remove(path)
+		return nil
+	}
+	return &m
+}
+
+func ClearThrottle(providerID string) {
+	_ = os.Remove(ThrottlePath(providerID))
 }
 
 func ClearModelsCache() {
@@ -104,7 +150,15 @@ func ClearAllCache(providerID string) {
 	}
 	ClearSnapshotCache("")
 	ClearOrgIDCache("")
+	ClearThrottles()
 	ClearModelsCache()
+}
+
+func ClearThrottles() {
+	entries, _ := os.ReadDir(ThrottlesDir())
+	for _, e := range entries {
+		_ = os.Remove(filepath.Join(ThrottlesDir(), e.Name()))
+	}
 }
 
 // FileCache implements fetch.Cache using the filesystem-based snapshot
@@ -118,4 +172,20 @@ func (FileCache) Save(snapshot models.UsageSnapshot) error {
 
 func (FileCache) Load(providerID string) *models.UsageSnapshot {
 	return LoadCachedSnapshot(providerID)
+}
+
+// FileThrottleStore implements fetch.ThrottleStore on top of the
+// filesystem-based throttle marker helpers.
+type FileThrottleStore struct{}
+
+func (FileThrottleStore) Load(providerID string) *fetch.ThrottleMarker {
+	return LoadThrottle(providerID)
+}
+
+func (FileThrottleStore) Save(providerID string, marker fetch.ThrottleMarker) error {
+	return SaveThrottle(providerID, marker)
+}
+
+func (FileThrottleStore) Clear(providerID string) {
+	ClearThrottle(providerID)
 }

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -9,6 +9,7 @@ import (
 	"testing"
 	"time"
 
+	"github.com/joshuadavidthomas/vibeusage/internal/fetch"
 	"github.com/joshuadavidthomas/vibeusage/internal/models"
 )
 
@@ -1464,5 +1465,90 @@ func TestSeedDefaultRoles_PreservesExistingConfigWhenCacheIsStale(t *testing.T) 
 	}
 	if len(loaded.Roles) == 0 {
 		t.Error("expected default roles to be seeded")
+	}
+}
+
+func TestSaveAndLoadThrottle(t *testing.T) {
+	setupTempDir(t)
+
+	retryAt := time.Now().Add(5 * time.Minute).UTC().Truncate(time.Second)
+	marker := fetch.ThrottleMarker{
+		RetryAt: retryAt,
+		Reason:  "Rate limited by provider",
+	}
+
+	if err := SaveThrottle("claude", marker); err != nil {
+		t.Fatalf("SaveThrottle error: %v", err)
+	}
+
+	loaded := LoadThrottle("claude")
+	if loaded == nil {
+		t.Fatal("expected throttle marker to load")
+	}
+	if !loaded.RetryAt.Equal(retryAt) {
+		t.Errorf("RetryAt = %v, want %v", loaded.RetryAt, retryAt)
+	}
+	if loaded.Reason != marker.Reason {
+		t.Errorf("Reason = %q, want %q", loaded.Reason, marker.Reason)
+	}
+}
+
+func TestLoadThrottle_ExpiredIsDeleted(t *testing.T) {
+	setupTempDir(t)
+
+	past := time.Now().Add(-1 * time.Minute).UTC()
+	if err := SaveThrottle("claude", fetch.ThrottleMarker{RetryAt: past, Reason: "old"}); err != nil {
+		t.Fatalf("SaveThrottle error: %v", err)
+	}
+
+	if m := LoadThrottle("claude"); m != nil {
+		t.Errorf("expected nil for expired marker, got %+v", m)
+	}
+
+	if _, err := os.Stat(ThrottlePath("claude")); !os.IsNotExist(err) {
+		t.Error("expected expired throttle file to be removed on load")
+	}
+}
+
+func TestLoadThrottle_MissingReturnsNil(t *testing.T) {
+	setupTempDir(t)
+	if m := LoadThrottle("claude"); m != nil {
+		t.Errorf("expected nil for missing marker, got %+v", m)
+	}
+}
+
+func TestClearThrottle(t *testing.T) {
+	setupTempDir(t)
+
+	marker := fetch.ThrottleMarker{RetryAt: time.Now().Add(time.Hour), Reason: "rate limited"}
+	if err := SaveThrottle("claude", marker); err != nil {
+		t.Fatalf("SaveThrottle error: %v", err)
+	}
+
+	ClearThrottle("claude")
+
+	if _, err := os.Stat(ThrottlePath("claude")); !os.IsNotExist(err) {
+		t.Error("expected throttle file to be removed after ClearThrottle")
+	}
+}
+
+func TestFileThrottleStore_ImplementsInterface(t *testing.T) {
+	setupTempDir(t)
+
+	var store fetch.ThrottleStore = FileThrottleStore{}
+
+	retryAt := time.Now().Add(3 * time.Minute).UTC().Truncate(time.Second)
+	if err := store.Save("claude", fetch.ThrottleMarker{RetryAt: retryAt, Reason: "rl"}); err != nil {
+		t.Fatalf("Save error: %v", err)
+	}
+
+	loaded := store.Load("claude")
+	if loaded == nil || !loaded.RetryAt.Equal(retryAt) {
+		t.Errorf("Load mismatch: got %+v, want RetryAt=%v", loaded, retryAt)
+	}
+
+	store.Clear("claude")
+	if store.Load("claude") != nil {
+		t.Error("expected nil after Clear")
 	}
 }

--- a/internal/config/paths.go
+++ b/internal/config/paths.go
@@ -42,6 +42,7 @@ func CacheDir() string {
 func credentialsDir() string  { return filepath.Join(DataDir(), "credentials") }
 func SnapshotsDir() string    { return filepath.Join(CacheDir(), "snapshots") }
 func OrgIDsDir() string       { return filepath.Join(CacheDir(), "org-ids") }
+func ThrottlesDir() string    { return filepath.Join(CacheDir(), "throttles") }
 func ModelsFile() string      { return filepath.Join(CacheDir(), "models.json") }
 func MultipliersFile() string { return filepath.Join(CacheDir(), "multipliers.json") }
 func ConfigFile() string      { return filepath.Join(ConfigDir(), "config.toml") }

--- a/internal/fetch/pipeline.go
+++ b/internal/fetch/pipeline.go
@@ -2,6 +2,7 @@ package fetch
 
 import (
 	"context"
+	"fmt"
 	"time"
 
 	"github.com/joshuadavidthomas/vibeusage/internal/models"
@@ -14,6 +15,34 @@ import (
 func ExecutePipeline(ctx context.Context, providerID string, strategies []Strategy, useCache bool, cfg PipelineConfig) FetchOutcome {
 	anyAttempted := false
 	lastErr := ""
+
+	// Honor a persisted rate-limit cooldown before any network attempt.
+	// Within the window, serve cache if present; otherwise surface the
+	// cooldown as the error so the user sees why nothing fetched.
+	if useCache && cfg.Throttles != nil && hasAvailableStrategy(strategies) {
+		if marker := cfg.Throttles.Load(providerID); marker != nil {
+			if cfg.Cache != nil {
+				if cached := cfg.Cache.Load(providerID); cached != nil {
+					return FetchOutcome{
+						ProviderID: providerID,
+						Success:    true,
+						Snapshot:   cached,
+						Source:     "cache (throttled)",
+						Cached:     true,
+					}
+				}
+			}
+			reason := marker.Reason
+			if reason == "" {
+				reason = "Rate limited"
+			}
+			return FetchOutcome{
+				ProviderID: providerID,
+				Success:    false,
+				Error:      fmt.Sprintf("%s; retry after %s", reason, marker.RetryAt.Format(time.RFC3339)),
+			}
+		}
+	}
 
 	if useCache && cfg.Cache != nil && cfg.FreshCacheTTL > 0 && hasAvailableStrategy(strategies) {
 		if cached := cfg.Cache.Load(providerID); isFreshSnapshot(cached, cfg.FreshCacheTTL) {
@@ -63,9 +92,20 @@ func ExecutePipeline(ctx context.Context, providerID string, strategies []Strate
 			continue
 		}
 
+		if result.RetryAfter != nil && cfg.Throttles != nil {
+			reason := result.Error
+			if reason == "" {
+				reason = "Rate limited"
+			}
+			_ = cfg.Throttles.Save(providerID, ThrottleMarker{RetryAt: *result.RetryAfter, Reason: reason})
+		}
+
 		if result.Success && result.Snapshot != nil {
 			if cfg.Cache != nil {
 				_ = cfg.Cache.Save(*result.Snapshot)
+			}
+			if cfg.Throttles != nil {
+				cfg.Throttles.Clear(providerID)
 			}
 
 			return FetchOutcome{

--- a/internal/fetch/pipeline_test.go
+++ b/internal/fetch/pipeline_test.go
@@ -3,6 +3,7 @@ package fetch
 import (
 	"context"
 	"fmt"
+	"strings"
 	"sync"
 	"testing"
 	"time"
@@ -44,6 +45,45 @@ func (c *memCache) Load(providerID string) *models.UsageSnapshot {
 		return nil
 	}
 	return &s
+}
+
+// memThrottles is a thread-safe in-memory ThrottleStore for testing.
+// Load respects RetryAt — callers see nil once the cooldown has passed,
+// matching the filesystem implementation.
+type memThrottles struct {
+	mu   sync.Mutex
+	data map[string]ThrottleMarker
+}
+
+func newMemThrottles() *memThrottles {
+	return &memThrottles{data: make(map[string]ThrottleMarker)}
+}
+
+func (t *memThrottles) Load(providerID string) *ThrottleMarker {
+	t.mu.Lock()
+	defer t.mu.Unlock()
+	m, ok := t.data[providerID]
+	if !ok {
+		return nil
+	}
+	if time.Now().After(m.RetryAt) {
+		delete(t.data, providerID)
+		return nil
+	}
+	return &m
+}
+
+func (t *memThrottles) Save(providerID string, marker ThrottleMarker) error {
+	t.mu.Lock()
+	defer t.mu.Unlock()
+	t.data[providerID] = marker
+	return nil
+}
+
+func (t *memThrottles) Clear(providerID string) {
+	t.mu.Lock()
+	defer t.mu.Unlock()
+	delete(t.data, providerID)
 }
 
 func defaultTestPipelineCfg() PipelineConfig {
@@ -947,5 +987,217 @@ func TestExecutePipeline_NilCacheNoFallback(t *testing.T) {
 
 	if outcome.Success {
 		t.Error("expected failure — nil cache means no fallback")
+	}
+}
+
+func TestExecutePipeline_ThrottleMarkerServesCacheWithoutFetch(t *testing.T) {
+	cache := newMemCache()
+	cache.data["test-provider"] = models.UsageSnapshot{
+		Provider:  "test-provider",
+		FetchedAt: time.Now().Add(-5 * time.Minute).UTC(),
+		Periods:   []models.UsagePeriod{{Name: "monthly", Utilization: 42}},
+		Source:    "previous-fetch",
+	}
+
+	throttles := newMemThrottles()
+	throttles.data["test-provider"] = ThrottleMarker{
+		RetryAt: time.Now().Add(10 * time.Minute),
+		Reason:  "Rate limited",
+	}
+
+	fetchCalled := false
+	strategy := &mockStrategy{
+		available: true,
+		fetchFn: func(ctx context.Context) (FetchResult, error) {
+			fetchCalled = true
+			return ResultOK(testSnapshot("test-provider", "mock", 80)), nil
+		},
+	}
+
+	cfg := PipelineConfig{
+		Timeout:   30 * time.Second,
+		Cache:     cache,
+		Throttles: throttles,
+	}
+
+	outcome := ExecutePipeline(context.Background(), "test-provider", []Strategy{strategy}, true, cfg)
+
+	if !outcome.Success {
+		t.Fatalf("expected cache hit during throttle window, got error: %s", outcome.Error)
+	}
+	if outcome.Source != "cache (throttled)" {
+		t.Errorf("expected source %q, got %q", "cache (throttled)", outcome.Source)
+	}
+	if !outcome.Cached {
+		t.Error("expected Cached=true")
+	}
+	if fetchCalled {
+		t.Error("expected throttle marker to skip live fetch")
+	}
+}
+
+func TestExecutePipeline_ThrottleMarkerNoCacheReturnsError(t *testing.T) {
+	throttles := newMemThrottles()
+	throttles.data["test-provider"] = ThrottleMarker{
+		RetryAt: time.Now().Add(10 * time.Minute),
+		Reason:  "Rate limited by Anthropic",
+	}
+
+	fetchCalled := false
+	strategy := &mockStrategy{
+		available: true,
+		fetchFn: func(ctx context.Context) (FetchResult, error) {
+			fetchCalled = true
+			return ResultOK(testSnapshot("test-provider", "mock", 80)), nil
+		},
+	}
+
+	cfg := PipelineConfig{
+		Timeout:   30 * time.Second,
+		Cache:     newMemCache(),
+		Throttles: throttles,
+	}
+
+	outcome := ExecutePipeline(context.Background(), "test-provider", []Strategy{strategy}, true, cfg)
+
+	if outcome.Success {
+		t.Fatal("expected failure when throttled with no cache")
+	}
+	if fetchCalled {
+		t.Error("expected throttle marker to skip live fetch even without cache")
+	}
+	if !strings.Contains(outcome.Error, "Rate limited by Anthropic") {
+		t.Errorf("expected rate-limit reason in error, got %q", outcome.Error)
+	}
+	if !strings.Contains(outcome.Error, "retry after") {
+		t.Errorf("expected retry-after hint in error, got %q", outcome.Error)
+	}
+}
+
+func TestExecutePipeline_ThrottleMarkerBypassedWithNoCacheFlag(t *testing.T) {
+	throttles := newMemThrottles()
+	throttles.data["test-provider"] = ThrottleMarker{
+		RetryAt: time.Now().Add(10 * time.Minute),
+		Reason:  "Rate limited",
+	}
+
+	fetchCalled := false
+	strategy := &mockStrategy{
+		available: true,
+		fetchFn: func(ctx context.Context) (FetchResult, error) {
+			fetchCalled = true
+			return ResultOK(testSnapshot("test-provider", "mock", 12)), nil
+		},
+	}
+
+	cfg := PipelineConfig{
+		Timeout:   30 * time.Second,
+		Cache:     newMemCache(),
+		Throttles: throttles,
+	}
+
+	outcome := ExecutePipeline(context.Background(), "test-provider", []Strategy{strategy}, false, cfg)
+
+	if !outcome.Success {
+		t.Fatalf("expected --no-cache to bypass throttle and call strategy, got error: %s", outcome.Error)
+	}
+	if !fetchCalled {
+		t.Error("expected --no-cache to bypass throttle check")
+	}
+}
+
+func TestExecutePipeline_RetryAfterPersisted(t *testing.T) {
+	retryAt := time.Now().Add(2 * time.Minute).UTC()
+
+	strategy := &mockStrategy{
+		available: true,
+		fetchFn: func(ctx context.Context) (FetchResult, error) {
+			return ResultThrottled("Rate limited by Anthropic", retryAt), nil
+		},
+	}
+
+	throttles := newMemThrottles()
+	cfg := PipelineConfig{
+		Timeout:   30 * time.Second,
+		Cache:     newMemCache(),
+		Throttles: throttles,
+	}
+
+	outcome := ExecutePipeline(context.Background(), "test-provider", []Strategy{strategy}, false, cfg)
+
+	if outcome.Success {
+		t.Error("expected non-success outcome when strategy returned throttled result without cache")
+	}
+	saved, ok := throttles.data["test-provider"]
+	if !ok {
+		t.Fatal("expected throttle marker to be persisted after 429 result")
+	}
+	if !saved.RetryAt.Equal(retryAt) {
+		t.Errorf("persisted RetryAt = %v, want %v", saved.RetryAt, retryAt)
+	}
+	if saved.Reason != "Rate limited by Anthropic" {
+		t.Errorf("persisted Reason = %q, want %q", saved.Reason, "Rate limited by Anthropic")
+	}
+}
+
+func TestExecutePipeline_SuccessClearsThrottleMarker(t *testing.T) {
+	throttles := newMemThrottles()
+	throttles.data["test-provider"] = ThrottleMarker{
+		RetryAt: time.Now().Add(-1 * time.Second),
+		Reason:  "stale marker",
+	}
+
+	strategy := &mockStrategy{
+		available: true,
+		fetchFn: func(ctx context.Context) (FetchResult, error) {
+			return ResultOK(testSnapshot("test-provider", "mock", 33)), nil
+		},
+	}
+
+	cfg := PipelineConfig{
+		Timeout:   30 * time.Second,
+		Cache:     newMemCache(),
+		Throttles: throttles,
+	}
+
+	outcome := ExecutePipeline(context.Background(), "test-provider", []Strategy{strategy}, false, cfg)
+
+	if !outcome.Success {
+		t.Fatalf("expected success, got error: %s", outcome.Error)
+	}
+	if _, ok := throttles.data["test-provider"]; ok {
+		t.Error("expected throttle marker to be cleared on success")
+	}
+}
+
+func TestExecutePipeline_ExpiredThrottleMarkerIgnored(t *testing.T) {
+	throttles := newMemThrottles()
+	throttles.data["test-provider"] = ThrottleMarker{
+		RetryAt: time.Now().Add(-1 * time.Minute),
+		Reason:  "stale",
+	}
+
+	fetchCalled := false
+	strategy := &mockStrategy{
+		available: true,
+		fetchFn: func(ctx context.Context) (FetchResult, error) {
+			fetchCalled = true
+			return ResultOK(testSnapshot("test-provider", "mock", 44)), nil
+		},
+	}
+
+	cfg := PipelineConfig{
+		Timeout:   30 * time.Second,
+		Cache:     newMemCache(),
+		Throttles: throttles,
+	}
+
+	outcome := ExecutePipeline(context.Background(), "test-provider", []Strategy{strategy}, true, cfg)
+
+	if !outcome.Success {
+		t.Fatalf("expected success once throttle window passed, got error: %s", outcome.Error)
+	}
+	if !fetchCalled {
+		t.Error("expected live fetch once throttle window expired")
 	}
 }

--- a/internal/fetch/strategy.go
+++ b/internal/fetch/strategy.go
@@ -17,11 +17,29 @@ type Cache interface {
 	Load(providerID string) *models.UsageSnapshot
 }
 
+// ThrottleMarker is a persisted record that a provider asked us to stop
+// making requests until RetryAt. Populated from a 429 response's Retry-After
+// header (or a sensible default when the header is missing).
+type ThrottleMarker struct {
+	RetryAt time.Time `json:"retry_at"`
+	Reason  string    `json:"reason,omitempty"`
+}
+
+// ThrottleStore abstracts per-provider rate-limit cooldown persistence.
+// Load must return nil once RetryAt has passed, so callers don't need to
+// compare times themselves.
+type ThrottleStore interface {
+	Load(providerID string) *ThrottleMarker
+	Save(providerID string, marker ThrottleMarker) error
+	Clear(providerID string)
+}
+
 // PipelineConfig holds the parameters that ExecutePipeline needs,
 // replacing the previous hidden dependency on config.Get().
 type PipelineConfig struct {
 	Timeout       time.Duration
 	Cache         Cache
+	Throttles     ThrottleStore
 	FreshCacheTTL time.Duration
 }
 
@@ -33,11 +51,15 @@ type OrchestratorConfig struct {
 }
 
 // FetchResult represents the outcome of a single strategy attempt.
+// RetryAfter is set when the provider asked us to back off (e.g. 429);
+// the pipeline persists it as a ThrottleMarker so subsequent invocations
+// skip the network entirely until the cooldown passes.
 type FetchResult struct {
 	Success        bool
 	Snapshot       *models.UsageSnapshot
 	Error          string
 	ShouldFallback bool
+	RetryAfter     *time.Time
 }
 
 func ResultOK(snapshot models.UsageSnapshot) FetchResult {
@@ -50,6 +72,18 @@ func ResultFail(err string) FetchResult {
 
 func ResultFatal(err string) FetchResult {
 	return FetchResult{Success: false, Error: err, ShouldFallback: false}
+}
+
+// ResultThrottled signals that the provider rate-limited us. The pipeline
+// persists a ThrottleMarker from retryAfter so future calls within the
+// window skip the network. ShouldFallback is true so cache is served.
+func ResultThrottled(err string, retryAfter time.Time) FetchResult {
+	return FetchResult{
+		Success:        false,
+		Error:          err,
+		ShouldFallback: true,
+		RetryAfter:     &retryAfter,
+	}
 }
 
 // FetchOutcome is the complete result of fetching from a provider.

--- a/internal/provider/claude/oauth.go
+++ b/internal/provider/claude/oauth.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
+	"net/http"
 	"os"
 	"path/filepath"
 	"time"
@@ -98,6 +99,7 @@ func (s *OAuthStrategy) Fetch(ctx context.Context) (fetch.FetchResult, error) {
 	type usageOutcome struct {
 		resp    OAuthUsageResponse
 		status  int
+		header  http.Header
 		jsonErr error
 		err     error
 	}
@@ -115,7 +117,7 @@ func (s *OAuthStrategy) Fetch(ctx context.Context) (fetch.FetchResult, error) {
 			usageCh <- usageOutcome{err: err}
 			return
 		}
-		usageCh <- usageOutcome{resp: usageResp, status: resp.StatusCode, jsonErr: resp.JSONErr}
+		usageCh <- usageOutcome{resp: usageResp, status: resp.StatusCode, header: resp.Header, jsonErr: resp.JSONErr}
 	}()
 
 	if cachedIdentity != nil {
@@ -143,6 +145,10 @@ func (s *OAuthStrategy) Fetch(ctx context.Context) (fetch.FetchResult, error) {
 	}
 	if usage.status == 403 {
 		return fetch.ResultFatal("Not authorized to access usage."), nil
+	}
+	if usage.status == 429 {
+		retryAt := parseRetryAfter(usage.header, time.Now().UTC())
+		return fetch.ResultThrottled("Rate limited by Anthropic", retryAt), nil
 	}
 	if usage.status != 200 {
 		return fetch.ResultFail(fmt.Sprintf("Usage request failed: %d", usage.status)), nil

--- a/internal/provider/claude/retryafter.go
+++ b/internal/provider/claude/retryafter.go
@@ -1,0 +1,30 @@
+package claude
+
+import (
+	"net/http"
+	"strconv"
+	"time"
+)
+
+// defaultRetryAfter is used when a 429 response has no Retry-After header.
+// Matches the freshSnapshotReuseTTL cadence of ~60s; conservative enough to
+// be a real cooldown while not punishing transient blips.
+const defaultRetryAfter = 60 * time.Second
+
+// parseRetryAfter returns the absolute time the client should wait until
+// before retrying. RFC 7231 allows Retry-After as either delta-seconds
+// (integer) or an HTTP-date; we accept both, falling back to now+default
+// when the header is absent or malformed.
+func parseRetryAfter(h http.Header, now time.Time) time.Time {
+	v := h.Get("Retry-After")
+	if v == "" {
+		return now.Add(defaultRetryAfter)
+	}
+	if secs, err := strconv.Atoi(v); err == nil && secs >= 0 {
+		return now.Add(time.Duration(secs) * time.Second)
+	}
+	if t, err := http.ParseTime(v); err == nil {
+		return t
+	}
+	return now.Add(defaultRetryAfter)
+}

--- a/internal/provider/claude/retryafter_test.go
+++ b/internal/provider/claude/retryafter_test.go
@@ -1,0 +1,61 @@
+package claude
+
+import (
+	"net/http"
+	"testing"
+	"time"
+)
+
+func TestParseRetryAfter(t *testing.T) {
+	now := time.Date(2026, 4, 21, 12, 0, 0, 0, time.UTC)
+
+	tests := []struct {
+		name   string
+		header string
+		want   time.Time
+	}{
+		{
+			name:   "delta-seconds",
+			header: "30",
+			want:   now.Add(30 * time.Second),
+		},
+		{
+			name:   "zero delta-seconds",
+			header: "0",
+			want:   now,
+		},
+		{
+			name:   "http-date",
+			header: "Tue, 21 Apr 2026 12:05:00 GMT",
+			want:   time.Date(2026, 4, 21, 12, 5, 0, 0, time.UTC),
+		},
+		{
+			name:   "missing header uses default",
+			header: "",
+			want:   now.Add(defaultRetryAfter),
+		},
+		{
+			name:   "malformed header uses default",
+			header: "not-a-duration",
+			want:   now.Add(defaultRetryAfter),
+		},
+		{
+			name:   "negative delta-seconds is malformed, uses default",
+			header: "-5",
+			want:   now.Add(defaultRetryAfter),
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			h := http.Header{}
+			if tt.header != "" {
+				h.Set("Retry-After", tt.header)
+			}
+			got := parseRetryAfter(h, now)
+			if !got.Equal(tt.want) {
+				t.Errorf("parseRetryAfter(%q) = %v, want %v", tt.header, got, tt.want)
+			}
+		})
+	}
+}

--- a/internal/provider/claude/web.go
+++ b/internal/provider/claude/web.go
@@ -4,7 +4,9 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
+	"net/http"
 	"strings"
+	"time"
 
 	"github.com/joshuadavidthomas/vibeusage/internal/config"
 	"github.com/joshuadavidthomas/vibeusage/internal/fetch"
@@ -46,6 +48,7 @@ func (s *WebStrategy) Fetch(ctx context.Context) (fetch.FetchResult, error) {
 	type usageOutcome struct {
 		resp    OAuthUsageResponse
 		status  int
+		header  http.Header
 		jsonErr error
 		err     error
 	}
@@ -67,7 +70,7 @@ func (s *WebStrategy) Fetch(ctx context.Context) (fetch.FetchResult, error) {
 			usageCh <- usageOutcome{err: err}
 			return
 		}
-		usageCh <- usageOutcome{resp: usageResp, status: resp.StatusCode, jsonErr: resp.JSONErr}
+		usageCh <- usageOutcome{resp: usageResp, status: resp.StatusCode, header: resp.Header, jsonErr: resp.JSONErr}
 	}()
 
 	go func() {
@@ -99,6 +102,10 @@ func (s *WebStrategy) Fetch(ctx context.Context) (fetch.FetchResult, error) {
 	}
 	if usage.status == 401 {
 		return fetch.ResultFatal("Session key expired or invalid"), nil
+	}
+	if usage.status == 429 {
+		retryAt := parseRetryAfter(usage.header, time.Now().UTC())
+		return fetch.ResultThrottled("Rate limited by Anthropic", retryAt), nil
 	}
 	if usage.status != 200 {
 		return fetch.ResultFail(fmt.Sprintf("Usage request failed: %d", usage.status)), nil


### PR DESCRIPTION
Persist a per-provider rate-limit cooldown when Claude returns 429. While the cooldown is active, vibeusage skips the network and serves cached data (tagged `cache (throttled)`); once it passes, live fetches resume automatically.

## Changes

- New `fetch.ThrottleMarker` + `fetch.ThrottleStore` interface, plumbed through `PipelineConfig` alongside `Cache` — same DI shape we already use.
- `fetch.ResultThrottled(...)` and a new `FetchResult.RetryAfter` field let strategies signal a cooldown without hard-coding where it's persisted.
- `ExecutePipeline` now:
  - Checks for an active marker *before* the fresh-cache short-circuit; serves cache (source = `cache (throttled)`) or surfaces the cooldown as the error if no cache exists.
  - Persists `RetryAfter` from the strategy result (after the 429 path returns).
  - Clears the marker on any successful fetch, so recovery is automatic.
- `FileThrottleStore` writes markers under `CacheDir()/throttles/<provider>.json`. `LoadThrottle` lazily deletes expired files so disk state stays clean.
- `ClearProviderCache` / `ClearAllCache` now also wipe throttles.
- Claude's OAuth and web strategies map HTTP 429 → `fetch.ResultThrottled`, using `parseRetryAfter` which handles both RFC 7231 forms (delta-seconds, HTTP-date) and falls back to a 60 s default when the header is absent or malformed.

## Behavior

- `--no-cache` bypasses throttle checks too, consistent with how it already bypasses fresh-reuse and stale fallback.
- A 429 with cache present is visible to the user as `cache (throttled)` in the source column, with the snapshot's real `fetched_at` preserved.
- A 429 without cache surfaces `Rate limited by Anthropic; retry after <RFC3339>` so the user knows why nothing fetched.

## Tests

- `parseRetryAfter`: delta-seconds, zero, HTTP-date, missing, malformed, negative.
- Pipeline: marker serves cache, marker without cache returns error, `--no-cache` bypasses, `RetryAfter` persists, success clears, expired marker ignored.
- Config: save/load round-trip, expired marker self-deletes on load, missing returns nil, `ClearThrottle`, `FileThrottleStore` implements the interface.