### PR TITLE
Add cached update check header

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,10 @@ and this project attempts to adhere to [Semantic Versioning](https://semver.org/
 
 ## [Unreleased]
 
+### Added
+
+- Added an update-available header to normal terminal output when a newer vibeusage release is available. Release checks are cached to keep routine CLI use cheap. Machine-oriented output (`--json`, `statusline`, `completion`) remains unchanged.
+
 ## [0.6.0]
 
 ### Added

--- a/internal/cli/root.go
+++ b/internal/cli/root.go
@@ -17,6 +17,8 @@ import (
 	"github.com/joshuadavidthomas/vibeusage/internal/logging"
 	"github.com/joshuadavidthomas/vibeusage/internal/models"
 	"github.com/joshuadavidthomas/vibeusage/internal/provider"
+	"github.com/joshuadavidthomas/vibeusage/internal/updater"
+
 	// Register all providers
 	_ "github.com/joshuadavidthomas/vibeusage/internal/provider/amp"
 	_ "github.com/joshuadavidthomas/vibeusage/internal/provider/antigravity"
@@ -34,13 +36,6 @@ import (
 
 // version is injected at build time via -ldflags.
 var version = "dev"
-
-// freshSnapshotReuseTTL is how long a cached snapshot is considered
-// "fresh enough" to skip the network entirely. Matches the ~1 minute
-// refresh cadence of Anthropic's own usage UI and broadly suits other
-// providers whose quotas update on similar timescales. --no-cache
-// bypasses this window and always fetches live.
-const freshSnapshotReuseTTL = 60 * time.Second
 
 var (
 	jsonOutput bool
@@ -75,6 +70,8 @@ var rootCmd = &cobra.Command{
 		if err := config.MigrateCredentials(); err != nil {
 			l.Warn("credential migration failed", "err", err)
 		}
+
+		showUpdateCheckHeader(cmd)
 	},
 	RunE: runDefaultUsage,
 }
@@ -87,15 +84,15 @@ func init() {
 	rootCmd.PersistentFlags().BoolVar(&noCache, "no-cache", false, "Disable cached snapshot reuse and fallback")
 	rootCmd.Flags().Bool("version", false, "Show version and exit")
 
-	rootCmd.AddCommand(authCmd)
-	rootCmd.AddCommand(statusCmd)
-	rootCmd.AddCommand(configCmd)
-
-	rootCmd.AddCommand(routeCmd)
-	rootCmd.AddCommand(updateCmd)
-	rootCmd.AddCommand(usageCmd)
-	rootCmd.AddCommand(statuslineCmd)
-
+	rootCmd.AddCommand(
+		authCmd,
+		configCmd,
+		routeCmd,
+		statusCmd,
+		statuslineCmd,
+		updateCmd,
+		usageCmd,
+	)
 }
 
 func Execute() error {
@@ -106,6 +103,76 @@ func Execute() error {
 // Commands access it via cmd.Context().
 func ExecuteContext(ctx context.Context) error {
 	return rootCmd.ExecuteContext(ctx)
+}
+
+const (
+	updateCheckBackgroundRefreshInterval = time.Hour
+	updateCheckForegroundRefreshInterval = 24 * time.Hour
+	updateCheckTimeout                   = 800 * time.Millisecond
+)
+
+func showUpdateCheckHeader(cmd *cobra.Command) {
+	if cmd == nil || jsonOutput || quiet || !isTerminal() || !updater.IsReleaseVersion(version) {
+		return
+	}
+
+	if versionFlag, err := cmd.Flags().GetBool("version"); err == nil && versionFlag {
+		return
+	}
+
+	switch cmd.Name() {
+	case "completion", "help", "statusline", "update":
+		return
+	}
+
+	cached := updater.LoadLatestReleaseCache()
+	var availableUpdate *updater.AvailableUpdate
+	if cached != nil {
+		availableUpdate, _ = updater.AvailableUpdateForVersion(version, *cached)
+	}
+
+	client := updater.NewCheckClient(updateCheckTimeout)
+	switch {
+	case cached == nil || cached.AttemptExpired(updateCheckForegroundRefreshInterval):
+		latestRelease := refreshUpdateCheckCache(client, cached)
+		if latestRelease == nil {
+			return
+		}
+		availableUpdate, _ = updater.AvailableUpdateForVersion(version, *latestRelease)
+	case cached.AttemptExpired(updateCheckBackgroundRefreshInterval):
+		go refreshUpdateCheckCache(client, cached)
+	}
+
+	if availableUpdate == nil {
+		return
+	}
+
+	_, _ = fmt.Fprintln(
+		outWriter,
+		display.RenderUpdateCheckHeader(
+			availableUpdate.CurrentVersion,
+			availableUpdate.LatestVersion,
+			noColor,
+		),
+	)
+	_, _ = fmt.Fprintln(outWriter)
+}
+
+func refreshUpdateCheckCache(client *updater.Client, cached *updater.LatestReleaseInfo) *updater.LatestReleaseInfo {
+	ctx, cancel := context.WithTimeout(context.Background(), updateCheckTimeout)
+	defer cancel()
+
+	latestRelease, err := updater.RefreshLatestReleaseCache(ctx, client, cached)
+	if err == nil || cached != nil {
+		_ = updater.SaveLatestReleaseCache(latestRelease)
+	}
+	if err != nil {
+		if cached != nil {
+			return &latestRelease
+		}
+		return nil
+	}
+	return &latestRelease
 }
 
 func runDefaultUsage(cmd *cobra.Command, args []string) error {
@@ -352,6 +419,12 @@ func fetchAndDisplayProvider(ctx context.Context, providerID string) error {
 }
 
 func pipelineConfigFromConfig(cfg config.Config) fetch.PipelineConfig {
+	// Treat cached snapshots as "fresh enough" for about a minute before
+	// forcing a live fetch. This matches the rough refresh cadence of provider
+	// usage UIs while keeping normal CLI use responsive. --no-cache bypasses
+	// this window entirely.
+	const freshSnapshotReuseTTL = 60 * time.Second
+
 	return fetch.PipelineConfig{
 		Timeout:       time.Duration(cfg.Fetch.Timeout * float64(time.Second)),
 		Cache:         config.FileCache{},

--- a/internal/display/update_check.go
+++ b/internal/display/update_check.go
@@ -1,0 +1,18 @@
+package display
+
+import (
+	"fmt"
+
+	"github.com/charmbracelet/lipgloss"
+)
+
+func RenderUpdateCheckHeader(currentVersion, latestVersion string, noColor bool) string {
+	text := fmt.Sprintf("Update available: %s → %s", currentVersion, latestVersion)
+	if noColor {
+		return "↑ " + text
+	}
+
+	arrow := lipgloss.NewStyle().Bold(true).Foreground(lipgloss.Color("3")).Render("↑")
+	body := lipgloss.NewStyle().Foreground(lipgloss.Color("3")).Render(text)
+	return arrow + " " + body
+}

--- a/internal/display/update_check_test.go
+++ b/internal/display/update_check_test.go
@@ -1,0 +1,19 @@
+package display
+
+import "testing"
+
+func TestRenderUpdateCheckHeader_NoColor(t *testing.T) {
+	got := RenderUpdateCheckHeader("v1.0.0", "v1.1.0", true)
+	want := "↑ Update available: v1.0.0 → v1.1.0"
+	if got != want {
+		t.Fatalf("RenderUpdateCheckHeader() = %q, want %q", got, want)
+	}
+}
+
+func TestRenderUpdateCheckHeader_WithColor(t *testing.T) {
+	got := stripANSI(RenderUpdateCheckHeader("v1.0.0", "v1.1.0", false))
+	want := "↑ Update available: v1.0.0 → v1.1.0"
+	if got != want {
+		t.Fatalf("RenderUpdateCheckHeader() stripped = %q, want %q", got, want)
+	}
+}

--- a/internal/updater/check.go
+++ b/internal/updater/check.go
@@ -1,0 +1,171 @@
+package updater
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"os"
+	"path/filepath"
+	"strings"
+	"time"
+
+	"golang.org/x/mod/semver"
+
+	"github.com/joshuadavidthomas/vibeusage/internal/config"
+)
+
+const latestReleaseCacheFilename = "update-check.json"
+
+// LatestReleaseInfo stores the latest known release metadata for lightweight
+// update checks in normal CLI output.
+type LatestReleaseInfo struct {
+	// CheckedAt is the last successful live check time.
+	CheckedAt time.Time `json:"checked_at,omitempty"`
+	// AttemptedAt is the last live-check attempt time, whether it succeeded or failed.
+	AttemptedAt   time.Time `json:"attempted_at,omitempty"`
+	LatestVersion string    `json:"latest_version,omitempty"`
+	ReleaseURL    string    `json:"release_url,omitempty"`
+}
+
+// AvailableUpdate describes an update available for the current version.
+type AvailableUpdate struct {
+	CurrentVersion string
+	LatestVersion  string
+	ReleaseURL     string
+}
+
+// NewCheckClient creates a GitHub-backed client with a short timeout for
+// lightweight latest-release checks in normal CLI output.
+func NewCheckClient(timeout time.Duration) *Client {
+	if timeout <= 0 {
+		timeout = time.Second
+	}
+	c := NewClient()
+	c.HTTP = &http.Client{Timeout: timeout}
+	return c
+}
+
+// LatestReleaseCachePath returns the path to the lightweight update-check
+// cache file.
+func LatestReleaseCachePath() string {
+	return filepath.Join(config.CacheDir(), latestReleaseCacheFilename)
+}
+
+// LoadLatestReleaseCache returns the cached latest-release metadata, or nil
+// when absent or malformed.
+func LoadLatestReleaseCache() *LatestReleaseInfo {
+	data, err := os.ReadFile(LatestReleaseCachePath())
+	if err != nil {
+		return nil
+	}
+
+	var entry LatestReleaseInfo
+	if err := json.Unmarshal(data, &entry); err != nil {
+		return nil
+	}
+	if entry.AttemptedAt.IsZero() && entry.CheckedAt.IsZero() {
+		return nil
+	}
+	if entry.AttemptedAt.IsZero() && !entry.CheckedAt.IsZero() {
+		entry.AttemptedAt = entry.CheckedAt
+	}
+	return &entry
+}
+
+// SaveLatestReleaseCache persists the latest-release metadata for reuse by
+// future commands.
+func SaveLatestReleaseCache(entry LatestReleaseInfo) error {
+	path := LatestReleaseCachePath()
+	if err := os.MkdirAll(filepath.Dir(path), 0o755); err != nil {
+		return fmt.Errorf("saving update-check cache: %w", err)
+	}
+	data, err := json.Marshal(entry)
+	if err != nil {
+		return fmt.Errorf("saving update-check cache: %w", err)
+	}
+	if err := os.WriteFile(path, data, 0o644); err != nil {
+		return fmt.Errorf("saving update-check cache: %w", err)
+	}
+	return nil
+}
+
+// AttemptExpired reports whether the last live-check attempt is older than the
+// supplied interval. A zero AttemptedAt is treated as expired.
+func (e LatestReleaseInfo) AttemptExpired(interval time.Duration) bool {
+	if interval <= 0 {
+		return true
+	}
+	if e.AttemptedAt.IsZero() {
+		return true
+	}
+	return time.Since(e.AttemptedAt) >= interval
+}
+
+// IsReleaseVersion reports whether the version looks like a tagged semver
+// release suitable for update comparisons.
+func IsReleaseVersion(v string) bool {
+	normalized := normalizeVersion(v)
+	if normalized == "" {
+		return false
+	}
+	return semver.IsValid("v" + normalized)
+}
+
+// AvailableUpdateForVersion reports whether the current version is behind the
+// latest known release.
+func AvailableUpdateForVersion(currentVersion string, latest LatestReleaseInfo) (*AvailableUpdate, bool) {
+	if !IsReleaseVersion(currentVersion) {
+		return nil, false
+	}
+	if strings.TrimSpace(latest.LatestVersion) == "" {
+		return nil, false
+	}
+	cmp, ok := compareVersions(currentVersion, latest.LatestVersion)
+	if !ok || cmp >= 0 {
+		return nil, false
+	}
+	return &AvailableUpdate{
+		CurrentVersion: currentVersion,
+		LatestVersion:  latest.LatestVersion,
+		ReleaseURL:     latest.ReleaseURL,
+	}, true
+}
+
+// CheckLatestRelease fetches the latest release metadata from GitHub without
+// performing the heavier asset validation used by self-update install flows.
+func (c *Client) CheckLatestRelease(ctx context.Context) (LatestReleaseInfo, error) {
+	checkedAt := time.Now().UTC()
+	rel, err := c.fetchRelease(ctx, "")
+	if err != nil {
+		return LatestReleaseInfo{}, err
+	}
+	return LatestReleaseInfo{
+		CheckedAt:     checkedAt,
+		AttemptedAt:   checkedAt,
+		LatestVersion: rel.TagName,
+		ReleaseURL:    rel.HTMLURL,
+	}, nil
+}
+
+// RefreshLatestReleaseCache performs a live latest-release check and merges the
+// result into the existing cache entry. Failed attempts still advance
+// AttemptedAt so callers can throttle future checks.
+func RefreshLatestReleaseCache(ctx context.Context, client *Client, cached *LatestReleaseInfo) (LatestReleaseInfo, error) {
+	next := LatestReleaseInfo{}
+	if cached != nil {
+		next = *cached
+	}
+	next.AttemptedAt = time.Now().UTC()
+
+	latest, err := client.CheckLatestRelease(ctx)
+	if err != nil {
+		return next, err
+	}
+	return LatestReleaseInfo{
+		CheckedAt:     latest.CheckedAt,
+		AttemptedAt:   latest.AttemptedAt,
+		LatestVersion: latest.LatestVersion,
+		ReleaseURL:    latest.ReleaseURL,
+	}, nil
+}

--- a/internal/updater/check_test.go
+++ b/internal/updater/check_test.go
@@ -1,0 +1,88 @@
+package updater
+
+import (
+	"context"
+	"errors"
+	"net/http"
+	"testing"
+	"time"
+)
+
+func TestIsReleaseVersion(t *testing.T) {
+	if !IsReleaseVersion("v1.2.3") {
+		t.Fatal("expected tagged semver release to be valid")
+	}
+	if IsReleaseVersion("dev") {
+		t.Fatal("expected dev version to be rejected")
+	}
+}
+
+func TestAvailableUpdateForVersion_UpdateAvailable(t *testing.T) {
+	update, ok := AvailableUpdateForVersion("v1.0.0", LatestReleaseInfo{
+		CheckedAt:     time.Now(),
+		AttemptedAt:   time.Now(),
+		LatestVersion: "v1.1.0",
+		ReleaseURL:    "https://example.com/release",
+	})
+	if !ok {
+		t.Fatal("expected available update")
+	}
+	if update.CurrentVersion != "v1.0.0" {
+		t.Fatalf("current version = %q, want %q", update.CurrentVersion, "v1.0.0")
+	}
+	if update.LatestVersion != "v1.1.0" {
+		t.Fatalf("latest version = %q, want %q", update.LatestVersion, "v1.1.0")
+	}
+}
+
+func TestAvailableUpdateForVersion_NoUpdateForInvalidCurrentVersion(t *testing.T) {
+	if _, ok := AvailableUpdateForVersion("dev", LatestReleaseInfo{LatestVersion: "v1.1.0"}); ok {
+		t.Fatal("expected no update for dev builds")
+	}
+}
+
+func TestLatestReleaseInfoAttemptExpired(t *testing.T) {
+	entry := LatestReleaseInfo{AttemptedAt: time.Now().Add(-2 * time.Hour)}
+	if !entry.AttemptExpired(time.Hour) {
+		t.Fatal("expected attempt to be expired")
+	}
+	if entry.AttemptExpired(3 * time.Hour) {
+		t.Fatal("expected attempt to be fresh")
+	}
+	if !(LatestReleaseInfo{}).AttemptExpired(time.Hour) {
+		t.Fatal("expected zero AttemptedAt to be expired")
+	}
+}
+
+func TestRefreshLatestReleaseCache_PreservesCachedDataOnError(t *testing.T) {
+	cached := &LatestReleaseInfo{
+		CheckedAt:     time.Now().Add(-48 * time.Hour),
+		AttemptedAt:   time.Now().Add(-48 * time.Hour),
+		LatestVersion: "v1.1.0",
+		ReleaseURL:    "https://example.com/release",
+	}
+	client := &Client{HTTP: roundTripperClient(func(*http.Request) (*http.Response, error) {
+		return nil, errors.New("boom")
+	})}
+
+	updated, err := RefreshLatestReleaseCache(context.Background(), client, cached)
+	if err == nil {
+		t.Fatal("expected refresh error")
+	}
+	if updated.LatestVersion != cached.LatestVersion {
+		t.Fatalf("latest version = %q, want preserved %q", updated.LatestVersion, cached.LatestVersion)
+	}
+	if !updated.AttemptedAt.After(cached.AttemptedAt) {
+		t.Fatal("expected AttemptedAt to advance on error")
+	}
+}
+
+type roundTripperFunc func(*http.Request) (*http.Response, error)
+
+func (f roundTripperFunc) RoundTrip(req *http.Request) (*http.Response, error) {
+	return f(req)
+}
+
+func roundTripperClient(fn roundTripperFunc) *http.Client {
+	return &http.Client{Transport: fn}
+}


### PR DESCRIPTION
## Summary
- add a lightweight update-available header to normal terminal output when a newer release exists
- cache latest release metadata and use a soft/background plus hard/foreground refresh policy to keep checks cheap
- document the new behavior in the changelog

## Testing
- just fmt
- just test
- just lint