### PR TITLE
Fix OAuth refresh token rotation breaking external CLI chains

### DIFF
--- a/internal/auth/google/google.go
+++ b/internal/auth/google/google.go
@@ -19,12 +19,15 @@ type TokenResponse = oauth.TokenResponse
 type RefreshConfig struct {
 	ClientID     string
 	ClientSecret string
-	ProviderID   string // e.g. "gemini" or "antigravity"
-	HTTPTimeout  float64
+	// Save, if non-nil, is invoked with the refreshed credentials so the
+	// caller can persist them. See oauth.RefreshConfig.Save.
+	Save        func(*oauth.Credentials) error
+	HTTPTimeout float64
 }
 
-// RefreshToken refreshes an expired Google OAuth token and saves the updated
-// credentials to disk. Returns nil if the refresh fails.
+// RefreshToken refreshes an expired Google OAuth token. If cfg.Save is
+// non-nil, it is invoked with the new credentials. Returns nil if the
+// refresh fails.
 func RefreshToken(ctx context.Context, creds *oauth.Credentials, cfg RefreshConfig) *oauth.Credentials {
 	return oauth.Refresh(ctx, creds.RefreshToken, oauth.RefreshConfig{
 		TokenURL: TokenURL,
@@ -32,7 +35,7 @@ func RefreshToken(ctx context.Context, creds *oauth.Credentials, cfg RefreshConf
 			"client_id":     cfg.ClientID,
 			"client_secret": cfg.ClientSecret,
 		},
-		ProviderID:  cfg.ProviderID,
+		Save:        cfg.Save,
 		HTTPTimeout: cfg.HTTPTimeout,
 	})
 }

--- a/internal/auth/oauth/cli_refresh.go
+++ b/internal/auth/oauth/cli_refresh.go
@@ -23,7 +23,26 @@ type CLIRefreshConfig struct {
 // that refreshes tokens as a side effect on startup. It polls for fresh
 // credentials every 25ms and kills the process as soon as they appear (or
 // after a 15-second timeout).
+//
+// "Fresh" means the access token differs from whatever was on disk before
+// the subprocess started. Some providers (notably Codex) store credentials
+// without an expires_at, so NeedsRefresh() alone can't tell whether the CLI
+// has actually rotated the token — checking for a change in access token
+// avoids accepting the pre-refresh creds on the first poll.
 func RefreshViaCLI(ctx context.Context, cfg CLIRefreshConfig) *Credentials {
+	initial := cfg.LoadCredentials()
+	var initialToken string
+	if initial != nil {
+		initialToken = initial.AccessToken
+	}
+
+	isFresh := func(c *Credentials) bool {
+		if c == nil || c.AccessToken == "" || c.AccessToken == initialToken {
+			return false
+		}
+		return !c.NeedsRefresh()
+	}
+
 	binPath, err := exec.LookPath(cfg.BinaryName)
 	if err != nil {
 		return nil
@@ -50,7 +69,7 @@ func RefreshViaCLI(ctx context.Context, cfg CLIRefreshConfig) *Credentials {
 	defer ticker.Stop()
 
 	for {
-		if creds := cfg.LoadCredentials(); creds != nil && !creds.NeedsRefresh() {
+		if creds := cfg.LoadCredentials(); isFresh(creds) {
 			killProcess(cmd)
 			return creds
 		}
@@ -58,14 +77,14 @@ func RefreshViaCLI(ctx context.Context, cfg CLIRefreshConfig) *Credentials {
 		select {
 		case <-done:
 			creds := cfg.LoadCredentials()
-			if creds == nil || creds.NeedsRefresh() {
+			if !isFresh(creds) {
 				return nil
 			}
 			return creds
 		case <-tctx.Done():
 			killProcess(cmd)
 			creds := cfg.LoadCredentials()
-			if creds == nil || creds.NeedsRefresh() {
+			if !isFresh(creds) {
 				return nil
 			}
 			return creds

--- a/internal/auth/oauth/cli_refresh_test.go
+++ b/internal/auth/oauth/cli_refresh_test.go
@@ -118,6 +118,88 @@ func TestRefreshViaCLI_RespectsContextCancellation(t *testing.T) {
 	}
 }
 
+func TestRefreshViaCLI_DoesNotShortCircuitWhenCredsHaveNoExpiry(t *testing.T) {
+	// Regression: providers like Codex store creds without expires_at, so
+	// NeedsRefresh() returns false even for stale tokens. RefreshViaCLI must
+	// not accept the pre-refresh creds on the first poll just because they
+	// look "non-expiring".
+	binDir, credPath := setupFakeCLI(t,
+		"#!/usr/bin/env sh\nsleep 0.05\nmkdir -p \"$(dirname \"$CRED_PATH\")\"\n"+
+			"cat > \"$CRED_PATH\" <<'JSON'\n"+
+			"{\"access_token\":\"refreshed\",\"refresh_token\":\"newref\"}\n"+
+			"JSON\n")
+
+	// Pre-write the existing creds file with the *old* token (no expires_at).
+	initial := `{"access_token":"stale","refresh_token":"oldref"}`
+	if err := os.WriteFile(credPath, []byte(initial), 0o600); err != nil {
+		t.Fatalf("WriteFile: %v", err)
+	}
+
+	got := RefreshViaCLI(context.Background(), CLIRefreshConfig{
+		BinaryName:      "testcli",
+		Args:            []string{"refresh"},
+		LoadCredentials: credLoader(credPath),
+	})
+	_ = binDir
+
+	if got == nil {
+		t.Fatal("RefreshViaCLI() = nil, want refreshed creds")
+	}
+	if got.AccessToken != "refreshed" {
+		t.Errorf("access_token = %q, want %q (must wait for CLI to write new token)", got.AccessToken, "refreshed")
+	}
+}
+
+func TestRefreshViaCLI_RejectsChangedButExpiredToken(t *testing.T) {
+	// A changed access token still has to satisfy !NeedsRefresh(). If the
+	// CLI rotates to a token that's already expired, treat it as a failed
+	// refresh — we don't want the caller to immediately re-enter the
+	// refresh path.
+	binDir, credPath := setupFakeCLI(t,
+		"#!/usr/bin/env sh\nsleep 0.05\nmkdir -p \"$(dirname \"$CRED_PATH\")\"\n"+
+			"cat > \"$CRED_PATH\" <<'JSON'\n"+
+			"{\"access_token\":\"changed\",\"refresh_token\":\"r\",\"expires_at\":\"2020-01-01T00:00:00Z\"}\n"+
+			"JSON\n")
+
+	initial := `{"access_token":"stale","refresh_token":"r","expires_at":"2020-01-01T00:00:00Z"}`
+	if err := os.WriteFile(credPath, []byte(initial), 0o600); err != nil {
+		t.Fatalf("WriteFile: %v", err)
+	}
+
+	got := RefreshViaCLI(context.Background(), CLIRefreshConfig{
+		BinaryName:      "testcli",
+		Args:            []string{"refresh"},
+		LoadCredentials: credLoader(credPath),
+	})
+	_ = binDir
+
+	if got != nil {
+		t.Errorf("RefreshViaCLI() = %+v, want nil for a token that was rotated to an already-expired value", got)
+	}
+}
+
+func TestRefreshViaCLI_ReturnsNilWhenCLIDoesNotChangeToken(t *testing.T) {
+	// If the CLI exits without rotating the token, refresh has effectively
+	// failed — we must return nil rather than the unchanged creds.
+	binDir, credPath := setupFakeCLI(t, "#!/usr/bin/env sh\nexit 0\n")
+
+	initial := `{"access_token":"unchanged","refresh_token":"ref"}`
+	if err := os.WriteFile(credPath, []byte(initial), 0o600); err != nil {
+		t.Fatalf("WriteFile: %v", err)
+	}
+
+	got := RefreshViaCLI(context.Background(), CLIRefreshConfig{
+		BinaryName:      "testcli",
+		Args:            []string{"refresh"},
+		LoadCredentials: credLoader(credPath),
+	})
+	_ = binDir
+
+	if got != nil {
+		t.Errorf("RefreshViaCLI() = %+v, want nil when token did not change", got)
+	}
+}
+
 func TestRefreshViaCLI_PollsMultipleTimes(t *testing.T) {
 	binDir, credPath := setupFakeCLI(t,
 		"#!/usr/bin/env sh\nsleep 0.1\nmkdir -p \"$(dirname \"$CRED_PATH\")\"\n"+

--- a/internal/auth/oauth/oauth.go
+++ b/internal/auth/oauth/oauth.go
@@ -4,11 +4,10 @@ package oauth
 
 import (
 	"context"
-	"encoding/json"
 	"time"
 
-	"github.com/joshuadavidthomas/vibeusage/internal/config"
 	"github.com/joshuadavidthomas/vibeusage/internal/httpclient"
+	"github.com/joshuadavidthomas/vibeusage/internal/logging"
 )
 
 // RefreshBuffer is the duration before token expiry at which a refresh is
@@ -53,14 +52,24 @@ type RefreshConfig struct {
 	FormFields map[string]string
 	// Headers are provider-specific request options (e.g. anthropic-beta header).
 	Headers []httpclient.RequestOption
-	// ProviderID is used to determine the credential save path.
-	ProviderID string
+	// Save, if non-nil, is invoked with the refreshed credentials so the caller
+	// can persist them. Vibeusage-owned chains pass a writer here; piggy-back
+	// providers (where another tool owns the rotating chain) leave it nil so
+	// rotated tokens are not written back to vibeusage's own credential store.
+	//
+	// A Save error does not invalidate the refreshed credentials — they are
+	// still returned for use by the current request — but the failure is
+	// logged via the context's logger (see logging.FromContext) so operators
+	// can detect that rotated tokens were not durably stored. The next
+	// invocation will refresh again.
+	Save func(*Credentials) error
 	// HTTPTimeout is the request timeout in seconds.
 	HTTPTimeout float64
 }
 
-// Refresh exchanges a refresh token for a new access token and saves the
-// updated credentials to disk. Returns nil if the refresh fails for any reason.
+// Refresh exchanges a refresh token for a new access token. If cfg.Save is
+// non-nil, it is invoked with the new credentials so the caller can persist
+// them. Returns nil if the refresh fails for any reason.
 func Refresh(ctx context.Context, refreshToken string, cfg RefreshConfig) *Credentials {
 	if refreshToken == "" {
 		return nil
@@ -99,8 +108,11 @@ func Refresh(ctx context.Context, refreshToken string, cfg RefreshConfig) *Crede
 		updated.RefreshToken = refreshToken
 	}
 
-	content, _ := json.Marshal(updated)
-	_ = config.WriteCredential(cfg.ProviderID, "oauth", content)
+	if cfg.Save != nil {
+		if err := cfg.Save(updated); err != nil {
+			logging.FromContext(ctx).Warn("oauth: persisting refreshed credentials failed", "err", err)
+		}
+	}
 
 	return updated
 }

--- a/internal/auth/oauth/oauth_test.go
+++ b/internal/auth/oauth/oauth_test.go
@@ -1,7 +1,10 @@
 package oauth
 
 import (
+	"context"
 	"encoding/json"
+	"net/http"
+	"net/http/httptest"
 	"testing"
 	"time"
 )
@@ -127,5 +130,184 @@ func TestTokenResponse_UnmarshalMinimal(t *testing.T) {
 	}
 	if resp.ExpiresIn != 0 {
 		t.Errorf("expires_in = %v, want 0", resp.ExpiresIn)
+	}
+}
+
+func TestRefresh_EmptyRefreshToken(t *testing.T) {
+	saveCalled := false
+	got := Refresh(context.Background(), "", RefreshConfig{
+		TokenURL: "http://unused.invalid",
+		Save:     func(*Credentials) error { saveCalled = true; return nil },
+	})
+	if got != nil {
+		t.Errorf("Refresh() = %+v, want nil", got)
+	}
+	if saveCalled {
+		t.Error("Save should not be called when refresh token is empty")
+	}
+}
+
+func TestRefresh_SaveInvokedWithNewCreds(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		_ = r.ParseForm()
+		if r.FormValue("grant_type") != "refresh_token" {
+			t.Errorf("grant_type = %q, want refresh_token", r.FormValue("grant_type"))
+		}
+		if r.FormValue("refresh_token") != "old-refresh" {
+			t.Errorf("refresh_token = %q, want old-refresh", r.FormValue("refresh_token"))
+		}
+		if r.FormValue("client_id") != "cid" {
+			t.Errorf("client_id = %q, want cid", r.FormValue("client_id"))
+		}
+		_ = json.NewEncoder(w).Encode(map[string]any{
+			"access_token":  "new-access",
+			"refresh_token": "new-refresh",
+			"expires_in":    3600,
+		})
+	}))
+	defer srv.Close()
+
+	var saved *Credentials
+	got := Refresh(context.Background(), "old-refresh", RefreshConfig{
+		TokenURL:   srv.URL,
+		FormFields: map[string]string{"client_id": "cid"},
+		Save:       func(c *Credentials) error { saved = c; return nil },
+	})
+
+	if got == nil {
+		t.Fatal("Refresh() = nil, want creds")
+	}
+	if got.AccessToken != "new-access" {
+		t.Errorf("access_token = %q, want new-access", got.AccessToken)
+	}
+	if got.RefreshToken != "new-refresh" {
+		t.Errorf("refresh_token = %q, want new-refresh", got.RefreshToken)
+	}
+	if got.ExpiresAt == "" {
+		t.Error("expires_at should be set when expires_in > 0")
+	}
+	if saved == nil {
+		t.Fatal("Save was not invoked")
+	}
+	if saved != got {
+		t.Error("Save received a different *Credentials than was returned")
+	}
+}
+
+func TestRefresh_NilSaveIsNoop(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		_ = json.NewEncoder(w).Encode(map[string]any{
+			"access_token": "new-access",
+			"expires_in":   3600,
+		})
+	}))
+	defer srv.Close()
+
+	got := Refresh(context.Background(), "old-refresh", RefreshConfig{
+		TokenURL: srv.URL,
+		Save:     nil,
+	})
+
+	if got == nil {
+		t.Fatal("Refresh() = nil, want creds")
+	}
+	if got.AccessToken != "new-access" {
+		t.Errorf("access_token = %q, want new-access", got.AccessToken)
+	}
+}
+
+func TestRefresh_PreservesOldRefreshTokenWhenServerOmitsIt(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		_ = json.NewEncoder(w).Encode(map[string]any{
+			"access_token": "new-access",
+			"expires_in":   3600,
+		})
+	}))
+	defer srv.Close()
+
+	var saved *Credentials
+	got := Refresh(context.Background(), "old-refresh", RefreshConfig{
+		TokenURL: srv.URL,
+		Save:     func(c *Credentials) error { saved = c; return nil },
+	})
+
+	if got == nil || got.RefreshToken != "old-refresh" {
+		t.Errorf("refresh_token = %q, want old-refresh (preserved)", got.RefreshToken)
+	}
+	if saved == nil || saved.RefreshToken != "old-refresh" {
+		t.Error("Save should receive creds with the preserved old refresh token")
+	}
+}
+
+func TestRefresh_ServerErrorDoesNotInvokeSave(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		http.Error(w, "bad request", http.StatusBadRequest)
+	}))
+	defer srv.Close()
+
+	saveCalled := false
+	got := Refresh(context.Background(), "old-refresh", RefreshConfig{
+		TokenURL: srv.URL,
+		Save:     func(*Credentials) error { saveCalled = true; return nil },
+	})
+
+	if got != nil {
+		t.Errorf("Refresh() = %+v, want nil on server error", got)
+	}
+	if saveCalled {
+		t.Error("Save must not be called when refresh fails")
+	}
+}
+
+func TestRefresh_SaveErrorDoesNotInvalidateReturnedCreds(t *testing.T) {
+	// Save errors mean persistence failed; the freshly-refreshed creds are
+	// still valid in memory and must be returned so the current request
+	// succeeds (the next invocation will refresh again).
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		_ = json.NewEncoder(w).Encode(map[string]any{
+			"access_token": "new-access",
+			"expires_in":   3600,
+		})
+	}))
+	defer srv.Close()
+
+	got := Refresh(context.Background(), "old-refresh", RefreshConfig{
+		TokenURL: srv.URL,
+		Save: func(*Credentials) error {
+			return errEphemeralPersistFail
+		},
+	})
+
+	if got == nil {
+		t.Fatal("Refresh() = nil, want creds even when Save fails")
+	}
+	if got.AccessToken != "new-access" {
+		t.Errorf("access_token = %q, want new-access", got.AccessToken)
+	}
+}
+
+var errEphemeralPersistFail = &persistErr{msg: "persist failed"}
+
+type persistErr struct{ msg string }
+
+func (e *persistErr) Error() string { return e.msg }
+
+func TestRefresh_EmptyAccessTokenDoesNotInvokeSave(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		_ = json.NewEncoder(w).Encode(map[string]any{"refresh_token": "r"})
+	}))
+	defer srv.Close()
+
+	saveCalled := false
+	got := Refresh(context.Background(), "old-refresh", RefreshConfig{
+		TokenURL: srv.URL,
+		Save:     func(*Credentials) error { saveCalled = true; return nil },
+	})
+
+	if got != nil {
+		t.Errorf("Refresh() = %+v, want nil when access_token missing", got)
+	}
+	if saveCalled {
+		t.Error("Save must not be called when access_token is empty")
 	}
 }

--- a/internal/cli/auth.go
+++ b/internal/cli/auth.go
@@ -485,10 +485,9 @@ func authSetToken(providerID string, p provider.Provider, token string) error {
 		return fmt.Errorf("credential cannot be empty")
 	}
 
-	auth, ok := p.(provider.Authenticator)
-	if ok {
-		flow := auth.Auth()
-		if f, isManual := flow.(provider.ManualKeyAuthFlow); isManual {
+	if auth, ok := p.(provider.Authenticator); ok {
+		switch f := auth.Auth().(type) {
+		case provider.ManualKeyAuthFlow:
 			if f.Validate != nil {
 				if err := f.Validate(token); err != nil {
 					return err
@@ -508,10 +507,27 @@ func authSetToken(providerID string, p provider.Provider, token string) error {
 				out("✓ %s credential saved\n", provider.DisplayName(providerID))
 			}
 			return nil
+		default:
+			// The provider's primary flow doesn't accept a manually pasted
+			// token (e.g. device flow, browser redirect, or a CLI-owned
+			// chain). Some such providers still expose a secondary stored
+			// credential path — they opt in via TokenAcceptor. Without that
+			// opt-in we refuse rather than write a credential fetch will
+			// silently ignore.
+			if acceptor, ok := p.(provider.TokenAcceptor); ok {
+				if err := acceptor.AcceptToken(token); err != nil {
+					return fmt.Errorf("error saving credential: %w", err)
+				}
+				if !quiet {
+					out("✓ %s credential saved\n", provider.DisplayName(providerID))
+				}
+				return nil
+			}
+			return fmt.Errorf("%s does not support --token; run `vibeusage auth %s` for the supported flow", provider.DisplayName(providerID), providerID)
 		}
 	}
 
-	// Fallback for providers without a ManualKeyAuthFlow.
+	// Provider doesn't implement Authenticator at all — generic apikey fallback.
 	credData, _ := json.Marshal(map[string]string{"api_key": token})
 	if err := config.WriteCredential(providerID, "apikey", credData); err != nil {
 		return fmt.Errorf("error saving credential: %w", err)

--- a/internal/cli/auth_test.go
+++ b/internal/cli/auth_test.go
@@ -385,6 +385,61 @@ func TestAuthSetToken_RejectsEmpty(t *testing.T) {
 	}
 }
 
+func TestAuthSetToken_RejectsCustomAuthFlowProvider(t *testing.T) {
+	// Codex now uses a CustomAuthFlow that defers to the Codex CLI; --token
+	// has no usable destination and previously fell through to a generic
+	// apikey slot that fetch ignored. authSetToken must refuse instead.
+	tmpDir := t.TempDir()
+	testenv.ApplySameDir(t.Setenv, tmpDir)
+	config.Override(t, config.DefaultConfig())
+
+	var buf bytes.Buffer
+	outWriter = &buf
+	defer func() { outWriter = os.Stdout }()
+
+	p, _ := provider.Get("codex")
+	err := authSetToken("codex", p, "some-token")
+	if err == nil {
+		t.Fatal("expected --token to be rejected for codex (CustomAuthFlow)")
+	}
+	if config.HasCredential("codex", "apikey") {
+		t.Error("codex/apikey must not be written for a CustomAuthFlow provider")
+	}
+	if config.HasCredential("codex", "oauth") {
+		t.Error("codex/oauth must not be written by --token")
+	}
+}
+
+func TestAuthSetToken_AcceptsKimiCodeViaTokenAcceptor(t *testing.T) {
+	// KimiCode advertises a DeviceAuthFlow but also supports a stored API
+	// key via APIKeyStrategy; it implements provider.TokenAcceptor so
+	// --token routes to the apikey slot instead of being rejected.
+	tmpDir := t.TempDir()
+	testenv.ApplySameDir(t.Setenv, tmpDir)
+	t.Setenv("KIMI_CODE_API_KEY", "")
+	config.Override(t, config.DefaultConfig())
+
+	var buf bytes.Buffer
+	outWriter = &buf
+	defer func() { outWriter = os.Stdout }()
+
+	p, _ := provider.Get("kimicode")
+	if err := authSetToken("kimicode", p, "my-api-key"); err != nil {
+		t.Fatalf("authSetToken error: %v", err)
+	}
+	data, err := config.ReadCredential("kimicode", "apikey")
+	if err != nil || data == nil {
+		t.Fatalf("kimicode/apikey not written: data=%q err=%v", data, err)
+	}
+	var payload map[string]string
+	if err := json.Unmarshal(data, &payload); err != nil {
+		t.Fatalf("unmarshal: %v", err)
+	}
+	if payload["api_key"] != "my-api-key" {
+		t.Errorf("api_key = %q, want my-api-key", payload["api_key"])
+	}
+}
+
 // JSON output tests
 
 func TestAuthStatusJSON_UsesTypedStruct(t *testing.T) {

--- a/internal/provider/antigravity/antigravity.go
+++ b/internal/provider/antigravity/antigravity.go
@@ -112,7 +112,7 @@ func vscdbPath() string {
 }
 
 func (s *OAuthStrategy) Fetch(ctx context.Context) (fetch.FetchResult, error) {
-	creds := s.loadCredentials()
+	creds, source := s.loadCredentials()
 	if creds == nil {
 		return fetch.ResultFail("No OAuth credentials found"), nil
 	}
@@ -121,11 +121,30 @@ func (s *OAuthStrategy) Fetch(ctx context.Context) (fetch.FetchResult, error) {
 		return fetch.ResultFail("Invalid credentials: missing access_token"), nil
 	}
 
+	// Buggy-era residue: vibeusage's slot was populated by the pre-fix
+	// refresh path (no vibeusage_owned marker) and there is no canonical
+	// IDE source to migrate to. The chain forked at the moment of that
+	// rotated-RT write, so we can't refresh and can't trust the access
+	// token long-term. Fail closed so the user re-auths cleanly.
+	if source == sourceUnmarkedSlot {
+		return fetch.ResultFatal("Stale Antigravity credentials detected. Run `vibeusage auth antigravity` to re-authenticate."), nil
+	}
+
 	if creds.NeedsRefresh() {
+		// Only refresh against Google's token endpoint when vibeusage owns the
+		// chain (i.e. the user explicitly minted credentials via `vibeusage
+		// auth antigravity`). For creds piggy-backed off the IDE's file or
+		// vscdb, the refresh request itself can rotate the refresh token
+		// server-side — invalidating the IDE's stored copy and breaking its
+		// next refresh. Fail closed and let the user re-authenticate via
+		// the IDE, which will refresh on its own terms.
+		if source != sourceSlot {
+			return fetch.ResultFail("Token expired. Sign back in via the Antigravity IDE to refresh credentials, or run `vibeusage auth antigravity` for a vibeusage-owned chain."), nil
+		}
 		refreshed := google.RefreshToken(ctx, creds, google.RefreshConfig{
 			ClientID:     antigravityClientID,
 			ClientSecret: antigravityClientSecret,
-			ProviderID:   "antigravity",
+			Save:         saveAntigravityCredentials,
 			HTTPTimeout:  s.HTTPTimeout,
 		})
 		if refreshed == nil {
@@ -150,32 +169,109 @@ func (s *OAuthStrategy) Fetch(ctx context.Context) (fetch.FetchResult, error) {
 	return fetch.ResultOK(*snapshot), nil
 }
 
-func (s *OAuthStrategy) loadCredentials() *oauth.Credentials {
-	// Check vibeusage consolidated storage first
-	if data, err := config.ReadCredential("antigravity", "oauth"); err == nil && data != nil {
-		if creds := parseAntigravityCredentials(data); creds != nil {
-			return creds
-		}
+// credSource identifies which storage location supplied the loaded credentials.
+// Vibeusage owns the rotating chain only when the slot was the source (i.e.
+// the user minted credentials via `vibeusage auth antigravity`); for the
+// IDE-managed file and vscdb sources, vibeusage piggy-backs and must not
+// persist rotated tokens. sourceUnmarkedSlot is a buggy-era residue that
+// can no longer be safely refreshed and is treated as a hard failure.
+type credSource int
+
+const (
+	sourceNone credSource = iota
+	sourceSlot
+	sourceFile
+	sourceVSCDB
+	sourceUnmarkedSlot
+)
+
+func (s *OAuthStrategy) loadCredentials() (*oauth.Credentials, credSource) {
+	// Read the vibeusage slot first, but distinguish legitimately-minted
+	// credentials (carrying the vibeusage_owned marker, written by
+	// RunAuthFlow / saveAntigravityCredentials) from buggy-era residue (the
+	// old refresh path persisted rotated tokens here without a marker).
+	slotCreds, slotOwned := s.loadSlotCredentials()
+	if slotOwned {
+		return slotCreds, sourceSlot
 	}
 
-	// Check external CLI paths
+	// Check external CLI paths (IDE's credentials file).
 	for _, path := range s.externalPaths() {
 		data, err := os.ReadFile(path)
 		if err != nil {
 			continue
 		}
 		if creds := parseAntigravityCredentials(data); creds != nil {
-			return creds
+			if slotCreds != nil {
+				config.DeleteCredential("antigravity", "oauth")
+			}
+			return creds, sourceFile
 		}
 	}
 
-	// Try reading from Antigravity's VS Code state database
+	// Try reading from Antigravity's VS Code state database.
 	if result := loadFromVSCDB(); result != nil {
 		s.vscdb = result
-		return result.creds
+		if slotCreds != nil {
+			config.DeleteCredential("antigravity", "oauth")
+		}
+		return result.creds, sourceVSCDB
 	}
 
-	return nil
+	// No canonical source. If we still have an unmarked slot, surface it
+	// as sourceUnmarkedSlot so callers can recognise buggy-era residue and
+	// force a re-auth instead of refreshing it against Google or treating
+	// it as legitimate detected credentials.
+	if slotCreds != nil {
+		return slotCreds, sourceUnmarkedSlot
+	}
+
+	return nil, sourceNone
+}
+
+// loadSlotCredentials reads vibeusage's antigravity/oauth slot and reports
+// whether it carries the vibeusage_owned marker. Unmarked slots predate the
+// owned-chain marker (or were written by the old buggy refresh path) and are
+// not safe to refresh against Google's token endpoint.
+func (s *OAuthStrategy) loadSlotCredentials() (*oauth.Credentials, bool) {
+	data, err := config.ReadCredential("antigravity", "oauth")
+	if err != nil || data == nil {
+		return nil, false
+	}
+	var sc slotCredentials
+	if err := json.Unmarshal(data, &sc); err != nil || sc.AccessToken == "" {
+		return nil, false
+	}
+	return &oauth.Credentials{
+		AccessToken:  sc.AccessToken,
+		RefreshToken: sc.RefreshToken,
+		ExpiresAt:    sc.ExpiresAt,
+	}, sc.VibeusageOwned
+}
+
+// slotCredentials is the on-disk shape for vibeusage's antigravity/oauth slot.
+// VibeusageOwned distinguishes credentials minted via `vibeusage auth
+// antigravity` (refreshable here) from stale credentials written by the
+// pre-fix refresh path (must not be refreshed here).
+type slotCredentials struct {
+	AccessToken    string `json:"access_token"`
+	RefreshToken   string `json:"refresh_token,omitempty"`
+	ExpiresAt      string `json:"expires_at,omitempty"`
+	VibeusageOwned bool   `json:"vibeusage_owned,omitempty"`
+}
+
+func saveAntigravityCredentials(c *oauth.Credentials) error {
+	sc := slotCredentials{
+		AccessToken:    c.AccessToken,
+		RefreshToken:   c.RefreshToken,
+		ExpiresAt:      c.ExpiresAt,
+		VibeusageOwned: true,
+	}
+	content, err := json.Marshal(sc)
+	if err != nil {
+		return fmt.Errorf("marshal antigravity credentials: %w", err)
+	}
+	return config.WriteCredential("antigravity", "oauth", content)
 }
 
 func parseAntigravityCredentials(data []byte) *oauth.Credentials {

--- a/internal/provider/antigravity/antigravity_test.go
+++ b/internal/provider/antigravity/antigravity_test.go
@@ -1,9 +1,16 @@
 package antigravity
 
 import (
+	"context"
+	"os"
+	"path/filepath"
+	"strings"
 	"testing"
 
+	"github.com/joshuadavidthomas/vibeusage/internal/auth/oauth"
+	"github.com/joshuadavidthomas/vibeusage/internal/config"
 	"github.com/joshuadavidthomas/vibeusage/internal/models"
+	"github.com/joshuadavidthomas/vibeusage/internal/testenv"
 )
 
 func TestMeta(t *testing.T) {
@@ -291,5 +298,225 @@ func TestPeriodTypeForTier(t *testing.T) {
 				t.Errorf("periodTypeForTier(%q) = %q, want %q", tt.tier, got, tt.want)
 			}
 		})
+	}
+}
+
+// applyAntigravityTestEnv isolates os.UserConfigDir(), os.UserHomeDir() and
+// vibeusage's config dir to fresh temp dirs so external paths and the vscdb
+// lookup never resolve to real user data.
+func applyAntigravityTestEnv(t *testing.T) string {
+	t.Helper()
+	cfg := t.TempDir()
+	t.Setenv("XDG_CONFIG_HOME", cfg)
+	t.Setenv("HOME", t.TempDir())
+	testenv.ApplyVibeusage(t.Setenv, t.TempDir())
+	return cfg
+}
+
+func writeAntigravityFileCreds(t *testing.T, configDir string) {
+	t.Helper()
+	dir := filepath.Join(configDir, "Antigravity")
+	if err := os.MkdirAll(dir, 0o700); err != nil {
+		t.Fatalf("MkdirAll: %v", err)
+	}
+	content := `{"access_token":"file-tok","refresh_token":"file-ref","expires_at":"2099-01-01T00:00:00Z"}`
+	if err := os.WriteFile(filepath.Join(dir, "credentials.json"), []byte(content), 0o600); err != nil {
+		t.Fatalf("WriteFile: %v", err)
+	}
+}
+
+// writeAntigravityOwnedSlot writes a slot credential with the
+// vibeusage_owned marker, simulating creds minted via `vibeusage auth
+// antigravity`.
+func writeAntigravityOwnedSlot(t *testing.T) {
+	t.Helper()
+	content := `{"access_token":"slot-tok","refresh_token":"slot-ref","expires_at":"2099-01-01T00:00:00Z","vibeusage_owned":true}`
+	if err := config.WriteCredential("antigravity", "oauth", []byte(content)); err != nil {
+		t.Fatalf("WriteCredential: %v", err)
+	}
+}
+
+// writeAntigravityUnmarkedSlot writes a slot credential without the
+// vibeusage_owned marker, simulating buggy-era residue from the pre-fix
+// refresh path.
+func writeAntigravityUnmarkedSlot(t *testing.T) {
+	t.Helper()
+	content := `{"access_token":"slot-tok","refresh_token":"slot-ref","expires_at":"2099-01-01T00:00:00Z"}`
+	if err := config.WriteCredential("antigravity", "oauth", []byte(content)); err != nil {
+		t.Fatalf("WriteCredential: %v", err)
+	}
+}
+
+func TestLoadCredentials_OwnedSlotWinsOverFile(t *testing.T) {
+	cfg := applyAntigravityTestEnv(t)
+	writeAntigravityFileCreds(t, cfg)
+	writeAntigravityOwnedSlot(t)
+
+	s := &OAuthStrategy{}
+	creds, source := s.loadCredentials()
+	if creds == nil {
+		t.Fatal("loadCredentials() returned nil creds")
+	}
+	if source != sourceSlot {
+		t.Errorf("source = %v, want sourceSlot", source)
+	}
+	if creds.AccessToken != "slot-tok" {
+		t.Errorf("access_token = %q, want slot-tok", creds.AccessToken)
+	}
+}
+
+func TestLoadCredentials_UnmarkedSlotMigrates_FilePresent(t *testing.T) {
+	cfg := applyAntigravityTestEnv(t)
+	writeAntigravityFileCreds(t, cfg)
+	writeAntigravityUnmarkedSlot(t)
+
+	s := &OAuthStrategy{}
+	creds, source := s.loadCredentials()
+	if creds == nil {
+		t.Fatal("loadCredentials() returned nil creds")
+	}
+	if source != sourceFile {
+		t.Errorf("source = %v, want sourceFile (unmarked slot is buggy-era residue)", source)
+	}
+	if creds.AccessToken != "file-tok" {
+		t.Errorf("access_token = %q, want file-tok (canonical source)", creds.AccessToken)
+	}
+	if config.HasCredential("antigravity", "oauth") {
+		t.Error("unmarked slot should be deleted when canonical source is found")
+	}
+}
+
+func TestLoadCredentials_UnmarkedSlotSurfacesAsBuggyResidue(t *testing.T) {
+	applyAntigravityTestEnv(t)
+	writeAntigravityUnmarkedSlot(t)
+
+	s := &OAuthStrategy{}
+	creds, source := s.loadCredentials()
+	if creds == nil {
+		t.Fatal("loadCredentials() returned nil creds")
+	}
+	if source != sourceUnmarkedSlot {
+		t.Errorf("source = %v, want sourceUnmarkedSlot (buggy-era residue must be distinguishable from legitimate piggyback)", source)
+	}
+	if creds.AccessToken != "slot-tok" {
+		t.Errorf("access_token = %q, want slot-tok", creds.AccessToken)
+	}
+	if !config.HasCredential("antigravity", "oauth") {
+		t.Error("unmarked slot should be preserved when there is no canonical replacement (Fetch surfaces a re-auth message instead of deleting blindly)")
+	}
+}
+
+func TestFetch_FailsClosedForUnmarkedSlot(t *testing.T) {
+	applyAntigravityTestEnv(t)
+	writeAntigravityUnmarkedSlot(t)
+
+	s := &OAuthStrategy{}
+	res, err := s.Fetch(context.Background())
+	if err != nil {
+		t.Fatalf("Fetch error: %v", err)
+	}
+	if res.Success {
+		t.Fatal("Fetch should fail for an unmarked slot — the chain forked when the buggy refresh wrote the rotated RT")
+	}
+	if res.ShouldFallback {
+		t.Error("Fetch should be fatal (no fallback) so verification during `vibeusage auth` cannot accept stale piggyback creds")
+	}
+	if !strings.Contains(res.Error, "vibeusage auth antigravity") {
+		t.Errorf("Fetch error = %q, want guidance to re-auth", res.Error)
+	}
+}
+
+func TestLoadCredentials_FileSourceWhenNoSlot(t *testing.T) {
+	cfg := applyAntigravityTestEnv(t)
+	writeAntigravityFileCreds(t, cfg)
+
+	s := &OAuthStrategy{}
+	creds, source := s.loadCredentials()
+	if creds == nil {
+		t.Fatal("loadCredentials() returned nil creds")
+	}
+	if source != sourceFile {
+		t.Errorf("source = %v, want sourceFile", source)
+	}
+	if creds.AccessToken != "file-tok" {
+		t.Errorf("access_token = %q, want file-tok", creds.AccessToken)
+	}
+}
+
+func TestLoadCredentials_NoneWhenNothingPresent(t *testing.T) {
+	applyAntigravityTestEnv(t)
+
+	s := &OAuthStrategy{}
+	creds, source := s.loadCredentials()
+	if creds != nil {
+		t.Errorf("creds = %+v, want nil", creds)
+	}
+	if source != sourceNone {
+		t.Errorf("source = %v, want sourceNone", source)
+	}
+}
+
+func TestSaveAntigravityCredentials_RoundTripsAsOwnedSlot(t *testing.T) {
+	applyAntigravityTestEnv(t)
+
+	in := &oauth.Credentials{
+		AccessToken:  "new-access",
+		RefreshToken: "new-refresh",
+		ExpiresAt:    "2099-01-01T00:00:00Z",
+	}
+	if err := saveAntigravityCredentials(in); err != nil {
+		t.Fatalf("saveAntigravityCredentials: %v", err)
+	}
+
+	s := &OAuthStrategy{}
+	got, source := s.loadCredentials()
+	if got == nil {
+		t.Fatal("loadCredentials() = nil after save")
+	}
+	if source != sourceSlot {
+		t.Errorf("source = %v, want sourceSlot (saveAntigravityCredentials must mark as vibeusage-owned)", source)
+	}
+	if got.AccessToken != in.AccessToken {
+		t.Errorf("access_token = %q, want %q", got.AccessToken, in.AccessToken)
+	}
+	if got.RefreshToken != in.RefreshToken {
+		t.Errorf("refresh_token = %q, want %q", got.RefreshToken, in.RefreshToken)
+	}
+
+	// Verify the marker landed on disk.
+	data, err := config.ReadCredential("antigravity", "oauth")
+	if err != nil || data == nil {
+		t.Fatalf("ReadCredential after save: data=%q err=%v", data, err)
+	}
+	if !strings.Contains(string(data), `"vibeusage_owned":true`) {
+		t.Errorf("persisted slot missing vibeusage_owned marker: %s", data)
+	}
+}
+
+func TestFetch_FailsClosedForSourceFileWhenRefreshNeeded(t *testing.T) {
+	cfg := applyAntigravityTestEnv(t)
+
+	// Write a sourceFile credential with an expired access token so
+	// NeedsRefresh() triggers the refresh branch.
+	expired := "2020-01-01T00:00:00Z"
+	dir := filepath.Join(cfg, "Antigravity")
+	if err := os.MkdirAll(dir, 0o700); err != nil {
+		t.Fatalf("MkdirAll: %v", err)
+	}
+	content := `{"access_token":"file-tok","refresh_token":"file-ref","expires_at":"` + expired + `"}`
+	if err := os.WriteFile(filepath.Join(dir, "credentials.json"), []byte(content), 0o600); err != nil {
+		t.Fatalf("WriteFile: %v", err)
+	}
+
+	s := &OAuthStrategy{}
+	res, err := s.Fetch(context.Background())
+	if err != nil {
+		t.Fatalf("Fetch error: %v", err)
+	}
+	if res.Success {
+		t.Fatal("Fetch should fail when sourceFile creds need refresh")
+	}
+	if !strings.Contains(res.Error, "Antigravity IDE") {
+		t.Errorf("Fetch error = %q, want guidance to use the IDE", res.Error)
 	}
 }

--- a/internal/provider/antigravity/auth.go
+++ b/internal/provider/antigravity/auth.go
@@ -2,7 +2,6 @@ package antigravity
 
 import (
 	"context"
-	"encoding/json"
 	"fmt"
 	"io"
 	"net"
@@ -146,8 +145,7 @@ func exchangeCode(w io.Writer, code, redirectURI string, quiet bool) (bool, erro
 		creds.ExpiresAt = time.Now().UTC().Add(time.Duration(tokenResp.ExpiresIn) * time.Second).Format(time.RFC3339)
 	}
 
-	content, _ := json.Marshal(creds)
-	if err := config.WriteCredential("antigravity", "oauth", content); err != nil {
+	if err := saveAntigravityCredentials(creds); err != nil {
 		return false, fmt.Errorf("failed to save credentials: %w", err)
 	}
 

--- a/internal/provider/auth.go
+++ b/internal/provider/auth.go
@@ -63,6 +63,16 @@ type Authenticator interface {
 	Auth() AuthFlow
 }
 
+// TokenAcceptor is an optional interface for providers whose primary Auth()
+// flow isn't a ManualKeyAuthFlow but still accept a manually pasted
+// credential via the `--token` flag (e.g. KimiCode advertises a device flow
+// for OAuth but also supports a stored API key). Providers that do not
+// implement this interface reject `--token` so vibeusage doesn't write a
+// credential its fetch strategies will silently ignore.
+type TokenAcceptor interface {
+	AcceptToken(token string) error
+}
+
 // ValidateNotEmpty returns an error if the string is empty or whitespace-only.
 // Use this as the Validate field in ManualKeyAuthFlow for providers that need
 // only basic non-empty checking.

--- a/internal/provider/claude/oauth.go
+++ b/internal/provider/claude/oauth.go
@@ -20,8 +20,6 @@ import (
 const (
 	oauthUsageURL        = "https://api.anthropic.com/api/oauth/usage"
 	oauthAccountURL      = "https://api.anthropic.com/api/oauth/account"
-	oauthTokenURL        = "https://platform.claude.com/v1/oauth/token"
-	oauthClientID        = "9d1c250a-e61b-44d9-88ed-5944d1962f5e"
 	anthropicBetaTag     = "oauth-2025-04-20"
 	claudeKeychainSecret = "Claude Code-credentials"
 
@@ -40,9 +38,6 @@ type OAuthStrategy struct {
 }
 
 func (s *OAuthStrategy) IsAvailable() bool {
-	if config.HasCredential("claude", "oauth") {
-		return true
-	}
 	for _, p := range s.externalPaths() {
 		if _, err := os.Stat(p); err == nil {
 			return true
@@ -62,24 +57,21 @@ func (s *OAuthStrategy) Fetch(ctx context.Context) (fetch.FetchResult, error) {
 	}
 
 	if creds.NeedsRefresh() {
-		refreshed := s.refreshToken(ctx, creds)
-		if refreshed == nil {
-			refreshed = oauth.RefreshViaCLI(ctx, oauth.CLIRefreshConfig{
-				BinaryName: "claude",
-				Args: []string{
-					"-p", "ok",
-					"--model", "haiku",
-					"--output-format", "json",
-					"--no-session-persistence",
-					"--permission-mode", "plan",
-					"--allowed-tools", "",
-					"--max-budget-usd", "0.001",
-				},
-				LoadCredentials: func() *oauth.Credentials {
-					return s.loadCredentials()
-				},
-			})
-		}
+		refreshed := oauth.RefreshViaCLI(ctx, oauth.CLIRefreshConfig{
+			BinaryName: "claude",
+			Args: []string{
+				"-p", "ok",
+				"--model", "haiku",
+				"--output-format", "json",
+				"--no-session-persistence",
+				"--permission-mode", "plan",
+				"--allowed-tools", "",
+				"--max-budget-usd", "0.001",
+			},
+			LoadCredentials: func() *oauth.Credentials {
+				return s.loadCredentials()
+			},
+		})
 		if refreshed == nil {
 			return fetch.ResultFatal("OAuth token expired and could not be refreshed. Re-authenticate with the Claude CLI."), nil
 		}
@@ -192,25 +184,37 @@ func (s *OAuthStrategy) externalPaths() []string {
 }
 
 func (s *OAuthStrategy) loadCredentials() *oauth.Credentials {
-	// Check vibeusage consolidated storage first
-	if data, err := config.ReadCredential("claude", "oauth"); err == nil && data != nil {
-		if creds := parseClaudeCredentials(data); creds != nil {
-			return creds
-		}
-	}
-
-	// Check external CLI paths
+	// Read only from canonical Claude CLI sources. The OAuth chain is owned
+	// by the Claude CLI; vibeusage is a piggy-back consumer and never writes
+	// new tokens. Any stale entry in vibeusage's own credentials store is
+	// cleared lazily so it can't shadow the live source.
 	for _, path := range s.externalPaths() {
 		data, err := os.ReadFile(path)
 		if err != nil {
 			continue
 		}
 		if creds := parseClaudeCredentials(data); creds != nil {
+			cleanupOrphanOAuthSlot()
 			return creds
 		}
 	}
 
-	return s.loadKeychainCredentials()
+	if creds := s.loadKeychainCredentials(); creds != nil {
+		cleanupOrphanOAuthSlot()
+		return creds
+	}
+	return nil
+}
+
+// cleanupOrphanOAuthSlot removes any vibeusage-owned claude/oauth credential.
+// Earlier versions of vibeusage wrote rotated refresh tokens here, which
+// silently invalidated the Claude CLI's own refresh token. The vibeusage slot
+// has no legitimate use for Claude (manual auth uses claude/session), so it
+// is safe to drop whenever a canonical CLI/keychain source is present.
+func cleanupOrphanOAuthSlot() {
+	if config.HasCredential("claude", "oauth") {
+		config.DeleteCredential("claude", "oauth")
+	}
 }
 
 func parseClaudeCredentials(data []byte) *oauth.Credentials {
@@ -248,15 +252,6 @@ func (s *OAuthStrategy) loadKeychainCredentials() *oauth.Credentials {
 		return nil
 	}
 	return &creds
-}
-
-func (s *OAuthStrategy) refreshToken(ctx context.Context, creds *oauth.Credentials) *oauth.Credentials {
-	return oauth.Refresh(ctx, creds.RefreshToken, oauth.RefreshConfig{
-		TokenURL:    oauthTokenURL,
-		FormFields:  map[string]string{"client_id": oauthClientID},
-		ProviderID:  "claude",
-		HTTPTimeout: s.HTTPTimeout,
-	})
 }
 
 func (s *OAuthStrategy) parseOAuthUsageResponse(resp OAuthUsageResponse) *models.UsageSnapshot {

--- a/internal/provider/claude/oauth_test.go
+++ b/internal/provider/claude/oauth_test.go
@@ -2,6 +2,8 @@ package claude
 
 import (
 	"errors"
+	"os"
+	"path/filepath"
 	"testing"
 	"time"
 
@@ -511,5 +513,98 @@ func TestLoadKeychainCredentials_Error(t *testing.T) {
 	s := OAuthStrategy{}
 	if creds := s.loadKeychainCredentials(); creds != nil {
 		t.Fatalf("expected nil credentials, got %+v", creds)
+	}
+}
+
+// stubKeychainEmpty stubs readKeychainSecret to behave as if the keychain
+// has no entry. It restores the previous stub when the test ends.
+func stubKeychainEmpty(t *testing.T) {
+	t.Helper()
+	old := readKeychainSecret
+	t.Cleanup(func() { readKeychainSecret = old })
+	readKeychainSecret = func(string, string) (string, error) {
+		return "", errors.New("no entry")
+	}
+}
+
+// writeClaudeCLICreds writes a Claude CLI credentials file to ~/.claude.
+func writeClaudeCLICreds(t *testing.T, home string) {
+	t.Helper()
+	dir := filepath.Join(home, ".claude")
+	if err := os.MkdirAll(dir, 0o700); err != nil {
+		t.Fatalf("MkdirAll: %v", err)
+	}
+	content := `{"claudeAiOauth":{"accessToken":"cli-tok","refreshToken":"cli-ref","expiresAt":4102444800000}}`
+	if err := os.WriteFile(filepath.Join(dir, ".credentials.json"), []byte(content), 0o600); err != nil {
+		t.Fatalf("WriteFile: %v", err)
+	}
+}
+
+func TestLoadCredentials_DeletesOrphanSlotWhenCanonicalFilePresent(t *testing.T) {
+	home := t.TempDir()
+	t.Setenv("HOME", home)
+	testenv.ApplyVibeusage(t.Setenv, t.TempDir())
+	stubKeychainEmpty(t)
+
+	writeClaudeCLICreds(t, home)
+	if err := config.WriteCredential("claude", "oauth", []byte(`{"access_token":"stale"}`)); err != nil {
+		t.Fatalf("WriteCredential: %v", err)
+	}
+
+	s := OAuthStrategy{}
+	creds := s.loadCredentials()
+	if creds == nil {
+		t.Fatal("loadCredentials() = nil, want canonical creds")
+	}
+	if creds.AccessToken != "cli-tok" {
+		t.Errorf("access_token = %q, want cli-tok (canonical CLI source)", creds.AccessToken)
+	}
+	if config.HasCredential("claude", "oauth") {
+		t.Error("orphan claude/oauth slot should have been deleted")
+	}
+}
+
+func TestLoadCredentials_DeletesOrphanSlotWhenKeychainPresent(t *testing.T) {
+	t.Setenv("HOME", t.TempDir())
+	testenv.ApplyVibeusage(t.Setenv, t.TempDir())
+
+	old := readKeychainSecret
+	t.Cleanup(func() { readKeychainSecret = old })
+	readKeychainSecret = func(string, string) (string, error) {
+		return `{"claudeAiOauth":{"accessToken":"kc-tok","refreshToken":"kc-ref","expiresAt":4102444800000}}`, nil
+	}
+
+	if err := config.WriteCredential("claude", "oauth", []byte(`{"access_token":"stale"}`)); err != nil {
+		t.Fatalf("WriteCredential: %v", err)
+	}
+
+	s := OAuthStrategy{}
+	creds := s.loadCredentials()
+	if creds == nil {
+		t.Fatal("loadCredentials() = nil, want keychain creds")
+	}
+	if creds.AccessToken != "kc-tok" {
+		t.Errorf("access_token = %q, want kc-tok", creds.AccessToken)
+	}
+	if config.HasCredential("claude", "oauth") {
+		t.Error("orphan claude/oauth slot should have been deleted")
+	}
+}
+
+func TestLoadCredentials_NoCanonicalSource_PreservesOrphan(t *testing.T) {
+	t.Setenv("HOME", t.TempDir())
+	testenv.ApplyVibeusage(t.Setenv, t.TempDir())
+	stubKeychainEmpty(t)
+
+	if err := config.WriteCredential("claude", "oauth", []byte(`{"access_token":"stale"}`)); err != nil {
+		t.Fatalf("WriteCredential: %v", err)
+	}
+
+	s := OAuthStrategy{}
+	if creds := s.loadCredentials(); creds != nil {
+		t.Errorf("loadCredentials() = %+v, want nil (no canonical source)", creds)
+	}
+	if !config.HasCredential("claude", "oauth") {
+		t.Error("orphan should not be deleted when no canonical source is found")
 	}
 }

--- a/internal/provider/codex/codex.go
+++ b/internal/provider/codex/codex.go
@@ -5,6 +5,7 @@ import (
 	"crypto/sha256"
 	"encoding/json"
 	"fmt"
+	"io"
 	"os"
 	"path/filepath"
 	"strings"
@@ -48,27 +49,29 @@ func (c Codex) FetchStatus(ctx context.Context) models.ProviderStatus {
 	return provider.FetchStatuspageStatus(ctx, "https://status.openai.com")
 }
 
-// Auth returns the manual bearer token flow for Codex.
-// Codex uses OAuth tokens managed by the Codex CLI — users must authenticate
-// with the CLI first, or provide an access token obtained from the browser.
+// Auth points users at the Codex CLI for credential setup. vibeusage is a
+// read-only consumer of the Codex CLI's rotating OAuth chain; manually
+// pasted access tokens never refreshed and silently broke once expired.
 func (c Codex) Auth() provider.AuthFlow {
-	return provider.ManualKeyAuthFlow{
-		Instructions: "Codex uses OAuth tokens from the Codex CLI (recommended):\n" +
-			"  Install the CLI and run `codex login`\n" +
-			"\n" +
-			"Or provide an access token manually:\n" +
-			"  1. Open https://chatgpt.com in your browser and sign in\n" +
-			"  2. Open DevTools (F12 or Cmd+Option+I) → Network tab\n" +
-			"  3. Reload the page and click any request to chatgpt.com/backend-api/\n" +
-			"  4. In Request Headers, find the Authorization header\n" +
-			"  5. Copy the value after \"Bearer \" (starts with ey...)\n" +
-			"\n" +
-			"Note: Manually obtained tokens won't auto-refresh — run auth again when they expire.",
-		Placeholder: "ey... (OAuth access token)",
-		Validate:    provider.ValidateNotEmpty,
-		ProviderID:  "codex",
-		CredType:    "oauth",
-		JSONKey:     "access_token",
+	return provider.CustomAuthFlow{
+		RunFlow: func(w io.Writer, quiet bool) (bool, error) {
+			// We can only detect what the Codex CLI has already written. If a
+			// canonical source is present, accept it as success; otherwise
+			// instruct the user and return failure so the auth command exits
+			// non-zero (instead of silently no-oping).
+			s := &OAuthStrategy{}
+			if s.IsAvailable() {
+				if !quiet {
+					_, _ = fmt.Fprintln(w, "✓ Codex CLI credentials detected.")
+				}
+				return true, nil
+			}
+			if !quiet {
+				_, _ = fmt.Fprintln(w, "Codex uses OAuth tokens managed by the Codex CLI.")
+				_, _ = fmt.Fprintln(w, "Install the CLI and run `codex login`, then re-run this command.")
+			}
+			return false, fmt.Errorf("Codex CLI credentials not detected")
+		},
 	}
 }
 
@@ -77,10 +80,6 @@ func init() {
 }
 
 const (
-	// OAuth client ID extracted from the Codex CLI installation.
-	// Required to refresh tokens stored in ~/.codex/auth.json.
-	codexClientID      = "app_EMoamEEZ73f0CkXaXp7hrann"
-	codexTokenURL      = "https://auth.openai.com/oauth/token"
 	defaultUsageURL    = "https://chatgpt.com/backend-api/wham/usage"
 	codexKeychainLabel = "Codex Auth"
 )
@@ -92,9 +91,6 @@ type OAuthStrategy struct {
 }
 
 func (s *OAuthStrategy) IsAvailable() bool {
-	if config.HasCredential("codex", "oauth") {
-		return true
-	}
 	for _, p := range s.externalPaths() {
 		if _, err := os.Stat(p); err == nil {
 			return true
@@ -114,24 +110,21 @@ func (s *OAuthStrategy) Fetch(ctx context.Context) (fetch.FetchResult, error) {
 	}
 
 	// The Codex CLI stores credentials without expires_at, so the shared
-	// NeedsRefresh() can't detect expiry. Treat a missing expires_at with
-	// a refresh token as needing refresh — the token may be stale and the
-	// only way to know is to try.
+	// NeedsRefresh() can't detect expiry. When a refresh token is present,
+	// always defer to the Codex CLI to refresh — it owns the rotating chain,
+	// and any direct refresh from here would invalidate the CLI's copy.
 	if creds.NeedsRefresh() || (creds.ExpiresAt == "" && creds.RefreshToken != "") {
-		refreshed := s.refreshToken(ctx, creds)
-		if refreshed == nil {
-			refreshed = oauth.RefreshViaCLI(ctx, oauth.CLIRefreshConfig{
-				BinaryName: "codex",
-				Args: []string{
-					"exec", "say ok",
-					"--skip-git-repo-check",
-					"--sandbox", "read-only",
-				},
-				LoadCredentials: func() *oauth.Credentials {
-					return s.loadCredentials()
-				},
-			})
-		}
+		refreshed := oauth.RefreshViaCLI(ctx, oauth.CLIRefreshConfig{
+			BinaryName: "codex",
+			Args: []string{
+				"exec", "say ok",
+				"--skip-git-repo-check",
+				"--sandbox", "read-only",
+			},
+			LoadCredentials: func() *oauth.Credentials {
+				return s.loadCredentials()
+			},
+		})
 		if refreshed == nil {
 			return fetch.ResultFatal("OAuth token expired and could not be refreshed. Re-authenticate with `codex login`."), nil
 		}
@@ -178,17 +171,10 @@ func (s *OAuthStrategy) externalPaths() []string {
 }
 
 func (s *OAuthStrategy) loadCredentials() *oauth.Credentials {
-	// Check vibeusage consolidated storage first
-	if data, err := config.ReadCredential("codex", "oauth"); err == nil && data != nil {
-		var cliCreds CLICredentials
-		if err := json.Unmarshal(data, &cliCreds); err == nil {
-			if creds := cliCreds.EffectiveCredentials(); creds != nil {
-				return creds
-			}
-		}
-	}
-
-	// Check external CLI paths
+	// Read only from canonical Codex CLI sources. The OAuth chain is owned
+	// by the Codex CLI; vibeusage is a piggy-back consumer and never writes
+	// new tokens. Any stale entry in vibeusage's own credentials store is
+	// cleared lazily so it can't shadow the live source.
 	for _, path := range s.externalPaths() {
 		data, err := os.ReadFile(path)
 		if err != nil {
@@ -199,10 +185,28 @@ func (s *OAuthStrategy) loadCredentials() *oauth.Credentials {
 			continue
 		}
 		if creds := cliCreds.EffectiveCredentials(); creds != nil {
+			cleanupOrphanOAuthSlot()
 			return creds
 		}
 	}
-	return s.loadKeychainCredentials()
+
+	if creds := s.loadKeychainCredentials(); creds != nil {
+		cleanupOrphanOAuthSlot()
+		return creds
+	}
+	return nil
+}
+
+// cleanupOrphanOAuthSlot removes any vibeusage-owned codex/oauth credential.
+// Earlier versions of vibeusage wrote rotated refresh tokens here (and accepted
+// manually pasted access tokens), both of which silently invalidated the Codex
+// CLI's own refresh token. The slot has no legitimate use now that Auth()
+// points users at `codex login`, so it is safe to drop whenever a canonical
+// CLI/keychain source is present.
+func cleanupOrphanOAuthSlot() {
+	if config.HasCredential("codex", "oauth") {
+		config.DeleteCredential("codex", "oauth")
+	}
 }
 
 func (s *OAuthStrategy) loadKeychainCredentials() *oauth.Credentials {
@@ -241,15 +245,6 @@ func codexHomeDir() string {
 		return filepath.Clean(".codex")
 	}
 	return filepath.Join(home, ".codex")
-}
-
-func (s *OAuthStrategy) refreshToken(ctx context.Context, creds *oauth.Credentials) *oauth.Credentials {
-	return oauth.Refresh(ctx, creds.RefreshToken, oauth.RefreshConfig{
-		TokenURL:    codexTokenURL,
-		FormFields:  map[string]string{"client_id": codexClientID},
-		ProviderID:  "codex",
-		HTTPTimeout: s.HTTPTimeout,
-	})
 }
 
 func (s *OAuthStrategy) getUsageURL() string {

--- a/internal/provider/codex/codex_test.go
+++ b/internal/provider/codex/codex_test.go
@@ -1,13 +1,19 @@
 package codex
 
 import (
+	"bytes"
 	"encoding/json"
 	"errors"
 	"os"
+	"path/filepath"
+	"strings"
 	"testing"
 	"time"
 
+	"github.com/joshuadavidthomas/vibeusage/internal/config"
 	"github.com/joshuadavidthomas/vibeusage/internal/models"
+	"github.com/joshuadavidthomas/vibeusage/internal/provider"
+	"github.com/joshuadavidthomas/vibeusage/internal/testenv"
 )
 
 func TestParseUsageResponse_FullResponse(t *testing.T) {
@@ -243,5 +249,112 @@ func TestCodexHomeDir_ExpandsTilde(t *testing.T) {
 	want := home + "/.custom-codex"
 	if got := codexHomeDir(); got != want {
 		t.Errorf("codexHomeDir() = %q, want %q", got, want)
+	}
+}
+
+func stubCodexKeychainEmpty(t *testing.T) {
+	t.Helper()
+	old := readKeychainSecret
+	t.Cleanup(func() { readKeychainSecret = old })
+	readKeychainSecret = func(string, string) (string, error) {
+		return "", errors.New("no entry")
+	}
+}
+
+func writeCodexCLICreds(t *testing.T, home string) {
+	t.Helper()
+	dir := filepath.Join(home, ".codex")
+	if err := os.MkdirAll(dir, 0o700); err != nil {
+		t.Fatalf("MkdirAll: %v", err)
+	}
+	content := `{"tokens":{"access_token":"cli-tok","refresh_token":"cli-ref"}}`
+	if err := os.WriteFile(filepath.Join(dir, "auth.json"), []byte(content), 0o600); err != nil {
+		t.Fatalf("WriteFile: %v", err)
+	}
+}
+
+func TestLoadCredentials_DeletesOrphanSlotWhenCanonicalFilePresent(t *testing.T) {
+	home := t.TempDir()
+	t.Setenv("HOME", home)
+	t.Setenv("CODEX_HOME", "")
+	testenv.ApplyVibeusage(t.Setenv, t.TempDir())
+	stubCodexKeychainEmpty(t)
+
+	writeCodexCLICreds(t, home)
+	if err := config.WriteCredential("codex", "oauth", []byte(`{"access_token":"stale"}`)); err != nil {
+		t.Fatalf("WriteCredential: %v", err)
+	}
+
+	s := OAuthStrategy{}
+	creds := s.loadCredentials()
+	if creds == nil {
+		t.Fatal("loadCredentials() = nil, want canonical creds")
+	}
+	if creds.AccessToken != "cli-tok" {
+		t.Errorf("access_token = %q, want cli-tok", creds.AccessToken)
+	}
+	if config.HasCredential("codex", "oauth") {
+		t.Error("orphan codex/oauth slot should have been deleted")
+	}
+}
+
+func TestLoadCredentials_NoCanonicalSource_PreservesOrphan(t *testing.T) {
+	t.Setenv("HOME", t.TempDir())
+	t.Setenv("CODEX_HOME", "")
+	testenv.ApplyVibeusage(t.Setenv, t.TempDir())
+	stubCodexKeychainEmpty(t)
+
+	if err := config.WriteCredential("codex", "oauth", []byte(`{"access_token":"stale"}`)); err != nil {
+		t.Fatalf("WriteCredential: %v", err)
+	}
+
+	s := OAuthStrategy{}
+	if creds := s.loadCredentials(); creds != nil {
+		t.Errorf("loadCredentials() = %+v, want nil (no canonical source)", creds)
+	}
+	if !config.HasCredential("codex", "oauth") {
+		t.Error("orphan should not be deleted when no canonical source is found")
+	}
+}
+
+func TestAuth_FailsWhenNoCanonicalSource(t *testing.T) {
+	t.Setenv("HOME", t.TempDir())
+	t.Setenv("CODEX_HOME", "")
+	testenv.ApplyVibeusage(t.Setenv, t.TempDir())
+	stubCodexKeychainEmpty(t)
+
+	flow, ok := Codex{}.Auth().(provider.CustomAuthFlow)
+	if !ok {
+		t.Fatalf("Codex.Auth() type = %T, want CustomAuthFlow", Codex{}.Auth())
+	}
+
+	var buf bytes.Buffer
+	success, err := flow.RunFlow(&buf, false)
+	if success {
+		t.Error("RunFlow() success = true, want false (no creds detected)")
+	}
+	if err == nil {
+		t.Error("RunFlow() err = nil, want non-nil so the auth command exits non-zero")
+	}
+	if !strings.Contains(buf.String(), "codex login") {
+		t.Errorf("RunFlow output = %q, want it to instruct the user to run codex login", buf.String())
+	}
+}
+
+func TestAuth_SucceedsWhenCanonicalSourcePresent(t *testing.T) {
+	home := t.TempDir()
+	t.Setenv("HOME", home)
+	t.Setenv("CODEX_HOME", "")
+	testenv.ApplyVibeusage(t.Setenv, t.TempDir())
+	stubCodexKeychainEmpty(t)
+	writeCodexCLICreds(t, home)
+
+	flow := Codex{}.Auth().(provider.CustomAuthFlow)
+	success, err := flow.RunFlow(&bytes.Buffer{}, true)
+	if err != nil {
+		t.Fatalf("RunFlow() err = %v", err)
+	}
+	if !success {
+		t.Error("RunFlow() success = false, want true (creds present)")
 	}
 }

--- a/internal/provider/copilot/copilot.go
+++ b/internal/provider/copilot/copilot.go
@@ -182,9 +182,17 @@ func (s *DeviceFlowStrategy) refreshToken(ctx context.Context, creds *oauth.Cred
 		TokenURL:    tokenURL,
 		FormFields:  map[string]string{"client_id": clientID},
 		Headers:     []httpclient.RequestOption{httpclient.WithHeader("Accept", "application/json")},
-		ProviderID:  "copilot",
+		Save:        saveCopilotCredentials,
 		HTTPTimeout: s.HTTPTimeout,
 	})
+}
+
+func saveCopilotCredentials(c *oauth.Credentials) error {
+	content, err := json.Marshal(c)
+	if err != nil {
+		return fmt.Errorf("marshal copilot credentials: %w", err)
+	}
+	return config.WriteCredential("copilot", "oauth", content)
 }
 
 func (s *DeviceFlowStrategy) parseTypedUsageResponse(resp UserResponse) *models.UsageSnapshot {

--- a/internal/provider/copilot/copilot_test.go
+++ b/internal/provider/copilot/copilot_test.go
@@ -1,10 +1,14 @@
 package copilot
 
 import (
+	"encoding/json"
 	"testing"
 	"time"
 
+	"github.com/joshuadavidthomas/vibeusage/internal/auth/oauth"
+	"github.com/joshuadavidthomas/vibeusage/internal/config"
 	"github.com/joshuadavidthomas/vibeusage/internal/models"
+	"github.com/joshuadavidthomas/vibeusage/internal/testenv"
 )
 
 func TestParseTypedUsageResponse_FullResponse(t *testing.T) {
@@ -208,5 +212,30 @@ func TestParseTypedUsageResponse_InvalidResetDate(t *testing.T) {
 	}
 	if snapshot.Periods[0].ResetsAt != nil {
 		t.Error("expected nil resets_at for invalid date")
+	}
+}
+
+func TestSaveCopilotCredentials_PersistsToSlot(t *testing.T) {
+	testenv.ApplyVibeusage(t.Setenv, t.TempDir())
+
+	in := &oauth.Credentials{
+		AccessToken:  "new-access",
+		RefreshToken: "new-refresh",
+		ExpiresAt:    "2099-01-01T00:00:00Z",
+	}
+	if err := saveCopilotCredentials(in); err != nil {
+		t.Fatalf("saveCopilotCredentials: %v", err)
+	}
+
+	data, err := config.ReadCredential("copilot", "oauth")
+	if err != nil || data == nil {
+		t.Fatalf("ReadCredential after save: data=%q err=%v", data, err)
+	}
+	var got oauth.Credentials
+	if err := json.Unmarshal(data, &got); err != nil {
+		t.Fatalf("Unmarshal: %v", err)
+	}
+	if got != *in {
+		t.Errorf("persisted creds = %+v, want %+v", got, *in)
 	}
 }

--- a/internal/provider/gemini/oauth.go
+++ b/internal/provider/gemini/oauth.go
@@ -18,11 +18,6 @@ import (
 )
 
 const (
-	// OAuth client credentials extracted from the Gemini CLI installation.
-	// Required to refresh tokens stored in ~/.gemini/oauth_creds.json.
-	geminiClientID     = "77185425430.apps.googleusercontent.com"
-	geminiClientSecret = "GOCSPX-1mdrl61JR9D-iFHq4QPq2mJGwZv"
-
 	quotaURL      = "https://cloudcode-pa.googleapis.com/v1internal:retrieveUserQuota"
 	codeAssistURL = "https://cloudcode-pa.googleapis.com/v1internal:loadCodeAssist"
 )
@@ -33,9 +28,6 @@ type OAuthStrategy struct {
 }
 
 func (s *OAuthStrategy) IsAvailable() bool {
-	if config.HasCredential("gemini", "oauth") {
-		return true
-	}
 	for _, p := range s.externalPaths() {
 		if _, err := os.Stat(p); err == nil {
 			return true
@@ -60,16 +52,12 @@ func (s *OAuthStrategy) Fetch(ctx context.Context) (fetch.FetchResult, error) {
 	}
 
 	if creds.NeedsRefresh() {
-		refreshed := google.RefreshToken(ctx, creds, google.RefreshConfig{
-			ClientID:     geminiClientID,
-			ClientSecret: geminiClientSecret,
-			ProviderID:   "gemini",
-			HTTPTimeout:  s.HTTPTimeout,
-		})
-		if refreshed == nil {
-			return fetch.ResultFail("Failed to refresh token"), nil
-		}
-		creds = refreshed
+		// The Gemini CLI owns the rotating chain in ~/.gemini/oauth_creds.json,
+		// and a refresh request to Google's token endpoint may rotate the
+		// refresh token server-side — invalidating the CLI's stored copy and
+		// breaking its next refresh. Fail closed and let the user re-run the
+		// CLI, which will refresh on its own terms.
+		return fetch.ResultFail("OAuth token expired. Run the Gemini CLI (e.g. `gemini`) to refresh credentials, then retry."), nil
 	}
 
 	quotaResp, codeAssistResp, fetchErr := s.fetchQuotaData(ctx, creds.AccessToken)
@@ -89,17 +77,10 @@ func (s *OAuthStrategy) Fetch(ctx context.Context) (fetch.FetchResult, error) {
 }
 
 func (s *OAuthStrategy) loadCredentials() *oauth.Credentials {
-	// Check vibeusage consolidated storage first
-	if data, err := config.ReadCredential("gemini", "oauth"); err == nil && data != nil {
-		var cliCreds GeminiCLICredentials
-		if err := json.Unmarshal(data, &cliCreds); err == nil {
-			if creds := cliCreds.EffectiveCredentials(); creds != nil {
-				return creds
-			}
-		}
-	}
-
-	// Check external CLI paths
+	// Read only from the canonical Gemini CLI source. The OAuth chain is
+	// owned by the Gemini CLI; vibeusage is a piggy-back consumer and never
+	// writes new tokens. Any stale entry in vibeusage's own credentials
+	// store is cleared lazily so it can't shadow the live source.
 	for _, path := range s.externalPaths() {
 		data, err := os.ReadFile(path)
 		if err != nil {
@@ -110,10 +91,23 @@ func (s *OAuthStrategy) loadCredentials() *oauth.Credentials {
 			continue
 		}
 		if creds := cliCreds.EffectiveCredentials(); creds != nil {
+			cleanupOrphanOAuthSlot()
 			return creds
 		}
 	}
 	return nil
+}
+
+// cleanupOrphanOAuthSlot removes any vibeusage-owned gemini/oauth credential.
+// Gemini's vibeusage Auth() flow stores an api_key, not an OAuth grant — the
+// only way the slot gets populated is by older buggy refresh writes, which
+// silently invalidated the Gemini CLI's own refresh token. The slot has no
+// legitimate use, so it is safe to drop whenever we successfully read from
+// the canonical CLI source.
+func cleanupOrphanOAuthSlot() {
+	if config.HasCredential("gemini", "oauth") {
+		config.DeleteCredential("gemini", "oauth")
+	}
 }
 
 type fetchError struct {

--- a/internal/provider/gemini/oauth_test.go
+++ b/internal/provider/gemini/oauth_test.go
@@ -1,0 +1,93 @@
+package gemini
+
+import (
+	"context"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/joshuadavidthomas/vibeusage/internal/config"
+	"github.com/joshuadavidthomas/vibeusage/internal/testenv"
+)
+
+func writeGeminiCLICreds(t *testing.T, home string) {
+	t.Helper()
+	dir := filepath.Join(home, ".gemini")
+	if err := os.MkdirAll(dir, 0o700); err != nil {
+		t.Fatalf("MkdirAll: %v", err)
+	}
+	content := `{"access_token":"cli-tok","refresh_token":"cli-ref","expires_at":"2099-01-01T00:00:00Z"}`
+	if err := os.WriteFile(filepath.Join(dir, "oauth_creds.json"), []byte(content), 0o600); err != nil {
+		t.Fatalf("WriteFile: %v", err)
+	}
+}
+
+func TestLoadCredentials_DeletesOrphanSlotWhenCanonicalFilePresent(t *testing.T) {
+	home := t.TempDir()
+	t.Setenv("HOME", home)
+	testenv.ApplyVibeusage(t.Setenv, t.TempDir())
+
+	writeGeminiCLICreds(t, home)
+	if err := config.WriteCredential("gemini", "oauth", []byte(`{"access_token":"stale"}`)); err != nil {
+		t.Fatalf("WriteCredential: %v", err)
+	}
+
+	s := OAuthStrategy{}
+	creds := s.loadCredentials()
+	if creds == nil {
+		t.Fatal("loadCredentials() = nil, want canonical creds")
+	}
+	if creds.AccessToken != "cli-tok" {
+		t.Errorf("access_token = %q, want cli-tok", creds.AccessToken)
+	}
+	if config.HasCredential("gemini", "oauth") {
+		t.Error("orphan gemini/oauth slot should have been deleted")
+	}
+}
+
+func TestLoadCredentials_NoCanonicalSource_PreservesOrphan(t *testing.T) {
+	t.Setenv("HOME", t.TempDir())
+	testenv.ApplyVibeusage(t.Setenv, t.TempDir())
+
+	if err := config.WriteCredential("gemini", "oauth", []byte(`{"access_token":"stale"}`)); err != nil {
+		t.Fatalf("WriteCredential: %v", err)
+	}
+
+	s := OAuthStrategy{}
+	if creds := s.loadCredentials(); creds != nil {
+		t.Errorf("loadCredentials() = %+v, want nil (no canonical source)", creds)
+	}
+	if !config.HasCredential("gemini", "oauth") {
+		t.Error("orphan should not be deleted when no canonical source is found")
+	}
+}
+
+func TestFetch_FailsClosedWhenRefreshNeeded(t *testing.T) {
+	home := t.TempDir()
+	t.Setenv("HOME", home)
+	testenv.ApplyVibeusage(t.Setenv, t.TempDir())
+
+	// Write Gemini CLI creds with an expired access token so NeedsRefresh()
+	// triggers the refresh branch.
+	dir := filepath.Join(home, ".gemini")
+	if err := os.MkdirAll(dir, 0o700); err != nil {
+		t.Fatalf("MkdirAll: %v", err)
+	}
+	content := `{"access_token":"stale","refresh_token":"ref","expires_at":"2020-01-01T00:00:00Z"}`
+	if err := os.WriteFile(filepath.Join(dir, "oauth_creds.json"), []byte(content), 0o600); err != nil {
+		t.Fatalf("WriteFile: %v", err)
+	}
+
+	s := OAuthStrategy{}
+	res, err := s.Fetch(context.Background())
+	if err != nil {
+		t.Fatalf("Fetch error: %v", err)
+	}
+	if res.Success {
+		t.Fatal("Fetch should fail when Gemini creds need refresh (vibeusage must not refresh externally-owned chains)")
+	}
+	if !strings.Contains(res.Error, "Gemini CLI") {
+		t.Errorf("Fetch error = %q, want guidance to use the Gemini CLI", res.Error)
+	}
+}

--- a/internal/provider/kimicode/device.go
+++ b/internal/provider/kimicode/device.go
@@ -3,6 +3,7 @@ package kimicode
 import (
 	"context"
 	"encoding/json"
+	"fmt"
 	"os"
 	"time"
 
@@ -89,7 +90,15 @@ func (s *DeviceFlowStrategy) refreshToken(ctx context.Context, creds *oauth.Cred
 		TokenURL:    oauthBaseURL() + tokenPath,
 		FormFields:  map[string]string{"client_id": clientID},
 		Headers:     commonHeaders(),
-		ProviderID:  "kimicode",
+		Save:        saveKimicodeCredentials,
 		HTTPTimeout: s.HTTPTimeout,
 	})
+}
+
+func saveKimicodeCredentials(c *oauth.Credentials) error {
+	content, err := json.Marshal(c)
+	if err != nil {
+		return fmt.Errorf("marshal kimicode credentials: %w", err)
+	}
+	return config.WriteCredential("kimicode", "oauth", content)
 }

--- a/internal/provider/kimicode/kimicode.go
+++ b/internal/provider/kimicode/kimicode.go
@@ -2,6 +2,7 @@ package kimicode
 
 import (
 	"context"
+	"encoding/json"
 	"fmt"
 	"os"
 	"runtime"
@@ -43,6 +44,18 @@ func (k KimiCode) FetchStrategies() []fetch.Strategy {
 
 func (k KimiCode) FetchStatus(ctx context.Context) models.ProviderStatus {
 	return provider.FetchStatuspageStatus(ctx, "https://status.moonshot.cn")
+}
+
+// AcceptToken stores a manually pasted KimiCode API key in the apikey slot.
+// KimiCode supports both an OAuth device flow (Auth()) and a stored API key
+// (APIKeyStrategy); --token routes to the API-key path since OAuth
+// credentials can't be obtained via paste.
+func (k KimiCode) AcceptToken(token string) error {
+	credData, err := json.Marshal(map[string]string{"api_key": token})
+	if err != nil {
+		return fmt.Errorf("marshal kimicode api key: %w", err)
+	}
+	return config.WriteCredential("kimicode", "apikey", credData)
 }
 
 // Auth returns the Kimi Code device flow.

--- a/internal/provider/kimicode/kimicode_test.go
+++ b/internal/provider/kimicode/kimicode_test.go
@@ -2,9 +2,13 @@ package kimicode
 
 import (
 	"context"
+	"encoding/json"
 	"testing"
 
+	"github.com/joshuadavidthomas/vibeusage/internal/auth/oauth"
+	"github.com/joshuadavidthomas/vibeusage/internal/config"
 	"github.com/joshuadavidthomas/vibeusage/internal/models"
+	"github.com/joshuadavidthomas/vibeusage/internal/testenv"
 )
 
 func TestAPIKeyStrategy_IsAvailable_EnvVar(t *testing.T) {
@@ -179,5 +183,30 @@ func TestKimiCode_Meta(t *testing.T) {
 	}
 	if meta.Name != "Kimi Code" {
 		t.Errorf("Name = %q, want %q", meta.Name, "Kimi Code")
+	}
+}
+
+func TestSaveKimicodeCredentials_PersistsToSlot(t *testing.T) {
+	testenv.ApplyVibeusage(t.Setenv, t.TempDir())
+
+	in := &oauth.Credentials{
+		AccessToken:  "new-access",
+		RefreshToken: "new-refresh",
+		ExpiresAt:    "2099-01-01T00:00:00Z",
+	}
+	if err := saveKimicodeCredentials(in); err != nil {
+		t.Fatalf("saveKimicodeCredentials: %v", err)
+	}
+
+	data, err := config.ReadCredential("kimicode", "oauth")
+	if err != nil || data == nil {
+		t.Fatalf("ReadCredential after save: data=%q err=%v", data, err)
+	}
+	var got oauth.Credentials
+	if err := json.Unmarshal(data, &got); err != nil {
+		t.Fatalf("Unmarshal: %v", err)
+	}
+	if got != *in {
+		t.Errorf("persisted creds = %+v, want %+v", got, *in)
 	}
 }


### PR DESCRIPTION
## Problem

Vibeusage was refreshing OAuth tokens directly via HTTP for chains it doesn't own (Claude CLI, Codex CLI, Gemini CLI, Antigravity IDE) and persisting the rotated tokens to its own credential store. When the authorization server rotated the refresh token, the external CLI's stored RT was silently invalidated and the chain forked.

## Core change

`oauth.RefreshConfig.ProviderID` is replaced with an explicit `Save func(*Credentials) error` callback. Vibeusage-owned chains pass a writer; piggy-backed chains pass `nil`. Save errors are logged via `logging.FromContext` but don't invalidate the in-memory creds.

## Per provider

- **Claude / Codex**: stop refreshing via direct HTTP. Use `oauth.RefreshViaCLI` (spawns the CLI binary so it refreshes its own chain). Fixed a regression where `RefreshViaCLI` accepted unchanged pre-spawn creds for providers with no `expires_at` — it now requires the access token to actually change before declaring the refresh fresh.
- **Gemini / Antigravity (file source)**: no longer hit Google's token endpoint at all for piggybacked chains. Fail closed with a clear "open the CLI/IDE to refresh" message.
- **Antigravity**: distinguish legitimately-minted slot creds (carrying a `vibeusage_owned: true` marker, written by `RunAuthFlow` and the owned `Save` helper) from buggy-era residue. Unmarked slots are deleted when a canonical IDE source is found, and surfaced as `sourceUnmarkedSlot` with a Fatal `Fetch` failure when no canonical source exists — so the re-auth flow can't be short-circuited by stale piggyback creds.
- **Copilot / Kimicode**: vibeusage owns these chains; pass a `Save` callback that writes back to its own slot.

## Codex auth flow

- Removed the manual access-token paste flow (manually pasted tokens never refreshed and silently broke). `Auth()` now detects whether the Codex CLI's canonical source exists and returns success accordingly, with a clear instruction to run `codex login` otherwise.
- `vibeusage auth codex --token …` is rejected (previously fell through to a generic apikey slot that fetch ignored).

## Manual `--token` handling

- `authSetToken` switches on the auth flow type. Non-`ManualKeyAuthFlow` providers can opt in via a new `provider.TokenAcceptor` interface (used by KimiCode, which advertises a device flow but also supports a stored API key); other non-manual providers reject `--token` instead of writing an unusable apikey slot.

## Orphan cleanup

- Claude / Codex / Gemini lazily delete any pre-fix `<provider>/oauth` slot when a canonical CLI/keychain source is found. Slots are preserved when no canonical source exists so the user isn't locked out of fetch entirely.

## Tests

Cover: Save callback invocation/non-invocation, `RefreshViaCLI` short-circuit regression, Gemini/Antigravity fail-closed paths, Antigravity marker migration, Codex auth detection + `--token` rejection, KimiCode `TokenAcceptor` path, and orphan-slot cleanup for all four piggyback providers.

## User-visible breaking changes

- `vibeusage auth codex` no longer accepts manually pasted access tokens (use `codex login`).
- `vibeusage auth codex --token …` returns an error instead of silently storing an unusable credential.
- Gemini OAuth fetches now fail closed when the access token is expired with guidance to run the Gemini CLI to refresh.
- Antigravity OAuth fetches that piggyback the IDE fail closed on expiry with guidance to sign in via the IDE.
