### PR TITLE
fix: trust CLI OAuth tokens before refreshing

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,10 @@ and this project attempts to adhere to [Semantic Versioning](https://semver.org/
 
 ## [Unreleased]
 
+### Fixed
+
+- Fixed Claude and Codex usage fetches incorrectly failing before trying still-valid OAuth access tokens when external CLI credentials had missing or stale expiry metadata.
+
 ## [0.9.0]
 
 ### Changed

--- a/internal/provider/claude/oauth.go
+++ b/internal/provider/claude/oauth.go
@@ -30,6 +30,11 @@ const (
 	accountReuseTTL = 24 * time.Hour
 )
 
+var (
+	oauthUsageEndpoint   = oauthUsageURL
+	oauthAccountEndpoint = oauthAccountURL
+)
+
 var readKeychainSecret = keychain.ReadGenericPassword
 
 // OAuthStrategy fetches Claude usage using OAuth credentials.
@@ -56,29 +61,39 @@ func (s *OAuthStrategy) Fetch(ctx context.Context) (fetch.FetchResult, error) {
 		return fetch.ResultFatal("Invalid OAuth credentials: missing access_token"), nil
 	}
 
-	if creds.NeedsRefresh() {
-		refreshed := oauth.RefreshViaCLI(ctx, oauth.CLIRefreshConfig{
-			BinaryName: "claude",
-			Args: []string{
-				"-p", "ok",
-				"--model", "haiku",
-				"--output-format", "json",
-				"--no-session-persistence",
-				"--permission-mode", "plan",
-				"--allowed-tools", "",
-				"--max-budget-usd", "0.001",
-			},
-			LoadCredentials: func() *oauth.Credentials {
-				return s.loadCredentials()
-			},
-		})
-		if refreshed == nil {
-			return fetch.ResultFatal("OAuth token expired and could not be refreshed. Re-authenticate with the Claude CLI."), nil
-		}
-		creds = refreshed
+	client := httpclient.NewFromConfig(s.HTTPTimeout)
+	result, unauthorized, err := s.fetchWithCredentials(ctx, client, creds)
+	if err != nil || !unauthorized || creds.RefreshToken == "" {
+		return result, err
 	}
 
-	client := httpclient.NewFromConfig(s.HTTPTimeout)
+	refreshed := s.refreshViaCLI(ctx)
+	if refreshed == nil {
+		return fetch.ResultFatal("OAuth token expired and could not be refreshed. Re-authenticate with the Claude CLI."), nil
+	}
+	result, _, err = s.fetchWithCredentials(ctx, client, refreshed)
+	return result, err
+}
+
+func (s *OAuthStrategy) refreshViaCLI(ctx context.Context) *oauth.Credentials {
+	return oauth.RefreshViaCLI(ctx, oauth.CLIRefreshConfig{
+		BinaryName: "claude",
+		Args: []string{
+			"-p", "ok",
+			"--model", "haiku",
+			"--output-format", "json",
+			"--no-session-persistence",
+			"--permission-mode", "plan",
+			"--allowed-tools", "",
+			"--max-budget-usd", "0.001",
+		},
+		LoadCredentials: func() *oauth.Credentials {
+			return s.loadCredentials()
+		},
+	})
+}
+
+func (s *OAuthStrategy) fetchWithCredentials(ctx context.Context, client *httpclient.Client, creds *oauth.Credentials) (fetch.FetchResult, bool, error) {
 	authOpts := []httpclient.RequestOption{
 		httpclient.WithBearer(creds.AccessToken),
 		httpclient.WithHeader("anthropic-beta", anthropicBetaTag),
@@ -104,7 +119,7 @@ func (s *OAuthStrategy) Fetch(ctx context.Context) (fetch.FetchResult, error) {
 
 	go func() {
 		var usageResp OAuthUsageResponse
-		resp, err := client.GetJSONCtx(ctx, oauthUsageURL, &usageResp, authOpts...)
+		resp, err := client.GetJSONCtx(ctx, oauthUsageEndpoint, &usageResp, authOpts...)
 		if err != nil {
 			usageCh <- usageOutcome{err: err}
 			return
@@ -117,7 +132,7 @@ func (s *OAuthStrategy) Fetch(ctx context.Context) (fetch.FetchResult, error) {
 	} else {
 		go func() {
 			var acctResp OAuthAccountResponse
-			resp, err := client.GetJSONCtx(ctx, oauthAccountURL, &acctResp, authOpts...)
+			resp, err := client.GetJSONCtx(ctx, oauthAccountEndpoint, &acctResp, authOpts...)
 			if err != nil || resp.StatusCode != 200 || resp.JSONErr != nil {
 				accountCh <- accountOutcome{}
 				return
@@ -130,23 +145,23 @@ func (s *OAuthStrategy) Fetch(ctx context.Context) (fetch.FetchResult, error) {
 	account := <-accountCh
 
 	if usage.err != nil {
-		return fetch.ResultFail("Request failed: " + usage.err.Error()), nil
+		return fetch.ResultFail("Request failed: " + usage.err.Error()), false, nil
 	}
 	if usage.status == 401 {
-		return fetch.ResultFatal("OAuth token expired or invalid. Re-authenticate with the Claude CLI."), nil
+		return fetch.ResultFatal("OAuth token expired or invalid. Re-authenticate with the Claude CLI."), true, nil
 	}
 	if usage.status == 403 {
-		return fetch.ResultFatal("Not authorized to access usage."), nil
+		return fetch.ResultFatal("Not authorized to access usage."), false, nil
 	}
 	if usage.status == 429 {
 		retryAt := parseRetryAfter(usage.header, time.Now().UTC())
-		return fetch.ResultThrottled("Rate limited by Anthropic", retryAt), nil
+		return fetch.ResultThrottled("Rate limited by Anthropic", retryAt), false, nil
 	}
 	if usage.status != 200 {
-		return fetch.ResultFail(fmt.Sprintf("Usage request failed: %d", usage.status)), nil
+		return fetch.ResultFail(fmt.Sprintf("Usage request failed: %d", usage.status)), false, nil
 	}
 	if usage.jsonErr != nil {
-		return fetch.ResultFail(fmt.Sprintf("Invalid response from usage endpoint: %v", usage.jsonErr)), nil
+		return fetch.ResultFail(fmt.Sprintf("Invalid response from usage endpoint: %v", usage.jsonErr)), false, nil
 	}
 
 	snapshot := s.parseOAuthUsageResponse(usage.resp)
@@ -157,7 +172,7 @@ func (s *OAuthStrategy) Fetch(ctx context.Context) (fetch.FetchResult, error) {
 		enrichWithAccount(snapshot, account.resp)
 	}
 
-	return fetch.ResultOK(*snapshot), nil
+	return fetch.ResultOK(*snapshot), false, nil
 }
 
 // loadCachedIdentity returns the cached Claude identity if the on-disk

--- a/internal/provider/claude/oauth_test.go
+++ b/internal/provider/claude/oauth_test.go
@@ -1,9 +1,14 @@
 package claude
 
 import (
+	"context"
 	"errors"
+	"net/http"
+	"net/http/httptest"
 	"os"
 	"path/filepath"
+	"strconv"
+	"sync/atomic"
 	"testing"
 	"time"
 
@@ -527,16 +532,123 @@ func stubKeychainEmpty(t *testing.T) {
 	}
 }
 
-// writeClaudeCLICreds writes a Claude CLI credentials file to ~/.claude.
-func writeClaudeCLICreds(t *testing.T, home string) {
+func writeClaudeAuth(t *testing.T, home, content string) {
 	t.Helper()
 	dir := filepath.Join(home, ".claude")
 	if err := os.MkdirAll(dir, 0o700); err != nil {
 		t.Fatalf("MkdirAll: %v", err)
 	}
-	content := `{"claudeAiOauth":{"accessToken":"cli-tok","refreshToken":"cli-ref","expiresAt":4102444800000}}`
 	if err := os.WriteFile(filepath.Join(dir, ".credentials.json"), []byte(content), 0o600); err != nil {
 		t.Fatalf("WriteFile: %v", err)
+	}
+}
+
+// writeClaudeCLICreds writes a Claude CLI credentials file to ~/.claude.
+func writeClaudeCLICreds(t *testing.T, home string) {
+	t.Helper()
+	writeClaudeAuth(t, home, `{"claudeAiOauth":{"accessToken":"cli-tok","refreshToken":"cli-ref","expiresAt":4102444800000}}`)
+}
+
+func prependFakeClaude(t *testing.T, script string) {
+	t.Helper()
+	binDir := filepath.Join(t.TempDir(), "bin")
+	if err := os.MkdirAll(binDir, 0o755); err != nil {
+		t.Fatalf("MkdirAll: %v", err)
+	}
+	bin := filepath.Join(binDir, "claude")
+	if err := os.WriteFile(bin, []byte(script), 0o755); err != nil {
+		t.Fatalf("WriteFile: %v", err)
+	}
+	t.Setenv("PATH", binDir+string(os.PathListSeparator)+os.Getenv("PATH"))
+}
+
+func setClaudeOAuthEndpoints(t *testing.T, usageURL, accountURL string) {
+	t.Helper()
+	oldUsage := oauthUsageEndpoint
+	oldAccount := oauthAccountEndpoint
+	oauthUsageEndpoint = usageURL
+	oauthAccountEndpoint = accountURL
+	t.Cleanup(func() {
+		oauthUsageEndpoint = oldUsage
+		oauthAccountEndpoint = oldAccount
+	})
+}
+
+func cacheClaudeIdentity(t *testing.T) {
+	t.Helper()
+	snap := models.UsageSnapshot{
+		Provider:  "claude",
+		FetchedAt: time.Now().UTC(),
+		Identity:  &models.ProviderIdentity{Email: "u@example.com", Plan: "Max"},
+	}
+	if err := config.CacheSnapshot(snap); err != nil {
+		t.Fatalf("CacheSnapshot: %v", err)
+	}
+}
+
+func TestFetch_UsesExpiredMetadataTokenBeforeRefreshing(t *testing.T) {
+	home := t.TempDir()
+	t.Setenv("HOME", home)
+	testenv.ApplyVibeusage(t.Setenv, t.TempDir())
+	stubKeychainEmpty(t)
+	cacheClaudeIdentity(t)
+	writeClaudeAuth(t, home, `{"claudeAiOauth":{"accessToken":"still-valid","refreshToken":"ref","expiresAt":1}}`)
+	prependFakeClaude(t, "#!/usr/bin/env sh\nexit 42\n")
+
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if got := r.Header.Get("Authorization"); got != "Bearer still-valid" {
+			t.Errorf("Authorization = %q, want Bearer still-valid", got)
+			http.Error(w, "unauthorized", http.StatusUnauthorized)
+			return
+		}
+		_, _ = w.Write([]byte(`{"five_hour":{"utilization":10}}`))
+	}))
+	defer server.Close()
+	setClaudeOAuthEndpoints(t, server.URL+"/usage", server.URL+"/account")
+
+	result, err := (&OAuthStrategy{HTTPTimeout: 2}).Fetch(context.Background())
+	if err != nil {
+		t.Fatalf("Fetch() err = %v", err)
+	}
+	if !result.Success {
+		t.Fatalf("Fetch() success = false, error = %q", result.Error)
+	}
+}
+
+func TestFetch_RefreshesAfterUnauthorized(t *testing.T) {
+	home := t.TempDir()
+	t.Setenv("HOME", home)
+	testenv.ApplyVibeusage(t.Setenv, t.TempDir())
+	stubKeychainEmpty(t)
+	cacheClaudeIdentity(t)
+	writeClaudeAuth(t, home, `{"claudeAiOauth":{"accessToken":"stale","refreshToken":"ref","expiresAt":1}}`)
+	prependFakeClaude(t, "#!/usr/bin/env sh\ncat > "+strconv.Quote(filepath.Join(home, ".claude", ".credentials.json"))+" <<'JSON'\n{\"claudeAiOauth\":{\"accessToken\":\"fresh\",\"refreshToken\":\"ref\",\"expiresAt\":4102444800000}}\nJSON\n")
+
+	var requests atomic.Int32
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		requests.Add(1)
+		switch r.Header.Get("Authorization") {
+		case "Bearer stale":
+			http.Error(w, "unauthorized", http.StatusUnauthorized)
+		case "Bearer fresh":
+			_, _ = w.Write([]byte(`{"five_hour":{"utilization":10}}`))
+		default:
+			t.Errorf("unexpected Authorization header: %q", r.Header.Get("Authorization"))
+			http.Error(w, "unauthorized", http.StatusUnauthorized)
+		}
+	}))
+	defer server.Close()
+	setClaudeOAuthEndpoints(t, server.URL+"/usage", server.URL+"/account")
+
+	result, err := (&OAuthStrategy{HTTPTimeout: 2}).Fetch(context.Background())
+	if err != nil {
+		t.Fatalf("Fetch() err = %v", err)
+	}
+	if !result.Success {
+		t.Fatalf("Fetch() success = false, error = %q", result.Error)
+	}
+	if got := requests.Load(); got != 2 {
+		t.Errorf("usage requests = %d, want 2", got)
 	}
 }
 

--- a/internal/provider/codex/codex.go
+++ b/internal/provider/codex/codex.go
@@ -109,60 +109,62 @@ func (s *OAuthStrategy) Fetch(ctx context.Context) (fetch.FetchResult, error) {
 		return fetch.ResultFail("Invalid credentials: missing access_token"), nil
 	}
 
-	// The Codex CLI stores credentials without expires_at, so the shared
-	// NeedsRefresh() can't detect expiry. When a refresh token is present,
-	// always defer to the Codex CLI to refresh — it owns the rotating chain,
-	// and any direct refresh from here would invalidate the CLI's copy.
-	if creds.NeedsRefresh() || (creds.ExpiresAt == "" && creds.RefreshToken != "") {
-		refreshed := oauth.RefreshViaCLI(ctx, oauth.CLIRefreshConfig{
-			BinaryName: "codex",
-			Args: []string{
-				"exec", "say ok",
-				"--skip-git-repo-check",
-				"--sandbox", "read-only",
-			},
-			LoadCredentials: func() *oauth.Credentials {
-				return s.loadCredentials()
-			},
-		})
-		if refreshed == nil {
-			return fetch.ResultFatal("OAuth token expired and could not be refreshed. Re-authenticate with `codex login`."), nil
-		}
-		creds = refreshed
-	}
-
 	usageURL := s.getUsageURL()
 	client := httpclient.NewFromConfig(s.HTTPTimeout)
 
-	return s.fetchUsage(ctx, client, usageURL, creds)
+	result, unauthorized, err := s.fetchUsage(ctx, client, usageURL, creds)
+	if err != nil || !unauthorized || creds.RefreshToken == "" {
+		return result, err
+	}
+
+	refreshed := s.refreshViaCLI(ctx)
+	if refreshed == nil {
+		return fetch.ResultFatal("OAuth token expired and could not be refreshed. Re-authenticate with `codex login`."), nil
+	}
+	result, _, err = s.fetchUsage(ctx, client, usageURL, refreshed)
+	return result, err
 }
 
-func (s *OAuthStrategy) fetchUsage(ctx context.Context, client *httpclient.Client, usageURL string, creds *oauth.Credentials) (fetch.FetchResult, error) {
+func (s *OAuthStrategy) refreshViaCLI(ctx context.Context) *oauth.Credentials {
+	return oauth.RefreshViaCLI(ctx, oauth.CLIRefreshConfig{
+		BinaryName: "codex",
+		Args: []string{
+			"exec", "say ok",
+			"--skip-git-repo-check",
+			"--sandbox", "read-only",
+		},
+		LoadCredentials: func() *oauth.Credentials {
+			return s.loadCredentials()
+		},
+	})
+}
+
+func (s *OAuthStrategy) fetchUsage(ctx context.Context, client *httpclient.Client, usageURL string, creds *oauth.Credentials) (fetch.FetchResult, bool, error) {
 	var usageResp UsageResponse
 	resp, err := client.GetJSONCtx(ctx, usageURL, &usageResp, httpclient.WithBearer(creds.AccessToken))
 	if err != nil {
-		return fetch.ResultFail("Request failed: " + err.Error()), nil
+		return fetch.ResultFail("Request failed: " + err.Error()), false, nil
 	}
 
 	if resp.StatusCode == 401 {
-		return fetch.ResultFatal("OAuth token expired or invalid. Re-authenticate with `codex login`."), nil
+		return fetch.ResultFatal("OAuth token expired or invalid. Re-authenticate with `codex login`."), true, nil
 	}
 	if resp.StatusCode == 403 {
-		return fetch.ResultFail("Not authorized. Account may not have ChatGPT Plus/Pro subscription."), nil
+		return fetch.ResultFail("Not authorized. Account may not have ChatGPT Plus/Pro subscription."), false, nil
 	}
 	if resp.StatusCode != 200 {
-		return fetch.ResultFail(fmt.Sprintf("Usage request failed: %d", resp.StatusCode)), nil
+		return fetch.ResultFail(fmt.Sprintf("Usage request failed: %d", resp.StatusCode)), false, nil
 	}
 	if resp.JSONErr != nil {
-		return fetch.ResultFail(fmt.Sprintf("Invalid response from usage endpoint: %v", resp.JSONErr)), nil
+		return fetch.ResultFail(fmt.Sprintf("Invalid response from usage endpoint: %v", resp.JSONErr)), false, nil
 	}
 
 	snapshot := s.parseTypedUsageResponse(usageResp)
 	if snapshot == nil {
-		return fetch.ResultFail("Failed to parse usage response"), nil
+		return fetch.ResultFail("Failed to parse usage response"), false, nil
 	}
 
-	return fetch.ResultOK(*snapshot), nil
+	return fetch.ResultOK(*snapshot), false, nil
 }
 
 func (s *OAuthStrategy) externalPaths() []string {

--- a/internal/provider/codex/codex_test.go
+++ b/internal/provider/codex/codex_test.go
@@ -2,11 +2,16 @@ package codex
 
 import (
 	"bytes"
+	"context"
 	"encoding/json"
 	"errors"
+	"net/http"
+	"net/http/httptest"
 	"os"
 	"path/filepath"
+	"strconv"
 	"strings"
+	"sync/atomic"
 	"testing"
 	"time"
 
@@ -261,16 +266,45 @@ func stubCodexKeychainEmpty(t *testing.T) {
 	}
 }
 
-func writeCodexCLICreds(t *testing.T, home string) {
+func writeCodexAuth(t *testing.T, home, content string) {
 	t.Helper()
 	dir := filepath.Join(home, ".codex")
 	if err := os.MkdirAll(dir, 0o700); err != nil {
 		t.Fatalf("MkdirAll: %v", err)
 	}
-	content := `{"tokens":{"access_token":"cli-tok","refresh_token":"cli-ref"}}`
 	if err := os.WriteFile(filepath.Join(dir, "auth.json"), []byte(content), 0o600); err != nil {
 		t.Fatalf("WriteFile: %v", err)
 	}
+}
+
+func writeCodexCLICreds(t *testing.T, home string) {
+	t.Helper()
+	writeCodexAuth(t, home, `{"tokens":{"access_token":"cli-tok","refresh_token":"cli-ref"}}`)
+}
+
+func writeCodexConfig(t *testing.T, home, usageURL string) {
+	t.Helper()
+	dir := filepath.Join(home, ".codex")
+	if err := os.MkdirAll(dir, 0o700); err != nil {
+		t.Fatalf("MkdirAll: %v", err)
+	}
+	content := "usage_url = " + strconv.Quote(usageURL) + "\n"
+	if err := os.WriteFile(filepath.Join(dir, "config.toml"), []byte(content), 0o600); err != nil {
+		t.Fatalf("WriteFile: %v", err)
+	}
+}
+
+func prependFakeCodex(t *testing.T, script string) {
+	t.Helper()
+	binDir := filepath.Join(t.TempDir(), "bin")
+	if err := os.MkdirAll(binDir, 0o755); err != nil {
+		t.Fatalf("MkdirAll: %v", err)
+	}
+	bin := filepath.Join(binDir, "codex")
+	if err := os.WriteFile(bin, []byte(script), 0o755); err != nil {
+		t.Fatalf("WriteFile: %v", err)
+	}
+	t.Setenv("PATH", binDir+string(os.PathListSeparator)+os.Getenv("PATH"))
 }
 
 func TestLoadCredentials_DeletesOrphanSlotWhenCanonicalFilePresent(t *testing.T) {
@@ -314,6 +348,101 @@ func TestLoadCredentials_NoCanonicalSource_PreservesOrphan(t *testing.T) {
 	}
 	if !config.HasCredential("codex", "oauth") {
 		t.Error("orphan should not be deleted when no canonical source is found")
+	}
+}
+
+func TestFetch_UsesNoExpiryTokenBeforeRefreshing(t *testing.T) {
+	home := t.TempDir()
+	t.Setenv("HOME", home)
+	t.Setenv("CODEX_HOME", "")
+	testenv.ApplyVibeusage(t.Setenv, t.TempDir())
+	stubCodexKeychainEmpty(t)
+	writeCodexAuth(t, home, `{"tokens":{"access_token":"still-valid","refresh_token":"ref"}}`)
+	prependFakeCodex(t, "#!/usr/bin/env sh\nexit 0\n")
+
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if got := r.Header.Get("Authorization"); got != "Bearer still-valid" {
+			t.Errorf("Authorization = %q, want Bearer still-valid", got)
+			http.Error(w, "unauthorized", http.StatusUnauthorized)
+			return
+		}
+		_, _ = w.Write([]byte(`{"plan_type":"pro","rate_limit":{"primary_window":{"used_percent":10}}}`))
+	}))
+	defer server.Close()
+	writeCodexConfig(t, home, server.URL)
+
+	result, err := (&OAuthStrategy{HTTPTimeout: 2}).Fetch(context.Background())
+	if err != nil {
+		t.Fatalf("Fetch() err = %v", err)
+	}
+	if !result.Success {
+		t.Fatalf("Fetch() success = false, error = %q", result.Error)
+	}
+}
+
+func TestFetch_UsesExpiredMetadataTokenBeforeRefreshing(t *testing.T) {
+	home := t.TempDir()
+	t.Setenv("HOME", home)
+	t.Setenv("CODEX_HOME", "")
+	testenv.ApplyVibeusage(t.Setenv, t.TempDir())
+	stubCodexKeychainEmpty(t)
+	writeCodexAuth(t, home, `{"tokens":{"access_token":"still-valid","refresh_token":"ref","expires_at":"2020-01-01T00:00:00Z"}}`)
+	prependFakeCodex(t, "#!/usr/bin/env sh\nexit 42\n")
+
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if got := r.Header.Get("Authorization"); got != "Bearer still-valid" {
+			t.Errorf("Authorization = %q, want Bearer still-valid", got)
+			http.Error(w, "unauthorized", http.StatusUnauthorized)
+			return
+		}
+		_, _ = w.Write([]byte(`{"plan_type":"pro","rate_limit":{"primary_window":{"used_percent":10}}}`))
+	}))
+	defer server.Close()
+	writeCodexConfig(t, home, server.URL)
+
+	result, err := (&OAuthStrategy{HTTPTimeout: 2}).Fetch(context.Background())
+	if err != nil {
+		t.Fatalf("Fetch() err = %v", err)
+	}
+	if !result.Success {
+		t.Fatalf("Fetch() success = false, error = %q", result.Error)
+	}
+}
+
+func TestFetch_RefreshesNoExpiryTokenAfterUnauthorized(t *testing.T) {
+	home := t.TempDir()
+	t.Setenv("HOME", home)
+	t.Setenv("CODEX_HOME", "")
+	testenv.ApplyVibeusage(t.Setenv, t.TempDir())
+	stubCodexKeychainEmpty(t)
+	writeCodexAuth(t, home, `{"tokens":{"access_token":"stale","refresh_token":"ref"}}`)
+	prependFakeCodex(t, "#!/usr/bin/env sh\ncat > \"$HOME/.codex/auth.json\" <<'JSON'\n{\"tokens\":{\"access_token\":\"fresh\",\"refresh_token\":\"ref\"}}\nJSON\n")
+
+	var requests atomic.Int32
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		requests.Add(1)
+		switch r.Header.Get("Authorization") {
+		case "Bearer stale":
+			http.Error(w, "unauthorized", http.StatusUnauthorized)
+		case "Bearer fresh":
+			_, _ = w.Write([]byte(`{"plan_type":"pro","rate_limit":{"primary_window":{"used_percent":10}}}`))
+		default:
+			t.Errorf("unexpected Authorization header: %q", r.Header.Get("Authorization"))
+			http.Error(w, "unauthorized", http.StatusUnauthorized)
+		}
+	}))
+	defer server.Close()
+	writeCodexConfig(t, home, server.URL)
+
+	result, err := (&OAuthStrategy{HTTPTimeout: 2}).Fetch(context.Background())
+	if err != nil {
+		t.Fatalf("Fetch() err = %v", err)
+	}
+	if !result.Success {
+		t.Fatalf("Fetch() success = false, error = %q", result.Error)
+	}
+	if got := requests.Load(); got != 2 {
+		t.Errorf("usage requests = %d, want 2", got)
 	}
 }
 


### PR DESCRIPTION
## Summary
- try existing Codex and Claude CLI OAuth access tokens before invoking CLI refresh
- refresh via the owning CLI only after a 401, then retry once
- add regression coverage and changelog entry

## Validation
- just test
- just lint
- just build
- local build from /tmp: vibeusage usage codex
- local build from /tmp: vibeusage usage claude