### PR TITLE
fix: display new provider quota buckets

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,6 +23,7 @@ and this project attempts to adhere to [Semantic Versioning](https://semver.org/
 ### Fixed
 
 - Fixed Claude and Codex usage fetches incorrectly failing before trying still-valid OAuth access tokens when external CLI credentials had missing or stale expiry metadata.
+- Fixed missing usage rows for newly added provider quota buckets, including Claude's structured model limits such as Fable.
 
 ## [0.9.0]
 

--- a/internal/provider/amp/amp_test.go
+++ b/internal/provider/amp/amp_test.go
@@ -61,6 +61,24 @@ func TestParseDisplayBalance_MultilineWithIdentity(t *testing.T) {
 	}
 }
 
+func TestParseDisplayBalance_MultipleQuotas(t *testing.T) {
+	result := balanceResult{DisplayText: "Free quota: $6.00 / $10.00 daily. Team quota: $25 / $50 daily."}
+
+	snapshot, err := parseDisplayBalance(result, "provider_cli")
+	if err != nil {
+		t.Fatalf("parseDisplayBalance() error = %v", err)
+	}
+	if len(snapshot.Periods) != 2 {
+		t.Fatalf("period count = %d, want 2", len(snapshot.Periods))
+	}
+	if snapshot.Periods[0].Name != "Free quota" || snapshot.Periods[0].Utilization != 40 {
+		t.Errorf("period[0] = %#v, want Free quota at 40%%", snapshot.Periods[0])
+	}
+	if snapshot.Periods[1].Name != "Team quota" || snapshot.Periods[1].Utilization != 50 {
+		t.Errorf("period[1] = %#v, want Team quota at 50%%", snapshot.Periods[1])
+	}
+}
+
 func TestParseDisplayBalance_CreditsOnly(t *testing.T) {
 	result := balanceResult{DisplayText: "Credits: $12.34"}
 

--- a/internal/provider/amp/balance.go
+++ b/internal/provider/amp/balance.go
@@ -94,8 +94,11 @@ func parseDisplayBalance(result balanceResult, source string) (*models.UsageSnap
 
 	periods := make([]models.UsagePeriod, 0, 1)
 
-	quotaMatch := quotaPattern.FindStringSubmatch(text)
-	if len(quotaMatch) == 4 {
+	quotaMatches := quotaPattern.FindAllStringSubmatch(text, -1)
+	for _, quotaMatch := range quotaMatches {
+		if len(quotaMatch) != 4 {
+			continue
+		}
 		remaining, err := strconv.ParseFloat(quotaMatch[2], 64)
 		if err != nil {
 			return nil, fmt.Errorf("parse remaining quota: %w", err)

--- a/internal/provider/claude/oauth_test.go
+++ b/internal/provider/claude/oauth_test.go
@@ -152,6 +152,65 @@ func TestParseOAuthUsageResponse_FullResponse(t *testing.T) {
 	}
 }
 
+func TestParseOAuthUsageResponse_StructuredLimitsDisplayFable(t *testing.T) {
+	resp := OAuthUsageResponse{
+		FiveHour: &UsagePeriodResponse{Utilization: 1.0},
+		SevenDay: &UsagePeriodResponse{Utilization: 20.0},
+		Limits: []OAuthLimitResponse{
+			{Group: "session", Kind: "session", Percent: 1},
+			{Group: "weekly", Kind: "weekly_all", Percent: 20},
+			{
+				Group:   "weekly",
+				Kind:    "weekly_scoped",
+				Percent: 34,
+				Scope: &OAuthLimitScope{Model: &OAuthLimitScopeItem{
+					DisplayName: "Fable",
+					ID:          "claude-fable-5",
+				}},
+			},
+		},
+	}
+
+	snapshot := (&OAuthStrategy{}).parseOAuthUsageResponse(resp)
+	periodByName := make(map[string]models.UsagePeriod)
+	for _, p := range snapshot.Periods {
+		periodByName[p.Name] = p
+	}
+
+	if len(snapshot.Periods) != 3 {
+		t.Fatalf("len(periods) = %d, want 3", len(snapshot.Periods))
+	}
+	fable, ok := periodByName["Fable"]
+	if !ok {
+		t.Fatal("missing Fable period")
+	}
+	if fable.Utilization != 34 {
+		t.Errorf("Fable utilization = %d, want 34", fable.Utilization)
+	}
+	if fable.Model != "claude-fable-5" {
+		t.Errorf("Fable model = %q, want claude-fable-5", fable.Model)
+	}
+}
+
+func TestParseOAuthUsageResponse_SuppressesOpaqueTopLevelCodenames(t *testing.T) {
+	resp := OAuthUsageResponse{
+		FiveHour: &UsagePeriodResponse{Utilization: 1.0},
+		AdditionalPeriods: map[string]UsagePeriodResponse{
+			"amber_ladder": {Utilization: 12.0},
+		},
+	}
+
+	snapshot := (&OAuthStrategy{}).parseOAuthUsageResponse(resp)
+	for _, p := range snapshot.Periods {
+		if p.Name == "Amber Ladder" {
+			t.Fatal("opaque codename should not be displayed as a user-facing usage period")
+		}
+	}
+	if len(snapshot.Periods) != 1 {
+		t.Fatalf("len(periods) = %d, want only known five_hour period", len(snapshot.Periods))
+	}
+}
+
 func TestParseOAuthUsageResponse_MinimalResponse(t *testing.T) {
 	resp := OAuthUsageResponse{
 		FiveHour: &UsagePeriodResponse{
@@ -272,7 +331,6 @@ func TestParseOAuthUsageResponse_NewPeriodFields(t *testing.T) {
 		SevenDay:          &UsagePeriodResponse{Utilization: 2.0},
 		SevenDayOAuthApps: &UsagePeriodResponse{Utilization: 15.0},
 		SevenDayCowork:    &UsagePeriodResponse{Utilization: 30.0},
-		IguanaNecktie:     &UsagePeriodResponse{Utilization: 5.0},
 	}
 
 	s := OAuthStrategy{}
@@ -303,17 +361,6 @@ func TestParseOAuthUsageResponse_NewPeriodFields(t *testing.T) {
 	}
 	if cowork.Model != "cowork" {
 		t.Errorf("Cowork model = %q, want %q", cowork.Model, "cowork")
-	}
-
-	iguana, ok := periodByName["Iguana Necktie"]
-	if !ok {
-		t.Fatal("missing Iguana Necktie period")
-	}
-	if iguana.Utilization != 5 {
-		t.Errorf("Iguana Necktie utilization = %d, want 5", iguana.Utilization)
-	}
-	if iguana.Model != "iguana_necktie" {
-		t.Errorf("Iguana Necktie model = %q, want %q", iguana.Model, "iguana_necktie")
 	}
 }
 

--- a/internal/provider/claude/response.go
+++ b/internal/provider/claude/response.go
@@ -28,16 +28,80 @@ type ExtraUsageResponse struct {
 // endpoint (/api/oauth/usage) and the web session endpoint
 // (/api/organizations/{orgID}/usage).
 type OAuthUsageResponse struct {
-	FiveHour            *UsagePeriodResponse `json:"five_hour,omitempty"`
-	SevenDay            *UsagePeriodResponse `json:"seven_day,omitempty"`
-	SevenDaySonnet      *UsagePeriodResponse `json:"seven_day_sonnet,omitempty"`
-	SevenDayOpus        *UsagePeriodResponse `json:"seven_day_opus,omitempty"`
-	SevenDayOAuthApps   *UsagePeriodResponse `json:"seven_day_oauth_apps,omitempty"`
-	SevenDayCowork      *UsagePeriodResponse `json:"seven_day_cowork,omitempty"`
-	SevenDayOmelette    *UsagePeriodResponse `json:"seven_day_omelette,omitempty"`
-	OmelettePromotional *UsagePeriodResponse `json:"omelette_promotional,omitempty"`
-	IguanaNecktie       *UsagePeriodResponse `json:"iguana_necktie,omitempty"`
-	ExtraUsage          *ExtraUsageResponse  `json:"extra_usage,omitempty"`
+	FiveHour            *UsagePeriodResponse           `json:"five_hour,omitempty"`
+	SevenDay            *UsagePeriodResponse           `json:"seven_day,omitempty"`
+	SevenDaySonnet      *UsagePeriodResponse           `json:"seven_day_sonnet,omitempty"`
+	SevenDayOpus        *UsagePeriodResponse           `json:"seven_day_opus,omitempty"`
+	SevenDayOAuthApps   *UsagePeriodResponse           `json:"seven_day_oauth_apps,omitempty"`
+	SevenDayCowork      *UsagePeriodResponse           `json:"seven_day_cowork,omitempty"`
+	SevenDayOmelette    *UsagePeriodResponse           `json:"seven_day_omelette,omitempty"`
+	OmelettePromotional *UsagePeriodResponse           `json:"omelette_promotional,omitempty"`
+	ExtraUsage          *ExtraUsageResponse            `json:"extra_usage,omitempty"`
+	Limits              []OAuthLimitResponse           `json:"limits,omitempty"`
+	AdditionalPeriods   map[string]UsagePeriodResponse `json:"-"`
+}
+
+// OAuthLimitResponse represents the structured limits[] entries Anthropic
+// started returning alongside the legacy top-level usage buckets.
+type OAuthLimitResponse struct {
+	Group    string           `json:"group,omitempty"`
+	Kind     string           `json:"kind,omitempty"`
+	Percent  float64          `json:"percent"`
+	ResetsAt string           `json:"resets_at,omitempty"`
+	Scope    *OAuthLimitScope `json:"scope,omitempty"`
+}
+
+type OAuthLimitScope struct {
+	Model   *OAuthLimitScopeItem `json:"model,omitempty"`
+	Surface *OAuthLimitScopeItem `json:"surface,omitempty"`
+}
+
+type OAuthLimitScopeItem struct {
+	DisplayName string `json:"display_name,omitempty"`
+	ID          string `json:"id,omitempty"`
+}
+
+func (r *OAuthUsageResponse) UnmarshalJSON(data []byte) error {
+	type knownResponse OAuthUsageResponse
+	var known knownResponse
+	if err := json.Unmarshal(data, &known); err != nil {
+		return err
+	}
+	*r = OAuthUsageResponse(known)
+
+	var raw map[string]json.RawMessage
+	if err := json.Unmarshal(data, &raw); err != nil {
+		return err
+	}
+
+	knownKeys := map[string]bool{
+		"five_hour": true, "seven_day": true, "seven_day_sonnet": true,
+		"seven_day_opus": true, "seven_day_oauth_apps": true,
+		"seven_day_cowork": true, "seven_day_omelette": true,
+		"omelette_promotional": true,
+		"extra_usage":          true, "limits": true,
+	}
+	for key, msg := range raw {
+		if knownKeys[key] || string(msg) == "null" {
+			continue
+		}
+		var fields map[string]json.RawMessage
+		if err := json.Unmarshal(msg, &fields); err != nil {
+			continue
+		}
+		if _, ok := fields["utilization"]; !ok {
+			continue
+		}
+		var period UsagePeriodResponse
+		if err := json.Unmarshal(msg, &period); err != nil {
+			continue
+		}
+		if r.AdditionalPeriods == nil {
+			r.AdditionalPeriods = make(map[string]UsagePeriodResponse)
+		}
+		r.AdditionalPeriods[key] = period
+	}
+	return nil
 }
 
 // ClaudeCLIOAuth represents the nested OAuth data inside Claude CLI credentials.

--- a/internal/provider/claude/response_test.go
+++ b/internal/provider/claude/response_test.go
@@ -139,6 +139,39 @@ func TestOAuthUsageResponse_UnmarshalEmptyResponse(t *testing.T) {
 	}
 }
 
+func TestOAuthUsageResponse_UnmarshalStructuredLimitsAndUnknownPeriods(t *testing.T) {
+	raw := `{
+		"five_hour": {"utilization": 1.0, "resets_at": "2026-07-02T07:40:00Z"},
+		"limits": [
+			{"group":"session","kind":"session","percent":1,"resets_at":"2026-07-02T07:40:00Z","scope":null},
+			{"group":"weekly","kind":"weekly_scoped","percent":34,"resets_at":"2026-07-02T08:00:00Z","scope":{"model":{"display_name":"Fable","id":"claude-fable-5"},"surface":null}}
+		],
+		"amber_ladder": {"utilization": 12.0, "resets_at": "2026-07-02T08:00:00Z"},
+		"member_dashboard_available": false
+	}`
+
+	var resp OAuthUsageResponse
+	if err := json.Unmarshal([]byte(raw), &resp); err != nil {
+		t.Fatalf("unmarshal failed: %v", err)
+	}
+
+	if len(resp.Limits) != 2 {
+		t.Fatalf("len(limits) = %d, want 2", len(resp.Limits))
+	}
+	if resp.Limits[1].Scope == nil || resp.Limits[1].Scope.Model == nil {
+		t.Fatal("expected model-scoped limit")
+	}
+	if resp.Limits[1].Scope.Model.DisplayName != "Fable" {
+		t.Errorf("model display_name = %q, want Fable", resp.Limits[1].Scope.Model.DisplayName)
+	}
+	if resp.AdditionalPeriods["amber_ladder"].Utilization != 12.0 {
+		t.Errorf("amber_ladder utilization = %v, want 12", resp.AdditionalPeriods["amber_ladder"].Utilization)
+	}
+	if _, ok := resp.AdditionalPeriods["member_dashboard_available"]; ok {
+		t.Error("non-period field captured as AdditionalPeriods")
+	}
+}
+
 func TestOAuthUsageResponse_PeriodWithoutResetsAt(t *testing.T) {
 	raw := `{
 		"five_hour": {"utilization": 50.0}
@@ -243,11 +276,8 @@ func TestOAuthUsageResponse_UnmarshalNewPeriodFields(t *testing.T) {
 		t.Errorf("seven_day_cowork utilization = %v, want 30.0", resp.SevenDayCowork.Utilization)
 	}
 
-	if resp.IguanaNecktie == nil {
-		t.Fatal("expected iguana_necktie to be present")
-	}
-	if resp.IguanaNecktie.Utilization != 5.0 {
-		t.Errorf("iguana_necktie utilization = %v, want 5.0", resp.IguanaNecktie.Utilization)
+	if resp.AdditionalPeriods["iguana_necktie"].Utilization != 5.0 {
+		t.Errorf("additional iguana_necktie utilization = %v, want 5.0", resp.AdditionalPeriods["iguana_necktie"].Utilization)
 	}
 }
 
@@ -270,8 +300,8 @@ func TestOAuthUsageResponse_NullNewFieldsAreNil(t *testing.T) {
 	if resp.SevenDayCowork != nil {
 		t.Error("expected seven_day_cowork to be nil")
 	}
-	if resp.IguanaNecktie != nil {
-		t.Error("expected iguana_necktie to be nil")
+	if _, ok := resp.AdditionalPeriods["iguana_necktie"]; ok {
+		t.Error("expected null iguana_necktie not to be captured")
 	}
 }
 

--- a/internal/provider/claude/usage.go
+++ b/internal/provider/claude/usage.go
@@ -12,7 +12,6 @@ import (
 var codenameLabels = map[string]string{
 	"omelette":             "Claude Design",
 	"omelette_promotional": "Claude Design (Promo)",
-	"iguana_necktie":       "Iguana Necktie",
 }
 
 // parseUsageResponse converts an OAuthUsageResponse (returned by both the
@@ -54,7 +53,6 @@ func parseUsageResponse(resp OAuthUsageResponse, source string) *models.UsageSna
 		{resp.SevenDayCowork, "Cowork", "cowork"},
 		{resp.SevenDayOmelette, codenameLabels["omelette"], "omelette"},
 		{resp.OmelettePromotional, codenameLabels["omelette_promotional"], "omelette_promotional"},
-		{resp.IguanaNecktie, codenameLabels["iguana_necktie"], "iguana_necktie"},
 	}
 
 	for _, mp := range modelPeriods {
@@ -65,11 +63,13 @@ func parseUsageResponse(resp OAuthUsageResponse, source string) *models.UsageSna
 			Name:        mp.display,
 			Utilization: int(mp.data.Utilization),
 			PeriodType:  models.PeriodWeekly,
-			Model:       strings.ToLower(strings.ReplaceAll(mp.model, " ", "_")),
+			Model:       modelSlug(mp.model),
 		}
 		p.ResetsAt = models.ParseRFC3339Ptr(mp.data.ResetsAt)
 		periods = append(periods, p)
 	}
+
+	periods = appendStructuredLimitPeriods(periods, resp.Limits)
 
 	var overage *models.OverageUsage
 	if resp.ExtraUsage != nil && resp.ExtraUsage.IsEnabled {
@@ -99,6 +99,118 @@ func parseUsageResponse(resp OAuthUsageResponse, source string) *models.UsageSna
 		Overage:   overage,
 		Source:    source,
 	}
+}
+
+func appendStructuredLimitPeriods(periods []models.UsagePeriod, limits []OAuthLimitResponse) []models.UsagePeriod {
+	for _, limit := range limits {
+		period := structuredLimitPeriod(limit)
+		if period == nil || hasEquivalentPeriod(periods, *period) {
+			continue
+		}
+		periods = append(periods, *period)
+	}
+	return periods
+}
+
+func structuredLimitPeriod(limit OAuthLimitResponse) *models.UsagePeriod {
+	name, model := limitDisplay(limit)
+	if name == "" {
+		return nil
+	}
+	return &models.UsagePeriod{
+		Name:        name,
+		Utilization: models.ClampPct(int(limit.Percent)),
+		PeriodType:  limitPeriodType(limit),
+		Model:       model,
+		ResetsAt:    models.ParseRFC3339Ptr(limit.ResetsAt),
+	}
+}
+
+func limitDisplay(limit OAuthLimitResponse) (string, string) {
+	if limit.Scope != nil {
+		if limit.Scope.Model != nil {
+			name := strings.TrimSpace(limit.Scope.Model.DisplayName)
+			model := strings.TrimSpace(limit.Scope.Model.ID)
+			if model == "" {
+				model = modelSlug(name)
+			}
+			if name != "" {
+				return name, model
+			}
+		}
+		if limit.Scope.Surface != nil {
+			name := strings.TrimSpace(limit.Scope.Surface.DisplayName)
+			model := strings.TrimSpace(limit.Scope.Surface.ID)
+			if model == "" {
+				model = modelSlug(name)
+			}
+			if name != "" {
+				return name, model
+			}
+		}
+	}
+
+	switch limit.Kind {
+	case "session":
+		return "Session (5h)", ""
+	case "weekly_all":
+		return "All Models", ""
+	case "weekly_scoped":
+		return "Weekly Scoped", "weekly_scoped"
+	default:
+		return humanizeUsageKey(limit.Kind), modelSlug(limit.Kind)
+	}
+}
+
+func limitPeriodType(limit OAuthLimitResponse) models.PeriodType {
+	switch limit.Group {
+	case "session":
+		return models.PeriodSession
+	case "daily":
+		return models.PeriodDaily
+	case "weekly":
+		return models.PeriodWeekly
+	case "monthly":
+		return models.PeriodMonthly
+	}
+	return periodTypeFromKey(limit.Kind)
+}
+
+func periodTypeFromKey(key string) models.PeriodType {
+	if strings.HasPrefix(key, "five_hour") || strings.Contains(key, "session") {
+		return models.PeriodSession
+	}
+	if strings.Contains(key, "daily") {
+		return models.PeriodDaily
+	}
+	if strings.Contains(key, "monthly") {
+		return models.PeriodMonthly
+	}
+	return models.PeriodWeekly
+}
+
+func humanizeUsageKey(key string) string {
+	parts := strings.Fields(strings.ReplaceAll(key, "_", " "))
+	for i, part := range parts {
+		if part == "" {
+			continue
+		}
+		parts[i] = strings.ToUpper(part[:1]) + part[1:]
+	}
+	return strings.Join(parts, " ")
+}
+
+func modelSlug(value string) string {
+	return strings.ToLower(strings.ReplaceAll(strings.TrimSpace(value), " ", "_"))
+}
+
+func hasEquivalentPeriod(periods []models.UsagePeriod, period models.UsagePeriod) bool {
+	for _, existing := range periods {
+		if existing.Name == period.Name && existing.PeriodType == period.PeriodType && existing.Model == period.Model {
+			return true
+		}
+	}
+	return false
 }
 
 // firstOfNextMonthUTC returns midnight UTC on the first day of the month

--- a/internal/provider/copilot/copilot.go
+++ b/internal/provider/copilot/copilot.go
@@ -4,6 +4,8 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
+	"sort"
+	"strings"
 	"time"
 
 	"github.com/joshuadavidthomas/vibeusage/internal/auth/device"
@@ -220,6 +222,24 @@ func (s *DeviceFlowStrategy) parseTypedUsageResponse(resp UserResponse) *models.
 				})
 			}
 		}
+
+		keys := make([]string, 0, len(resp.QuotaSnapshots.Additional))
+		for key := range resp.QuotaSnapshots.Additional {
+			keys = append(keys, key)
+		}
+		sort.Strings(keys)
+		for _, key := range keys {
+			quota := resp.QuotaSnapshots.Additional[key]
+			if quota == nil || !quota.HasUsage() || quota.QuotaID == "" {
+				continue
+			}
+			periods = append(periods, models.UsagePeriod{
+				Name:        "Monthly (" + humanizeQuotaKey(quota.QuotaID) + ")",
+				Utilization: quota.Utilization(),
+				PeriodType:  models.PeriodMonthly,
+				ResetsAt:    resetsAt,
+			})
+		}
 	}
 
 	if len(periods) == 0 {
@@ -239,4 +259,15 @@ func (s *DeviceFlowStrategy) parseTypedUsageResponse(resp UserResponse) *models.
 		Identity:  identity,
 		Source:    "device_flow",
 	}
+}
+
+func humanizeQuotaKey(key string) string {
+	parts := strings.Fields(strings.ReplaceAll(key, "_", " "))
+	for i, part := range parts {
+		if part == "" {
+			continue
+		}
+		parts[i] = strings.ToUpper(part[:1]) + part[1:]
+	}
+	return strings.Join(parts, " ")
 }

--- a/internal/provider/copilot/copilot_test.go
+++ b/internal/provider/copilot/copilot_test.go
@@ -85,6 +85,46 @@ func TestParseTypedUsageResponse_FullResponse(t *testing.T) {
 	}
 }
 
+func TestParseTypedUsageResponse_AdditionalQuotaSnapshotWithQuotaID(t *testing.T) {
+	resp := UserResponse{
+		QuotaResetDateUTC: "2025-03-01T00:00:00Z",
+		QuotaSnapshots: &QuotaSnapshots{
+			Additional: map[string]*Quota{
+				"some_key": {QuotaID: "custom_feature", Entitlement: 100, Remaining: 25},
+			},
+		},
+	}
+
+	snapshot := (&DeviceFlowStrategy{}).parseTypedUsageResponse(resp)
+	if snapshot == nil {
+		t.Fatal("expected non-nil snapshot")
+	}
+	if len(snapshot.Periods) != 1 {
+		t.Fatalf("len(periods) = %d, want 1", len(snapshot.Periods))
+	}
+	period := snapshot.Periods[0]
+	if period.Name != "Monthly (Custom Feature)" {
+		t.Errorf("period name = %q, want Monthly (Custom Feature)", period.Name)
+	}
+	if period.Utilization != 75 {
+		t.Errorf("period utilization = %d, want 75", period.Utilization)
+	}
+}
+
+func TestParseTypedUsageResponse_SuppressesUnidentifiedAdditionalQuotaSnapshot(t *testing.T) {
+	resp := UserResponse{
+		QuotaSnapshots: &QuotaSnapshots{
+			Additional: map[string]*Quota{
+				"custom_feature": {Entitlement: 100, Remaining: 25},
+			},
+		},
+	}
+
+	if snapshot := (&DeviceFlowStrategy{}).parseTypedUsageResponse(resp); snapshot != nil {
+		t.Fatalf("expected nil snapshot for unidentified additional quota, got %#v", snapshot)
+	}
+}
+
 func TestParseTypedUsageResponse_NoQuotas(t *testing.T) {
 	resp := UserResponse{
 		CopilotPlan: "free",

--- a/internal/provider/copilot/response.go
+++ b/internal/provider/copilot/response.go
@@ -1,5 +1,7 @@
 package copilot
 
+import "encoding/json"
+
 // UserResponse represents the response from the Copilot user API endpoint.
 type UserResponse struct {
 	Login                 string          `json:"login,omitempty"`
@@ -30,9 +32,43 @@ type Endpoints struct {
 
 // QuotaSnapshots contains quota information for different interaction types.
 type QuotaSnapshots struct {
-	PremiumInteractions *Quota `json:"premium_interactions,omitempty"`
-	Chat                *Quota `json:"chat,omitempty"`
-	Completions         *Quota `json:"completions,omitempty"`
+	PremiumInteractions *Quota            `json:"premium_interactions,omitempty"`
+	Chat                *Quota            `json:"chat,omitempty"`
+	Completions         *Quota            `json:"completions,omitempty"`
+	Additional          map[string]*Quota `json:"-"`
+}
+
+func (q *QuotaSnapshots) UnmarshalJSON(data []byte) error {
+	type knownQuotaSnapshots QuotaSnapshots
+	var known knownQuotaSnapshots
+	if err := json.Unmarshal(data, &known); err != nil {
+		return err
+	}
+	*q = QuotaSnapshots(known)
+
+	var raw map[string]json.RawMessage
+	if err := json.Unmarshal(data, &raw); err != nil {
+		return err
+	}
+	knownKeys := map[string]bool{
+		"premium_interactions": true,
+		"chat":                 true,
+		"completions":          true,
+	}
+	for key, msg := range raw {
+		if knownKeys[key] || string(msg) == "null" {
+			continue
+		}
+		var quota Quota
+		if err := json.Unmarshal(msg, &quota); err != nil {
+			continue
+		}
+		if q.Additional == nil {
+			q.Additional = make(map[string]*Quota)
+		}
+		q.Additional[key] = &quota
+	}
+	return nil
 }
 
 // Quota represents a single quota type with entitlement, remaining, and unlimited status.

--- a/internal/provider/copilot/response_test.go
+++ b/internal/provider/copilot/response_test.go
@@ -61,6 +61,11 @@ func TestUserResponse_UnmarshalFullResponse(t *testing.T) {
 				"remaining": 0,
 				"unlimited": true,
 				"timestamp_utc": "2025-02-20T12:00:00.000Z"
+			},
+			"custom_feature": {
+				"entitlement": 20,
+				"remaining": 5,
+				"unlimited": false
 			}
 		},
 		"quota_reset_date_utc": "2025-03-01T00:00:00Z"
@@ -169,6 +174,12 @@ func TestUserResponse_UnmarshalFullResponse(t *testing.T) {
 	}
 	if !resp.QuotaSnapshots.Completions.Unlimited {
 		t.Error("expected completions unlimited to be true")
+	}
+	if resp.QuotaSnapshots.Additional["custom_feature"] == nil {
+		t.Fatal("expected custom_feature additional quota")
+	}
+	if resp.QuotaSnapshots.Additional["custom_feature"].Remaining != 5 {
+		t.Errorf("custom_feature remaining = %v, want 5", resp.QuotaSnapshots.Additional["custom_feature"].Remaining)
 	}
 }
 

--- a/internal/provider/cursor/cursor.go
+++ b/internal/provider/cursor/cursor.go
@@ -178,6 +178,12 @@ func (s *WebStrategy) parseTypedResponse(usageResp UsageSummaryResponse, userRes
 		}
 	}
 
+	if usageResp.TeamUsage != nil && usageResp.TeamUsage.OnDemand != nil {
+		if p := onDemandPeriod("Team On-Demand", usageResp.TeamUsage.OnDemand, resetsAt); p != nil {
+			periods = append(periods, *p)
+		}
+	}
+
 	// Identity: prefer membershipType from usage-summary, email from user/me response
 	membershipType := usageResp.MembershipType
 	var identity *models.ProviderIdentity
@@ -204,5 +210,22 @@ func (s *WebStrategy) parseTypedResponse(usageResp UsageSummaryResponse, userRes
 		Overage:   overage,
 		Identity:  identity,
 		Source:    "web",
+	}
+}
+
+func onDemandPeriod(name string, od *OnDemandUsage, resetsAt *time.Time) *models.UsagePeriod {
+	if od == nil || od.Limit == nil || *od.Limit <= 0 {
+		return nil
+	}
+	enabled := od.Enabled == nil || *od.Enabled
+	if !enabled {
+		return nil
+	}
+	utilization := int((od.Used / *od.Limit) * 100)
+	return &models.UsagePeriod{
+		Name:        name,
+		Utilization: models.ClampPct(utilization),
+		PeriodType:  models.PeriodMonthly,
+		ResetsAt:    resetsAt,
 	}
 }

--- a/internal/provider/cursor/cursor_test.go
+++ b/internal/provider/cursor/cursor_test.go
@@ -86,6 +86,32 @@ func TestParseTypedResponse_FullResponse(t *testing.T) {
 	}
 }
 
+func TestParseTypedResponse_TeamOnDemandUsage(t *testing.T) {
+	usage := UsageSummaryResponse{
+		BillingCycleEnd: "2026-03-14T21:47:25.853Z",
+		TeamUsage: &TeamUsage{OnDemand: &OnDemandUsage{
+			Enabled: boolPtr(true),
+			Used:    3000,
+			Limit:   float64Ptr(50000),
+		}},
+	}
+
+	snapshot := (&WebStrategy{}).parseTypedResponse(usage, nil)
+	if snapshot == nil {
+		t.Fatal("expected non-nil snapshot")
+	}
+	if len(snapshot.Periods) != 1 {
+		t.Fatalf("len(periods) = %d, want 1", len(snapshot.Periods))
+	}
+	period := snapshot.Periods[0]
+	if period.Name != "Team On-Demand" {
+		t.Errorf("period name = %q, want Team On-Demand", period.Name)
+	}
+	if period.Utilization != 6 {
+		t.Errorf("period utilization = %d, want 6", period.Utilization)
+	}
+}
+
 func TestParseTypedResponse_NoPlanUsage(t *testing.T) {
 	usage := UsageSummaryResponse{}
 

--- a/internal/provider/warp/warp.go
+++ b/internal/provider/warp/warp.go
@@ -272,6 +272,7 @@ func parseUsageSnapshot(resp GraphQLResponse) (*models.UsageSnapshot, error) {
 	}
 
 	periods := []models.UsagePeriod{primary}
+	periods = appendVoicePeriods(periods, info, periodType)
 
 	// Combine user-level and workspace-level bonus grants
 	bonus := combineBonusGrants(userUnion.User)
@@ -306,6 +307,37 @@ func parseUsageSnapshot(resp GraphQLResponse) (*models.UsageSnapshot, error) {
 		},
 		Source: "api_key",
 	}, nil
+}
+
+func appendVoicePeriods(periods []models.UsagePeriod, info *RequestLimitInfo, periodType models.PeriodType) []models.UsagePeriod {
+	if info.IsUnlimitedVoice {
+		return periods
+	}
+	if info.VoiceRequestLimit > 0 {
+		used := info.VoiceRequestsUsedSinceLastRefresh
+		limit := info.VoiceRequestLimit
+		periods = append(periods, models.UsagePeriod{
+			Name:        "Voice Requests",
+			Utilization: models.ClampPct((used * 100) / limit),
+			PeriodType:  periodType,
+			ResetsAt:    models.ParseRFC3339Ptr(info.NextRefreshTime),
+			Used:        &used,
+			Limit:       &limit,
+		})
+	}
+	if info.VoiceTokenLimit > 0 {
+		used := info.VoiceTokensUsedSinceLastRefresh
+		limit := info.VoiceTokenLimit
+		periods = append(periods, models.UsagePeriod{
+			Name:        "Voice Tokens",
+			Utilization: models.ClampPct((used * 100) / limit),
+			PeriodType:  periodType,
+			ResetsAt:    models.ParseRFC3339Ptr(info.NextRefreshTime),
+			Used:        &used,
+			Limit:       &limit,
+		})
+	}
+	return periods
 }
 
 type bonusSummary struct {

--- a/internal/provider/warp/warp_test.go
+++ b/internal/provider/warp/warp_test.go
@@ -274,6 +274,21 @@ func TestParseUsageSnapshot_AllRequestLimitFields(t *testing.T) {
 	if snapshot.Periods[0].PeriodType != models.PeriodMonthly {
 		t.Errorf("period type = %v, want monthly", snapshot.Periods[0].PeriodType)
 	}
+	if len(snapshot.Periods) != 3 {
+		t.Fatalf("period count = %d, want 3", len(snapshot.Periods))
+	}
+	if snapshot.Periods[1].Name != "Voice Requests" {
+		t.Errorf("period[1].name = %q, want Voice Requests", snapshot.Periods[1].Name)
+	}
+	if snapshot.Periods[1].Used == nil || *snapshot.Periods[1].Used != 0 {
+		t.Errorf("voice request used = %v, want 0", snapshot.Periods[1].Used)
+	}
+	if snapshot.Periods[1].Limit == nil || *snapshot.Periods[1].Limit != 10000 {
+		t.Errorf("voice request limit = %v, want 10000", snapshot.Periods[1].Limit)
+	}
+	if snapshot.Periods[2].Name != "Voice Tokens" {
+		t.Errorf("period[2].name = %q, want Voice Tokens", snapshot.Periods[2].Name)
+	}
 }
 
 func TestFetchUsage_AuthFailure(t *testing.T) {


### PR DESCRIPTION
## Summary
- parse and display Claude structured limits[] rows, including model-scoped rows like Fable
- keep opaque Claude top-level codenames internal instead of displaying guessed labels
- display additional provider usage with reliable labels: Amp multiple quotas, Warp voice quotas, Cursor team on-demand usage, Copilot quotas with quota_id descriptors
- keep Codex coverage focused on code review and official additional_rate_limits[] entries
- add changelog entry and regression coverage

## Validation
- just test
- just lint